### PR TITLE
Fix GC on Android

### DIFF
--- a/d/druntime/rt/memory.d
+++ b/d/druntime/rt/memory.d
@@ -119,7 +119,7 @@ extern (C) void* rt_stackBottom()
         version(Android)
         {
             int stackSize;
-            return __get_stack_base(&stackSize);
+            return __get_stack_base(&stackSize) + stackSize;
         }
         else version( SimpleLibcStackEnd )
         {


### PR DESCRIPTION
__get_stack_base returns the base address which is the
'smallest possible top'. So bottom is actually base + size.
The stack then grows down from bottom to top.
