### PR TITLE
Implement generic backtraces for GDC

### DIFF
--- a/d/druntime/core/runtime.d
+++ b/d/druntime/core/runtime.d
@@ -40,7 +40,39 @@ private
 
     extern (C) string[] rt_args();
 
-    version( linux )
+    version(GNU)
+    {
+        import gcc.unwind;
+        import core.demangle;
+        import core.stdc.stdio : snprintf, printf;
+        import core.stdc.string : strlen;
+        import core.sys.posix.signal; // segv handler
+    }
+
+    version(Android)
+    {
+        version = haveDLADDR;
+    }
+
+    version(haveDLADDR)
+    {
+        extern(C)
+        {
+            int dladdr(void *addr, Dl_info *info);
+            struct Dl_info
+            {
+                const (char*) dli_fname;  /* Pathname of shared object that
+                                           contains address */
+                void*         dli_fbase;  /* Address at which shared object
+                                           is loaded */
+                const (char*) dli_sname;  /* Name of nearest symbol with address
+                                           lower than addr */
+                void*         dli_saddr;  /* Exact address of symbol named
+                                           in dli_sname */
+            }
+        }
+    }
+    else version( linux )
     {
         import core.demangle;
         import core.stdc.stdlib : free;
@@ -329,6 +361,64 @@ extern (C) bool runModuleUnitTests()
             sigaction( SIGBUS, &oldbus, null );
         }
     }
+    else version(GNU)
+    {
+        /*
+         * core.demangle may allocate, so no demangling here
+         *
+         * FIXME: At least on ARM this prints only the signal handler's
+         * stack. This is of course useless..
+         */
+        static extern (C) void unittestSegvHandler( int signum, siginfo_t* info, void* ptr )
+        {
+            gdcBacktraceData stackframe = gdcBacktrace();
+            btSymbolData syms = gdcBacktraceSymbols(stackframe);
+
+            for(size_t i = 0; i < syms.entries; i++)
+            {
+                auto sym = syms.symbols[i];
+                if(sym.fileName)
+                {
+                    if(sym.name)
+                    {
+                        printf("%s(%s+%#x) [%p]\n", sym.fileName, sym.name,
+                            sym.offset, sym.address);
+                    }
+                    else
+                    {
+                        printf("%s() [%p]\n", sym.fileName, sym.address);
+                    }
+                }
+                else
+                {
+                    if(sym.name)
+                    {
+                        printf("(%s+%#x) [%p]\n", sym.name, sym.offset, sym.address);
+                    }
+                    else
+                    {
+                        printf("() [%p]\n", sym.address);
+                    }
+                }
+            }
+        }
+
+        sigaction_t action = void;
+        sigaction_t oldseg = void;
+        sigaction_t oldbus = void;
+
+        (cast(byte*) &action)[0 .. action.sizeof] = 0;
+        sigfillset( &action.sa_mask ); // block other signals
+        action.sa_flags = SA_SIGINFO | SA_RESETHAND;
+        action.sa_sigaction = &unittestSegvHandler;
+        sigaction( SIGSEGV, &action, &oldseg );
+        sigaction( SIGBUS, &action, &oldbus );
+        scope( exit )
+        {
+            sigaction( SIGSEGV, &oldseg, null );
+            sigaction( SIGBUS, &oldbus, null );
+        }
+    }
 
     static struct Console
     {
@@ -558,8 +648,219 @@ Throwable.TraceInfo defaultTraceHandler( void* ptr = null )
     {
         return new StackTrace;
     }
+    else version(GNU)
+    {
+        class DefaultTraceInfo : Throwable.TraceInfo
+        {
+            this()
+            {
+                callstack = gdcBacktrace();
+                framelist = gdcBacktraceSymbols(callstack);
+            }
+
+            override int opApply( scope int delegate(ref char[]) dg )
+            {
+                return opApply( (ref size_t, ref char[] buf)
+                                {
+                                    return dg( buf );
+                                } );
+            }
+
+            override int opApply( scope int delegate(ref size_t, ref char[]) dg )
+            {
+                version( Posix )
+                {
+                    // NOTE: The first 5 frames with the current implementation are
+                    //       inside core.runtime and the object code, so eliminate
+                    //       these for readability.  The alternative would be to
+                    //       exclude the first N frames that are in a list of
+                    //       mangled function names.
+                    static enum FIRSTFRAME = 5;
+                }
+                else
+                {
+                    // NOTE: On Windows, the number of frames to exclude is based on
+                    //       whether the exception is user or system-generated, so
+                    //       it may be necessary to exclude a list of function names
+                    //       instead.
+                    static enum FIRSTFRAME = 0;
+                }
+                int ret = 0;
+
+                for( int i = FIRSTFRAME; i < framelist.entries; ++i )
+                {
+                    auto pos = cast(size_t)(i - FIRSTFRAME);
+                    auto buf = formatLine(framelist.symbols[i]);
+                    ret = dg( pos, buf );
+                    if( ret )
+                        break;
+                }
+                return ret;
+            }
+
+            override string toString()
+            {
+                string buf;
+                foreach( i, line; this )
+                    buf ~= i ? "\n" ~ line : line;
+                return buf;
+            }
+
+        private:
+            btSymbolData     framelist;
+            gdcBacktraceData callstack;
+
+        private:
+            char[4096] fixbuf;
+
+            /*Do not put \n at end of line!*/
+            char[] formatLine(backtraceSymbol sym)
+            {
+                int ret;
+                
+                if(sym.fileName)
+                {
+                    if(sym.name)
+                    {
+                        ret = snprintf(fixbuf.ptr, fixbuf.sizeof,
+                            "%s(", sym.fileName);
+                        if(ret >= fixbuf.sizeof)
+                            return fixbuf[];
+
+                        auto demangled = demangle(sym.name[0 .. strlen(sym.name)],
+                            fixbuf[ret .. $]);
+
+                        ret += demangled.length;
+                        if(ret >= fixbuf.sizeof)
+                            return fixbuf[];
+
+                        ret += snprintf(fixbuf.ptr + ret, fixbuf.sizeof - ret,
+                            "+%#x) [%p]", sym.offset, sym.address);
+                    }
+                    else
+                    {
+                        ret = snprintf(fixbuf.ptr, fixbuf.sizeof,
+                            "%s() [%p]", sym.fileName, sym.address);
+                    }
+                }
+                else
+                {
+                    if(sym.name)
+                    {
+                        fixbuf[0] = '(';
+                        ret = 1;
+
+                        auto demangled = demangle(sym.name[0 .. strlen(sym.name)],
+                            fixbuf[ret .. $]);
+
+                        ret += demangled.length;
+                        if(ret >= fixbuf.sizeof)
+                            return fixbuf[];
+
+                        ret += snprintf(fixbuf.ptr + ret, fixbuf.sizeof - ret,
+                            "+%#x) [%p]", sym.offset, sym.address);
+                    }
+                    else
+                    {
+                        ret = snprintf(fixbuf.ptr, fixbuf.sizeof, "() [%p]",
+                            sym.address);
+                    }
+                }
+
+                if(ret >= fixbuf.sizeof)
+                    return fixbuf[];
+                else
+                    return fixbuf[0 .. ret];
+            }
+        }
+
+        return new DefaultTraceInfo;
+    }
     else
     {
         return null;
+    }
+}
+
+version(GNU)
+{
+    import gcc.unwind;
+
+    static enum MAXFRAMES = 128;
+
+    struct gdcBacktraceData
+    {
+        void*[MAXFRAMES] callstack;
+        int numframes = 0;
+    }
+
+    struct backtraceSymbol
+    {
+        const(char)* name, fileName;
+        size_t offset;
+        void* address;
+    }
+
+    struct btSymbolData
+    {
+        size_t entries;
+        backtraceSymbol[MAXFRAMES] symbols;
+    }
+    
+    static extern (C) _Unwind_Reason_Code unwindCB(_Unwind_Context *ctx, void *d)
+    {
+        gdcBacktraceData* bt = cast(gdcBacktraceData*)d;
+        if(bt.numframes >= MAXFRAMES)
+            return _URC_NO_REASON;
+
+        bt.callstack[bt.numframes] = cast(void*)_Unwind_GetIP(ctx);
+        bt.numframes++;
+        return _URC_NO_REASON;
+    }
+
+    gdcBacktraceData gdcBacktrace()
+    {
+        gdcBacktraceData stackframe;
+        _Unwind_Backtrace(&unwindCB, &stackframe);
+        return stackframe;
+    }
+
+    btSymbolData gdcBacktraceSymbols(gdcBacktraceData data)
+    {
+        btSymbolData symData;
+
+        for(auto i = 0; i < data.numframes; i++)
+        {
+            version(haveDLADDR)
+            {
+                Dl_info funcInfo;
+
+                if(data.callstack[i] !is null && dladdr(data.callstack[i], &funcInfo) != 0)
+                {
+                    symData.symbols[symData.entries].name = funcInfo.dli_sname;
+                    symData.symbols[symData.entries].fileName = funcInfo.dli_fname;
+
+                    if(funcInfo.dli_saddr is null)
+                        symData.symbols[symData.entries].offset = 0;
+                    else
+                        symData.symbols[symData.entries].offset = data.callstack[i] - funcInfo.dli_saddr;
+
+                    symData.symbols[symData.entries].address = data.callstack[i];
+                    symData.entries++;
+                }
+                else
+                {
+                    symData.symbols[symData.entries].address = data.callstack[i];
+                    symData.entries++;
+                }
+            }
+            else
+            {
+                symData.symbols[symData.entries].address = data.callstack[i];
+                symData.entries++;
+            }
+        }
+
+        return symData;
     }
 }

--- a/d/phobos2/gcc/unwind_arm.d
+++ b/d/phobos2/gcc/unwind_arm.d
@@ -14,7 +14,7 @@ alias ulong _uw64;
 alias ushort _uw16;
 alias ubyte _uw8;
 
-typedef uint _Unwind_Reason_Code;
+alias uint _Unwind_Reason_Code;
 enum : _Unwind_Reason_Code
 {
     _URC_OK = 0,       /* operation completed successfully */
@@ -26,7 +26,7 @@ enum : _Unwind_Reason_Code
     _URC_FAILURE = 9   /* unspecified failure of some kind */
 }
 
-typedef int _Unwind_State;
+alias int _Unwind_State;
 enum : _Unwind_State
 {
     _US_VIRTUAL_UNWIND_FRAME = 0,
@@ -96,7 +96,7 @@ struct _Unwind_Control_Block
 };
 
   /* Virtual Register Set*/
-typedef int _Unwind_VRS_RegClass;
+alias int _Unwind_VRS_RegClass;
 enum : _Unwind_VRS_RegClass
 {
     _UVRSC_CORE = 0,      /* integer register */
@@ -106,7 +106,7 @@ enum : _Unwind_VRS_RegClass
     _UVRSC_WMMXC = 4      /* Intel WMMX control register */
 }
 
-typedef int _Unwind_VRS_DataRepresentation;
+alias int _Unwind_VRS_DataRepresentation;
 enum : _Unwind_VRS_DataRepresentation
 {
     _UVRSD_UINT32 = 0,
@@ -117,7 +117,7 @@ enum : _Unwind_VRS_DataRepresentation
     _UVRSD_DOUBLE = 5
 }
 
-typedef int _Unwind_VRS_Result;
+alias int _Unwind_VRS_Result;
 enum : _Unwind_VRS_Result
 {
     _UVRSR_OK = 0,
@@ -155,7 +155,7 @@ _Unwind_VRS_Result _Unwind_VRS_Pop(_Unwind_Context *, _Unwind_VRS_RegClass,
 
   /* Support functions for the PR.  */
 alias _Unwind_Control_Block _Unwind_Exception ;
-typedef char _Unwind_Exception_Class[8] = '\0';
+alias char[8] _Unwind_Exception_Class; // = '\0'
 
 void * _Unwind_GetLanguageSpecificData (_Unwind_Context *);
 _Unwind_Ptr _Unwind_GetRegionStart (_Unwind_Context *);
@@ -251,3 +251,11 @@ void _Unwind_SetIP(_Unwind_Context *context, _Unwind_Word val)
 {
     return _Unwind_SetGR (context, 15, val | (_Unwind_GetGR (context, 15) & 1));
 }
+
+/* @@@ Use unwind data to perform a stack backtrace.  The trace callback
+   is called for every stack frame in the call chain, but no cleanup
+   actions are performed.  */
+alias extern(C) _Unwind_Reason_Code function
+     (_Unwind_Context *, void *) _Unwind_Trace_Fn;
+
+_Unwind_Reason_Code _Unwind_Backtrace (_Unwind_Trace_Fn, void *);

--- a/d/phobos2/gcc/unwind_generic.d
+++ b/d/phobos2/gcc/unwind_generic.d
@@ -81,8 +81,7 @@ alias uint _Unwind_Reason_Code;
    implementation-specific, but it will be prefixed by a header
    understood by the unwind interface.  */
 
-extern(C) typedef void (*_Unwind_Exception_Cleanup_Fn) (_Unwind_Reason_Code,
-                                              _Unwind_Exception *);
+alias extern(C) void function(_Unwind_Reason_Code, _Unwind_Exception *) _Unwind_Exception_Cleanup_Fn;
 
 align struct _Unwind_Exception // D Note: this may not be "maxium alignment required by any type"?
 {
@@ -99,7 +98,7 @@ align struct _Unwind_Exception // D Note: this may not be "maxium alignment requ
 
 /* The ACTIONS argument to the personality routine is a bitwise OR of one
    or more of the following constants.  */
-typedef int _Unwind_Action;
+alias int _Unwind_Action;
 
 enum
 {
@@ -121,9 +120,9 @@ _Unwind_Reason_Code _Unwind_RaiseException (_Unwind_Exception *);
 
 /* Raise an exception for forced unwinding.  */
 
-extern(C) typedef _Unwind_Reason_Code (*_Unwind_Stop_Fn)
+alias extern(C) _Unwind_Reason_Code function
      (int, _Unwind_Action, _Unwind_Exception_Class,
-      _Unwind_Exception *, _Unwind_Context *, void *);
+      _Unwind_Exception *, _Unwind_Context *, void *) _Unwind_Stop_Fn;
 
 _Unwind_Reason_Code _Unwind_ForcedUnwind (_Unwind_Exception *,
                                                  _Unwind_Stop_Fn,
@@ -143,8 +142,8 @@ _Unwind_Reason_Code _Unwind_Resume_or_Rethrow (_Unwind_Exception *);
 /* @@@ Use unwind data to perform a stack backtrace.  The trace callback
    is called for every stack frame in the call chain, but no cleanup
    actions are performed.  */
-extern(C) typedef _Unwind_Reason_Code (*_Unwind_Trace_Fn)
-     (_Unwind_Context *, void *);
+alias extern(C) _Unwind_Reason_Code function
+     (_Unwind_Context *, void *) _Unwind_Trace_Fn;
 
 _Unwind_Reason_Code _Unwind_Backtrace (_Unwind_Trace_Fn, void *);
 
@@ -181,9 +180,9 @@ _Unwind_Ptr _Unwind_GetRegionStart (_Unwind_Context *);
    provides more effective versioning by detecting at link time the
    lack of code to handle the different data format.  */
 
-extern(C) typedef _Unwind_Reason_Code (*_Unwind_Personality_Fn)
+alias extern(C) _Unwind_Reason_Code function
      (int, _Unwind_Action, _Unwind_Exception_Class,
-      _Unwind_Exception *, _Unwind_Context *);
+      _Unwind_Exception *, _Unwind_Context *) _Unwind_Personality_Fn;
 
 /* @@@ The following alternate entry points are for setjmp/longjmp
    based unwinding.  */


### PR DESCRIPTION
Fixes the unwind_arm and unwind_generic files (mostly deprecated typedef), then implements backtraces using libgcc helper functions. Systems where 'backtrace' is supported remain unchanged.

This allows us to get at least the addresses for a stacktrace for every architecture where libgcc supports it. Address --> name resolution is implemented using dladdr, where available. According to some websites backtrace is also impemented using dladdr, so these implementations share the same problems and features (For example, you have to compile with --export-dynamic to make it work).

Stack traces generated for segfaults are not very useful yet, they only contain the stack trace after the signal handler has been called. Druntime catches segfaults in unittests, so in that case the output isn't very useful yet. Systems which support backtrace use the old implementation and are not affected.

Related information:
http://www.acsu.buffalo.edu/~charngda/backtrace.html
