### PR TITLE
Remove the gcc version string patching

### DIFF
--- a/d/setup-gcc.sh
+++ b/d/setup-gcc.sh
@@ -123,27 +123,7 @@ mkdir libphobos/zlib && \
     ../../symlink-tree ../../gcc/d/zlib > /dev/null && \
     cd "$top" || exit 1
 
-# 1.3 Patch the gcc version string
-cd gcc || exit 1
-d_gcc_ver=`echo $gcc_ver | sed -e 's/\.//g'`
-
-if test "$d_gcc_ver" -ge 41; then
-    sed -i 's/gdc [a-z0-9. :]*, using dmd [0-9. ]*//g' DEV-PHASE
-    cur_DEV_PHASE=`cat DEV-PHASE`
-    if test -z "$cur_DEV_PHASE"; then
-        echo "$gdc_ver_msg" > DEV-PHASE
-    else
-        echo "$cur_DEV_PHASE $gdc_ver_msg" > DEV-PHASE
-    fi
-else
-    sed -e 's/ *(gdc.*using dmd [0-9\.]*)//' \
-        -e 's/\(, *\)gdc.*using dmd [0-9\.]*/\1/' \
-        -e 's/\(version_string[^"]*"[^"]*\)"/\1 ('"$gdc_ver_msg"')"/' \
-        version.c > version.c.tmp && mv -f version.c.tmp version.c
-fi
-cd "$top" || exit 1
-
-# 1.4 Exit early if we are just updating d-make-include and the
+# 1.3 Exit early if we are just updating d-make-include and the
 # directory of links to the Phobos sources.
 if test "$d_update_phobos" = 1; then
     echo


### PR DESCRIPTION
As in the title.
gccgo doesn't do this so I don't see why gdc should.

Also, it patches the global gcc version string and some projects use this for gcc version detection, like djvu, which detects 2.057, rather than 4.6.2.
