### PR TITLE
Use fully qualified names for strlen. Fixes #7

### DIFF
--- a/d/druntime/core/sys/windows/stacktrace.d
+++ b/d/druntime/core/sys/windows/stacktrace.d
@@ -350,10 +350,10 @@ private:
                     if( dbghelp.SymGetLineFromAddr64( hProcess, stackframe.AddrPC.Offset, &displacement, &line ) == TRUE )
                     {
                         char[2048] demangleBuf;
-                        auto       symbolName = (cast(char*) symbol.Name.ptr)[0 .. strlen(symbol.Name.ptr)];
+                        auto       symbolName = (cast(char*) symbol.Name.ptr)[0 .. core.stdc.string.strlen(symbol.Name.ptr)];
 
                         // displacement bytes from beginning of line
-                        trace ~= line.FileName[0 .. strlen( line.FileName )] ~
+                        trace ~= line.FileName[0 .. core.stdc.string.strlen( line.FileName )] ~
                                  "(" ~ format( temp[], line.LineNumber ) ~ "): " ~
                                  demangle( symbolName, demangleBuf );
                     }


### PR DESCRIPTION
The alias import in runtime.d is supposed to be private, but
because of a bug in dmd it's not and therefore runtime.strlen
conflicts with stdc.string.strlen.
I'm sorry this happened, I'm not sure why I wasn't seeing this error before.
