### PR TITLE
Output thunks for DECL_EXTERNAL functions.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,9 @@
+2012-05-29  Daniel Green <venix1@gmail.com>
+
+	* d-objfile.cc(ObjectFile::outputThunk): Output thunks for
+	DECL_EXTERNAL functions. 
+	See https://bitbucket.org/goshawk/gdc/issue/284
+
 2012-05-29  Iain Buclaw  <ibuclaw@ubuntu.com>
 
 	* d-codegen.cc(IRState::endCase): Remove parameter from function. Use


### PR DESCRIPTION
Related to

https://bitbucket.org/goshawk/gdc/issue/284

Rationale:

cgraphunit.c(assemble_thunk) is responsible for outputting thunks.

As of 4.8 this will never be called for external functions so it must be done manually.

The changes made here mirror the function.
