### PR TITLE
Fix issue 120

### DIFF
--- a/gcc/d/d-decls.cc
+++ b/gcc/d/d-decls.cc
@@ -347,6 +347,7 @@ TypeInfoDeclaration::toSymbol (void)
       gcc_assert (TREE_CODE (TREE_TYPE (csym->Stree)) == REFERENCE_TYPE);
       TREE_TYPE (csym->Stree) = TREE_TYPE (TREE_TYPE (csym->Stree));
       TREE_USED (csym->Stree) = 1;
+      layout_decl (csym->Stree, 0);
 
       /* DMD makes typeinfo decls one-only by doing: s->Sclass = SCcomdat;
 	 in TypeInfoDeclaration::toObjFile.  The difference is that,

--- a/gcc/d/d-decls.cc
+++ b/gcc/d/d-decls.cc
@@ -680,9 +680,7 @@ ClassDeclaration::toSymbol (void)
       tree decl;
       csym = toSymbolX ("__Class", SCextern, 0, "Z");
       decl = build_decl (UNKNOWN_LOCATION, VAR_DECL, get_identifier (csym->Sident),
-			 TREE_TYPE (ClassDeclaration::classinfo != NULL
-				    ? ClassDeclaration::classinfo->type->toCtype() // want the RECORD_TYPE, not the REFERENCE_TYPE
-				    : error_mark_node));
+			 make_node (RECORD_TYPE));
       csym->Stree = decl;
       d_keep (decl);
 
@@ -721,12 +719,10 @@ Module::toSymbol (void)
 {
   if (!csym)
     {
-      Type *obj_type = gen.getObjectType();
-
       csym = toSymbolX ("__ModuleInfo", SCextern, 0, "Z");
 
       tree decl = build_decl (UNKNOWN_LOCATION, VAR_DECL, get_identifier (csym->Sident),
-			      TREE_TYPE (obj_type->toCtype())); // want the RECORD_TYPE, not the REFERENCE_TYPE
+			      make_node (RECORD_TYPE));
       g.ofile->setDeclLoc (decl, this);
       csym->Stree = decl;
 

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -973,6 +973,25 @@ outdata (Symbol *sym)
   gcc_assert (!DECL_EXTERNAL (t));
   relayout_decl (t);
 
+  if (DECL_INITIAL (t) != NULL_TREE)
+    {
+      //Initializer must never be bigger than symbol size
+      //(see ARM issue #120, section anchors)
+      //According to gcc manual, DECL_SIZE is authoritative:
+      HOST_WIDE_INT typesize = int_size_in_bytes (TREE_TYPE (t));
+      HOST_WIDE_INT initsize = int_size_in_bytes (TREE_TYPE (DECL_INITIAL (t)));
+      HOST_WIDE_INT declsize = gen.getTargetSizeConst (DECL_SIZE (t)) / BITS_PER_UNIT;
+
+      if (declsize < initsize)
+        internal_error ("Mismatch between declaration '%s' size (%wd) and it's initializer size (%wd).",
+                        sym->prettyIdent ? sym->prettyIdent : sym->Sident,
+                        declsize,  initsize);
+      else if (declsize != typesize)
+        internal_error ("Mismatch between declaration '%s' size (%wd) and it's type size (%wd).",
+                        sym->prettyIdent ? sym->prettyIdent : sym->Sident,
+                        declsize,  typesize);
+    }
+
   g.ofile->outputStaticSymbol (sym);
 }
 

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -936,8 +936,18 @@ outdata (Symbol *sym)
   tree t = check_static_sym (sym);
   gcc_assert (t);
 
-  if (sym->Sdt && DECL_INITIAL (t) == NULL_TREE)
-    DECL_INITIAL (t) = dt2tree (sym->Sdt);
+  if (sym->Sdt)
+    {
+      if (!COMPLETE_TYPE_P (TREE_TYPE (t)))
+        {
+          size_t fsize = dt_size (sym->Sdt);
+          TYPE_SIZE (TREE_TYPE (t)) = bitsize_int (fsize * BITS_PER_UNIT);
+          TYPE_SIZE_UNIT (TREE_TYPE (t)) = size_int (fsize);
+        }
+
+      if (DECL_INITIAL (t) == NULL_TREE)
+        DECL_INITIAL (t) = dt2tree (sym->Sdt);
+    }
 
   gcc_assert (!g.irs->isErrorMark (t));
 

--- a/gcc/d/dfrontend/typinf.c
+++ b/gcc/d/dfrontend/typinf.c
@@ -532,8 +532,7 @@ void TypeInfoStructDeclaration::toDt(dt_t **pdt)
     const char *name = sd->toPrettyChars();
     size_t namelen = strlen(name);
     dtsize_t(pdt, namelen);
-    //dtabytes(pdt, TYnptr, 0, namelen + 1, name);
-    dtxoff(pdt, toSymbol(), offset, TYnptr);
+    dtabytes(pdt, TYnptr, 0, namelen + 1, name);
     offset += namelen + 1;
 
     // void[] init;
@@ -709,9 +708,6 @@ void TypeInfoStructDeclaration::toDt(dt_t **pdt)
         dtsize_t(pdt, 1);       // has pointers
     else
         dtsize_t(pdt, 0);       // no pointers
-
-    // name[]
-    dtnbytes(pdt, namelen + 1, name);
 }
 
 void TypeInfoClassDeclaration::toDt(dt_t **pdt)

--- a/libphobos/libdruntime/object.di
+++ b/libphobos/libdruntime/object.di
@@ -138,11 +138,13 @@ class TypeInfo_AssociativeArray : TypeInfo
 class TypeInfo_Function : TypeInfo
 {
     TypeInfo next;
+    string deco;
 }
 
 class TypeInfo_Delegate : TypeInfo
 {
     TypeInfo next;
+    string deco;
 }
 
 class TypeInfo_Class : TypeInfo


### PR DESCRIPTION
This pull request includes these changes to fix issue #120:
- The static array initializer fix posted in the bug report (Pad static arrays with single elements )
- The TypeInfoDeclaration::toSymbol code did not correctly set DECL_SIZE
- The size of ModuleInfo and ClassInfo is not known until the initializer is constructed. Added a helper method which generates a struct node with unknown size. Then infer the size in outdata and set it correctly.
- TypeInfoStruct::toDt produced variable length output. Fixed by using an extra static symbol for name. (This should also be fixed in upstream dmd and is also contained in this pull request: https://github.com/D-Programming-Language/dmd/pull/1128)
- The TypeInfo_Function and TypeInfo_Delegate declarations in druntime are wrong. The fix is already applied in upstream druntime (https://github.com/D-Programming-Language/druntime/pull/307), but I included it here, so we don't have to wait for version 2.061.
- That dmd pull request will also error out if a TypeInfo declaration in druntime doesn't match the one in the compiler. So issues like that shouldn't happen again.
- Added code to outdata which detects size mismatches between initializer size, type size and declaration size and ices on these errors. (We sometimes have smaller initializers than DECL_SIZE, but I guess that's not a problem. So the code only checks for bigger initializers). This should make it easier to detect bugs which lead to problems with section anchors.

I tested those changes on x86, x64-64 and arm. There are no regressions in the test suite (which is especially important since this code introduces a new ice). Those changes produce the same testsuite output on ARM as using `-fno-section-anchors` (Actually, they're even a little better. Seems like I didn't correctly pass the -fno-section-anchors to the testsuite runner). So I hope these changes should fix all section anchor issues.

The testsuite results for reference: http://dl.dropbox.com/u/24218791/fix120/testsuite.html
(You might wonder why there is one more 'unresolved' runnable test with the new code on ARM: This is the **runnable/test23.d** test. It went from FAIL to UNRESOLVED. It now shows the same error on ARM as on X86)

Note: With this solution we don't have debug info for ClassInfos and ModuleInfos. This should really be fixed in the frontend, but that's more complicated than I thought. I'll file a bug report on the dmd bugtracker though, to make sure it won't be forgotten.
