### PR TITLE
Preliminary shared runtime support in build system

### DIFF
--- a/libphobos/Makefile.am
+++ b/libphobos/Makefile.am
@@ -21,9 +21,11 @@ ACLOCAL_AMFLAGS = -I . -I ..
 
 SUBDIRS = libdruntime
 
-OUR_CFLAGS=@DEFS@ -I . -I $(srcdir)/gcc -I$(top_srcdir)/../zlib
+#PIC_FLAGS=
+
+OUR_CFLAGS=@DEFS@ -I . -I $(srcdir)/gcc -I$(top_srcdir)/../zlib $(PIC_FLAGS)
 D_EXTRA_DFLAGS=-nostdinc -pipe -fdeprecated -fproperty -I $(srcdir) -I $(srcdir)/libdruntime -I ./libdruntime/$(host_alias)
-ALL_DFLAGS=$(DFLAGS) $(D_GC_FLAGS) $(D_EXTRA_DFLAGS) $(MULTIFLAGS)
+ALL_DFLAGS=$(DFLAGS) $(D_GC_FLAGS) $(D_EXTRA_DFLAGS) $(MULTIFLAGS) $(PIC_FLAGS)
 
 toolexecdir = $(phobos_toolexecdir)
 toolexeclibdir = $(phobos_toolexeclibdir)
@@ -101,7 +103,9 @@ ZLIB_OBJS=@ZLIB_OBJS@
 OS_OBJS=std/file.o std/mmfile.o std/path.o std/perf.o std/process.o \
 	std/socket.o std/socketstream.o
 
-LINUX_OBJS=std/c/linux/linux.o std/c/linux/socket.o
+# std/c/linux/linux.o is currently included on all unix systems for
+# compatibility, see acinclude.m4. Do not add std/c/linux/linux.o twice!
+LINUX_OBJS=std/c/linux/socket.o
 
 OSX_OBJS=std/c/osx/socket.o
 
@@ -125,6 +129,10 @@ libgphobos2.a : $(ALL_PHOBOS_OBJS) libdruntime/libgdruntime.a
 	cp libdruntime/libgdruntime.a libgphobos2.a
 	$(AR) -q $@ $(ALL_PHOBOS_OBJS)
 	$(RANLIB) $@
+
+libgphobos2.so : $(ALL_PHOBOS_OBJS) libdruntime/libgdruntime.so
+	$(GDC) -shared $(ALL_PHOBOS_OBJS) -Wl,-soname,libgphobos2.so.0 -o libgphobos2.so.0 -nophoboslib
+	ln -s -f libgphobos2.so.0 libgphobos2.so
 
 libgphobos2_t.a : $(ALL_PHOBOS_OBJS:.o=.t.o)
 	$(AR) -r $@ $(ALL_PHOBOS_OBJS:.o=.t.o)
@@ -155,6 +163,8 @@ clean-local:
 	rm -f unittest.o
 	rm -f unittest$(EXEEXT)
 	rm -f libgphobos2.a
+	rm -f libgphobos2.so
+	rm -f libgphobos2.so.0
 	rm -f libgphobos2_t.a
 
 

--- a/libphobos/libdruntime/Makefile.am
+++ b/libphobos/libdruntime/Makefile.am
@@ -19,9 +19,11 @@ AUTOMAKE_OPTIONS = 1.9.4 foreign no-dependencies
 
 ACLOCAL_AMFLAGS = -I . -I ..
 
-OUR_CFLAGS=@DEFS@ -I ../ -I $(srcdir)/gcc -I $(srcdir)/../zlib
+#PIC_FLAGS=
+
+OUR_CFLAGS=@DEFS@ -I ../ -I $(srcdir)/gcc -I $(srcdir)/../zlib $(PIC_FLAGS)
 D_EXTRA_DFLAGS=-nostdinc -pipe -fdeprecated -I $(srcdir) -I ./$(host_alias) -I .
-ALL_DFLAGS = $(DFLAGS) $(D_GC_FLAGS) $(D_EXTRA_DFLAGS) $(MULTIFLAGS)
+ALL_DFLAGS = $(DFLAGS) $(D_GC_FLAGS) $(D_EXTRA_DFLAGS) $(MULTIFLAGS) $(PIC_FLAGS)
 
 toolexecdir = $(phobos_toolexecdir)
 toolexeclibdir = $(phobos_toolexeclibdir)
@@ -60,7 +62,7 @@ BASE_OBJS=object_.o
 RUNTIME_OBJS=rt/aaA.o rt/aApply.o rt/aApplyR.o rt/adi.o rt/arrayassign.o \
 	     rt/arraybyte.o rt/arraycast.o rt/arraycat.o rt/arraydouble.o \
 	     rt/arrayfloat.o rt/arrayint.o rt/arrayreal.o rt/arrayshort.o \
-	     rt/cast_.o rt/critical_.o rt/dmain2.o rt/minfo.o \
+	     rt/cast_.o rt/critical_.o rt/minfo.o \
 	     rt/memory.o rt/invariant.o rt/invariant_.o rt/lifetime.o \
 	     rt/monitor_.o rt/obj.o rt/qsort.o rt/switch_.o rt/tlsgc.o
 
@@ -109,7 +111,7 @@ RT_WINDOWS_OBJS=core/sys/windows/dbghelp.o core/sys/windows/dll.o \
 		core/sys/windows/windows.o
 
 # This should not be linked into a shared library.
-CMAIN_OBJS= #rt/cmain.o
+MAIN_OBJS= rt/dmain2.o #rt/cmain.o
 
 D_GC_MODULES=@D_GC_MODULES@
 
@@ -162,9 +164,13 @@ CORE_IMPORTS=core/atomic.di core/bitop.di core/cpuid.di core/demangle.di \
 
 ALL_DRUNTIME_OBJS = $(DRUNTIME_OBJS) $(CORE_OBJS) $(D_GC_MODULES) $(GCC_OBJS)
 
-libgdruntime.a : $(ALL_DRUNTIME_OBJS) $(CMAIN_OBJS) $(subst core/,$(IMPORT)/core/,$(CORE_IMPORTS))
-	$(AR) -r $@ $(ALL_DRUNTIME_OBJS) $(CMAIN_OBJS)
+libgdruntime.a : $(ALL_DRUNTIME_OBJS) $(MAIN_OBJS) $(subst core/,$(IMPORT)/core/,$(CORE_IMPORTS))
+	$(AR) -r $@ $(ALL_DRUNTIME_OBJS) $(MAIN_OBJS)
 	$(RANLIB) $@
+
+libgdruntime.so : $(ALL_DRUNTIME_OBJS) $(MAIN_OBJS) $(subst core/,$(IMPORT)/core/,$(CORE_IMPORTS))
+	$(GDC) -shared $(ALL_DRUNTIME_OBJS) -Wl,-soname,libgdruntime.so.0 -o libgdruntime.so.0 -nophoboslib
+	ln -s -f libgdruntime.so.0 libgdruntime.so
 
 #--------------------------------------#
 # Install, doc, etc targets
@@ -201,12 +207,14 @@ install-data-local: $(D_PREREQ_SRCS) libgdruntime.a
 	$(INSTALL) phobos-ver-syms $(DESTDIR)$(gdc_include_dir)/$(host_alias)/$(MULTISUBDIR)
 
 clean-local:
-	rm -f $(CMAIN_OBJS)
+	rm -f $(MAIN_OBJS)
 	rm -f $(ALL_DRUNTIME_OBJS)
 	rm -f $(CORE_IMPORTS)
 	rm -rf $(IMPORT)
 	rm -f testgc$(EXEEXT)
 	rm -f libgdruntime.a
+	rm -f libgdruntime.so
+	rm -f libgdruntime.so.0
 
 
 # Work around what appears to be a GNU make bug handling MAKEFLAGS


### PR DESCRIPTION
This only adjusts the build system, no changes to the compiler or runtime are included. This allows specifying a `PIC_FLAGS` environment available to enable `-fPIC` when compiling and adds two new targets to the Makefiles: `libgdruntime.so` and `libgphobos2.so`

This is meant to make  the development of a shared runtime easier, but not for production use. The shared libraries are not built by default and they are not installed into the target system.

(The libraries are also not correctly versioned, but as shared library versioning depends on stable ABIs we can't decide anything here without phobos upstream)

When the shared runtime support is finished, we probably want to ship both static and shared libraries. But we probably wouldn't want the static library to be built with -fPIC so we'd have to make some changes in the Makefile to compile all files twice. 

See also: http://gdcproject.org/wiki/SharedRuntime
