### PR TITLE
[Incomplete] Fix arm EABI unwinder

### DIFF
--- a/libphobos/libdruntime/gcc/deh.d
+++ b/libphobos/libdruntime/gcc/deh.d
@@ -62,7 +62,7 @@ struct OurUnwindException
     // barrier_cache.bitpattern, but might as well use the space.
     void save(_Unwind_Context* context, ref Phase1Info info)
     {
-      unwindHeader.barrier_cache.sp = _Unwind_GetGR (context, UNWIND_REG_STACK);
+      unwindHeader.barrier_cache.sp = _Unwind_GetGR (context, UNWIND_STACK_REG);
       with (unwindHeader.barrier_cache)
 	{
 	  //bitpattern[0] = cast(_uw) info.obj; // No need for this yet
@@ -109,7 +109,7 @@ struct OurUnwindException
   static assert(unwindHeader.offsetof - obj.offsetof == obj.sizeof);
 
   // The generic exception header
-  _Unwind_Exception unwindHeader;
+  align(4) _Unwind_Exception unwindHeader;
 
   static OurUnwindException * fromHeader(_Unwind_Exception * p_ue)
   {
@@ -224,7 +224,6 @@ else version (GNU_ARM_EABI_Unwinder)
 	if (__gnu_unwind_frame (ue_header, context) != _URC_OK)
 	  return _URC_FAILURE;
 	return _URC_CONTINUE_UNWIND;
-	break;
 
       default:
 	abort();
@@ -568,7 +567,7 @@ parse_lsda_header (_Unwind_Context *context, ubyte *p,
       {
 	// Older ARM EABI toolchains set this value incorrectly, so use a
 	// hardcoded OS-specific format.
-	info.ttype_encoding = _TTYPE_ENCODING;
+	info.ttype_encoding = 0;
       }
       p = read_uleb128 (p, &tmp);
       info.TType = p + tmp;

--- a/libphobos/libdruntime/gcc/unwind_arm.d
+++ b/libphobos/libdruntime/gcc/unwind_arm.d
@@ -239,10 +239,10 @@ enum int UNWIND_POINTER_REG = 12;
 
 
 /* Decode an R_ARM_TARGET2 relocation.  */
-_Unwind_decode_typeinfo_ptr (_Unwind_Word base, _Unwind_Word ptr)
+_Unwind_Word _Unwind_decode_typeinfo_ptr (_Unwind_Word base, _Unwind_Word ptr)
 {
   _Unwind_Word tmp;
-  tmp = *(_Unwind_Word *) ptr;
+  tmp = *cast(_Unwind_Word *) ptr;
   /* Zero values are always NULL.  */
   if (!tmp)
     return 0;
@@ -252,14 +252,14 @@ _Unwind_decode_typeinfo_ptr (_Unwind_Word base, _Unwind_Word ptr)
     /* Pc-relative indirect.  */
     static uint _TTYPE_ENCODING = (DW_EH_PE_pcrel | DW_EH_PE_indirect);
     tmp += ptr;
-    tmp = *(_Unwind_Word *) tmp;
+    tmp = *cast(_Unwind_Word *) tmp;
   }
   else version (NetBSD)
   {
     /* Pc-relative indirect.  */
     static uint _TTYPE_ENCODING = (DW_EH_PE_pcrel | DW_EH_PE_indirect);
     tmp += ptr;
-    tmp = *(_Unwind_Word *) tmp;
+    tmp = *cast(_Unwind_Word *) tmp;
   }
   else version (symbian) // TODO: name
   {


### PR DESCRIPTION
The latest changes to the exception handling routines are broken for ARM.

This is meant to show what needs to be changed to fix it, it's not a ready to pull fix!

There are two problems I don't know how to fix:
- `_TTYPE_ENCODING` is not defined and I have no clue what it is.
- `static assert(unwindHeader.offsetof - obj.offsetof == obj.sizeof);` fails, but I'm not sure if `align(4)` is the correct solution
