### PR TITLE
Rename TARGET_ANDROID macro

### DIFF
--- a/gcc/d/d-spec.c
+++ b/gcc/d/d-spec.c
@@ -56,7 +56,7 @@
 #endif
 
 /* mingw and cygwin don't have pthread. %% TODO: check darwin.  */
-#if TARGET_WINDOS || TARGET_OSX || TARGET_ANDROID
+#if TARGET_WINDOS || TARGET_OSX || TARGET_ANDROID_D
 #define USE_PTHREADS	0
 #else
 #define USE_PTHREADS	1
@@ -485,7 +485,7 @@ lang_specific_driver (struct cl_decoded_option **in_decoded_options,
 
   if (saw_librt)
     new_decoded_options[j++] = *saw_librt;
-#if TARGET_LINUX && !TARGET_ANDROID
+#if TARGET_LINUX && !TARGET_ANDROID_D
   /* Only link if linking statically and target platform supports. */
   else if (library > 1 || static_link || static_phobos)
     {

--- a/gcc/d/target-ver-syms.sh
+++ b/gcc/d/target-ver-syms.sh
@@ -101,13 +101,13 @@ fi
 
 # In DMD, this is usually defined in the target's Makefile.
 case "$d_os_versym" in
-darwin)  echo "#define TARGET_OSX     1" ;;
-FreeBSD) echo "#define TARGET_FREEBSD 1" ;;
-linux)   echo "#define TARGET_LINUX   1" ;;
-OpenBSD) echo "#define TARGET_OPENBSD 1" ;;
-Solaris) echo "#define TARGET_SOLARIS 1" ;;
-Win32)   echo "#define TARGET_WINDOS  1" ;;
-Win64)   echo "#define TARGET_WINDOS  1" ;;
-Android) echo "#define TARGET_ANDROID 1";
-         echo "#define TARGET_LINUX 1";  ;;
+darwin)  echo "#define TARGET_OSX       1" ;;
+FreeBSD) echo "#define TARGET_FREEBSD   1" ;;
+linux)   echo "#define TARGET_LINUX     1" ;;
+OpenBSD) echo "#define TARGET_OPENBSD   1" ;;
+Solaris) echo "#define TARGET_SOLARIS   1" ;;
+Win32)   echo "#define TARGET_WINDOS    1" ;;
+Win64)   echo "#define TARGET_WINDOS    1" ;;
+Android) echo "#define TARGET_ANDROID_D 1";
+         echo "#define TARGET_LINUX     1";  ;;
 esac


### PR DESCRIPTION
UPDATE: As recent GCC defines a TARGET_ANDROID itself, rename our TARGET_ANDROID macro to TARGET_ANDROID_D
