### PR TITLE
update to new vector API in GCC

### DIFF
--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -1301,9 +1301,9 @@ IRState::extractMethodCallExpr (tree mcr, tree& callee_out, tree& object_out)
 {
   gcc_assert (D_IS_METHOD_CALL_EXPR (mcr));
 
-  VEC (constructor_elt,gc) *elts = CONSTRUCTOR_ELTS (mcr);
-  object_out = VEC_index (constructor_elt, elts, 0).value;
-  callee_out = VEC_index (constructor_elt, elts, 1).value;
+  vec<constructor_elt, va_gc>* elts = CONSTRUCTOR_ELTS (mcr);
+  object_out = (*elts)[0].value;
+  callee_out = (*elts)[1].value;
 }
 
 // Return correct callee for method FUNC, which is dereferenced from

--- a/gcc/d/d-codegen.h
+++ b/gcc/d/d-codegen.h
@@ -550,19 +550,19 @@ struct ListMaker
 struct CtorEltMaker
 {
  public:
-  VEC(constructor_elt, gc) *head;
+  vec<constructor_elt, va_gc>* head;
 
   CtorEltMaker (void)
     : head(NULL)
   { }
 
   void reserve (int i)
-  { VEC_reserve (constructor_elt, gc, this->head, i); }
+  { vec_safe_reserve (this->head, i); }
 
   void cons (tree p, tree v)
   {
     constructor_elt ce = { p, v };
-    VEC_safe_push (constructor_elt, gc, this->head, ce);
+    vec_safe_push (this->head, ce);
   }
 
   void cons (tree v)


### PR DESCRIPTION
Recently old macros for working with vectors were replaced with a template-based C++ implementation :

```
2012-11-16  Diego Novillo  <dnovillo@google.com>

    Adjust for new vec API (http://gcc.gnu.org/wiki/cxx-conversion/cxx-vec)

```

Only `d-codegen.h` and `d-codegen.cc` were affected by this change.
