### PR TITLE
Bug #27 - Undefined interface functions when inheriting from two sources.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,9 @@
+2013-01-08  Daniel Green <venix1@gmail.com>
+
+	* d-objfile.cc(ObjectFile::outputThunk): Force output of private thunks
+	when declaration is external.  Duplicates GCC's output_thunk
+	functionality.
+
 2012-12-16  Iain Buclaw  <ibuclaw@ubuntu.com>
 
 	* d-decls.cc(FuncDeclaration::toSymbol): Don't optimise PUREconst


### PR DESCRIPTION
(Corrects GDC's thunk output code responsible for the issue)

http://gdcproject.org/bugzilla/show_bug.cgi?id=27

In a nutshell, this is the same thunk issue seen before.  Thunk output was changed to use weakref, which worked, then that got removed from GCC 4.8 so it changed to use weak.  

Weak doesn't associate the thunk with the appropriate symbol, so we end up with undefined symbol errors.  This is the same patch as before which copies GCC's output_thunk code.
