### PR TITLE
Fix static chain issues

### DIFF
--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -4006,7 +4006,7 @@ IRState::functionNeedsChain (FuncDeclaration *f)
     {
       s = f->toParent();
       ti = s->isTemplateInstance();
-      if (ti && ti->isnested == NULL)
+      if (ti && ti->isnested == NULL && ti->parent->isModule())
 	return false;
 
       pf = f->toParent2()->isFuncDeclaration();

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -3990,6 +3990,37 @@ IRState::getFrameRef (FuncDeclaration *outer_func)
     }
 }
 
+// Special case: If a function returns a nested class with functions
+// but there are no "closure variables" the frontend (needsClosure) 
+// returns false even though the nested class _is_ returned from the
+// function. (See case 4 in needsClosure)
+// A closure is strictly speaking not necessary, but we also can not
+// use a static function chain for functions in the nested class as
+// they can be called from outside. GCC's nested functions can't deal
+// with those kind of functions. We have to detect them manually here
+// and make sure we neither construct a static chain nor a closure.
+
+bool
+functionDegenerateClosure (FuncDeclaration *f)
+{
+  if (!f->needsClosure() && f->closureVars.dim == 0)
+  {
+    Type *tret = ((TypeFunction *)f->type)->next;
+    gcc_assert(tret);
+    tret = tret->toBasetype();
+    if (tret->ty == Tclass || tret->ty == Tstruct)
+    { 
+      Dsymbol *st = tret->toDsymbol(NULL);
+      for (Dsymbol *s = st->parent; s; s = s->parent)
+      {
+	if (s == f)
+	  return true;
+      }
+    }
+  }
+  return false;
+}
+
 // Return true if function F needs to have the static chain passed to
 // it.  This only applies to nested function handling provided by the
 // GCC back end (not D closures.)
@@ -4024,7 +4055,7 @@ IRState::functionNeedsChain (FuncDeclaration *f)
     {
       s = s->toParent2();
       if ((pf = s->isFuncDeclaration())
-	  && !getFrameInfo (pf)->is_closure)
+	  && !getFrameInfo (pf)->is_closure && !functionDegenerateClosure(pf))
 	{
 	  return true;
 	}

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -3998,7 +3998,7 @@ bool
 IRState::functionNeedsChain (FuncDeclaration *f)
 {
   Dsymbol *s;
-  ClassDeclaration *a;
+  AggregateDeclaration *a;
   FuncDeclaration *pf = NULL;
   TemplateInstance *ti = NULL;
 
@@ -4020,7 +4020,7 @@ IRState::functionNeedsChain (FuncDeclaration *f)
 
   s = f->toParent2();
 
-  while (s && (a = s->isClassDeclaration()) && a->isNested())
+  while (s && (((a = s->isAggregateDeclaration()) && a->isNested()) || s->isTemplateInstance()))
     {
       s = s->toParent2();
       if ((pf = s->isFuncDeclaration())

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -209,16 +209,8 @@ ObjectFile::makeDeclOneOnly (tree decl_tree)
 {
   if (!D_DECL_IS_TEMPLATE (decl_tree) || gen.emitTemplates != TEprivate)
     {
-      /* Weak definitions have to be public.  Nested functions may or
-	 may not be emitted as public even if TREE_PUBLIC is set.
-	 There is no way to tell if the back end implements
-	 make_decl_one_only with DECL_WEAK, so this check is
-	 done first.  */
-      if (!TREE_PUBLIC (decl_tree)
-	  || (TREE_CODE (decl_tree) == FUNCTION_DECL
-	      && DECL_CONTEXT (decl_tree) != NULL_TREE
-	      && D_DECL_STATIC_CHAIN (decl_tree) == 1
-	      && D_DECL_IS_CONTRACT (decl_tree) == 0))
+      // Weak definitions have to be public.
+      if (!TREE_PUBLIC (decl_tree))
 	return;
     }
 

--- a/gcc/testsuite/gdc.test/runnable/gdc.d
+++ b/gcc/testsuite/gdc.test/runnable/gdc.d
@@ -112,10 +112,76 @@ void test4()
 }
 
 
+/*
+ * Here the BinaryHeap instance uses an alias parameter and therefore
+ * the instance's functions (percolateDown) need to be generated in
+ * topNIndex->BinaryHeap scope and not in the declaration scope
+ * (module->BinaryHeap).
+ */
+void topNIndex()()
+{
+    bool indirectLess(int a, int b)
+    {
+        return a > b;
+    }
+
+    auto a = BinaryHeap!(indirectLess)();
+}
+
+struct BinaryHeap(alias less)
+{
+    void percolateDown()
+    {
+        less(0, 1);
+    }
+}
+
+void test5()
+{
+    topNIndex();
+}
+
+/*
+ * Similar as test5 but with an additional indirection.
+ * The nested function chain for percolateDown should look like this:
+ * topNIndex2->BinaryHeap2->percolateDown.
+ */
+void topNIndex2()()
+{
+    bool indirectLess(int a, int b)
+    {
+        return a > b;
+    }
+    auto a = BinaryHeap2!(Test!(indirectLess)())();
+}
+
+struct Test(alias a)
+{
+    void foo()
+    {
+        a(0, 0);
+    }
+}
+
+struct BinaryHeap2(alias less)
+{
+    void percolateDown()
+    {
+        less.foo();
+    }
+}
+
+void test6()
+{
+    topNIndex2();
+}
+
 void main()
 {
     test1('n');
     test2('n');
     test3();
     test4();
+    test5();
+    test6();
 }

--- a/gcc/testsuite/gdc.test/runnable/gdc.d
+++ b/gcc/testsuite/gdc.test/runnable/gdc.d
@@ -1,0 +1,28 @@
+module gdc;
+
+/*
+ * Here getChar is a function in a template where template.isnested == false
+ * but getChar still is a nested function and needs to get a
+ * static chain containing test1.
+ */
+void test1()(char val)
+{
+    void error()
+    {
+    }
+
+    void getChar()()
+    {
+        error();
+    }
+
+    void parseString()
+    {
+        getChar();
+    }
+}
+
+void main()
+{
+    test1('n');
+}

--- a/gcc/testsuite/gdc.test/runnable/gdc.d
+++ b/gcc/testsuite/gdc.test/runnable/gdc.d
@@ -46,9 +46,37 @@ void test2()(char val)
     }
 }
 
+/*
+ * If g had accessed a, the frontend would have generated a closure.
+ *
+ * As we do not access it, there's no closure. We have to be careful
+ * not to set a static chain for g containing test3helper though,
+ * as g can be called from outside (here from test3). In the end
+ * we have to treat this as if everything in test3helper was declared
+ * at module scope.
+ */
+auto test3helper()
+{
+    int a;
+    void c() {};
+    class Result
+    {
+        int b;
+        void g() { c(); /*a = 42;*/ }
+    }
+
+    return new Result();
+}
+
+void test3()
+{
+    test3helper().g();
+}
+
 
 void main()
 {
     test1('n');
     test2('n');
+    test3();
 }

--- a/gcc/testsuite/gdc.test/runnable/gdc.d
+++ b/gcc/testsuite/gdc.test/runnable/gdc.d
@@ -22,7 +22,33 @@ void test1()(char val)
     }
 }
 
+/*
+ * Similar as test1, but a little more complicated:
+ * Here getChar is nested in a struct template which is nested
+ * in a function. getChar's static chain still needs to contain test2.
+ */
+void test2()(char val)
+{
+    void error()
+    {
+    }
+    
+    struct S(T){
+    void getChar()
+    {
+        error();
+    }}
+
+
+    void parseString()
+    {
+        S!(int)().getChar();
+    }
+}
+
+
 void main()
 {
     test1('n');
+    test2('n');
 }

--- a/gcc/testsuite/gdc.test/runnable/gdc.d
+++ b/gcc/testsuite/gdc.test/runnable/gdc.d
@@ -1,4 +1,8 @@
+// EXTRA_SOURCES: imports/gdca.d
+
 module gdc;
+
+import imports.gdca;
 
 /*
  * Here getChar is a function in a template where template.isnested == false
@@ -73,10 +77,45 @@ void test3()
     test3helper().g();
 }
 
+/*
+ * empty is a (private) function which is nested in lightPostprocess.
+ * At the same time it's a template instance, so it has to be declared
+ * as weak or otherwise one-only. imports/gdca.d creates another instance
+ * of Regex!char to verify that.
+ */
+struct Parser(R)
+{
+    @property program()
+    {
+        return Regex!char();
+    }
+}
+
+
+struct Regex(Char)
+{
+    @trusted lightPostprocess()
+    {
+        struct FixedStack(T) 
+        {
+            @property empty(){  return false; }
+        }
+
+        auto counterRange = FixedStack!uint();
+    }
+}
+
+void test4()
+{
+    auto parser = Parser!(char[])();
+    imports.gdca.test4a;
+}
+
 
 void main()
 {
     test1('n');
     test2('n');
     test3();
+    test4();
 }

--- a/gcc/testsuite/gdc.test/runnable/imports/gdca.d
+++ b/gcc/testsuite/gdc.test/runnable/imports/gdca.d
@@ -1,0 +1,8 @@
+module imports.gdca;
+
+private import gdc;
+
+void test4a()
+{
+    auto parser = Parser!(char[])();
+}


### PR DESCRIPTION
This fixes some static chain issues. Test cases are attached. I'm not sure if all test cases actually fail on gdc-4.8 right now, but they do fail on gdc-4.7 and I think the changes are not specific to gcc-4.7.

Fixed problems:
- Nested functions in template instances get a static chain
- Non-static nested structs get chains just like classes
- Template instances with alias this now get a correct chain
- "Degenerate" closures are handled
- nested template instance functions are marked as one-only
