### PR TITLE
Implement getVThis for nested structs

### DIFF
--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -3659,11 +3659,22 @@ IRState::getVThis (Dsymbol *decl, Expression *e)
   else if ((struct_decl = decl->isStructDeclaration()))
     {
       Dsymbol *outer = struct_decl->toParent2();
+      ClassDeclaration *cd_outer = outer->isClassDeclaration();
       FuncDeclaration *fd_outer = outer->isFuncDeclaration();
-      // Assuming this is kept as trivial as possible.
-      // NOTE: what about structs nested in structs nested in functions?
-      if (fd_outer)
+
+      if (cd_outer)
 	{
+	  vthis_value = findThis (cd_outer);
+	  if (vthis_value == NULL_TREE)
+	    {
+	      e->error ("outer class %s 'this' needed to create nested struct %s",
+			cd_outer->toChars(), struct_decl->toChars());
+	    }
+	}
+      else if (fd_outer)
+	{
+	  // Assuming this is kept as trivial as possible.
+	  // NOTE: what about structs nested in structs nested in functions?
 	  FuncFrameInfo *ffo = getFrameInfo (fd_outer);
 	  if (ffo->creates_frame || ffo->static_chain
 	      || fd_outer->hasNestedFrameRefs())


### PR DESCRIPTION
Here's the test case (also fails on 4.8): https://gist.github.com/jpf91/4756262

This example is kinda weird. Although getVthis is called it seems that there's no way the empty function can access variables of the RedBlackTree class. At least trying to access variables in the class is always refused by the frontend:
https://gist.github.com/jpf91/4756308
https://gist.github.com/jpf91/4756326

So I'm really not sure why getVthis is called. But the std.container unit tests manage to trigger this error and it's fixed by this pull request. AFAICS there should be no problem if we just implement this the same way it's already done for classes.
