### PR TITLE
Inline template function instances

### DIFF
--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -219,6 +219,10 @@ ObjectFile::makeDeclOneOnly (tree decl_tree)
      even if the target supports one-only. */
   if (!D_DECL_IS_TEMPLATE (decl_tree) || gen.emitTemplates != TEprivate)
     {
+      // Necessary to allow DECL_ONE_ONLY or DECL_WEAK functions to be inlined
+      if (TREE_CODE (decl_tree) == FUNCTION_DECL)
+	DECL_DECLARED_INLINE_P (decl_tree) = 1;
+
       /* The following makes assumptions about the behavior
 	 of make_decl_one_only */
       if (SUPPORTS_ONE_ONLY)


### PR DESCRIPTION
Functions which are marked as `DECL_WEAK` are not inlined by gcc as
they could be replaced with a completely different implementation
at link time.

We know that our template instances will always be identical so
they should be inlined. The solution is to mark the template
function instance as `DECL_DECLARED_INLINE_P` as it's also done in
C++.

This also applies to `DECL_ONE_ONLY` functions as `make_decl_one_only`
also sets `DECL_WEAK`.

Related discussion on gcc-list:
http://article.gmane.org/gmane.comp.gcc.devel/130242
