### PR TITLE
Uda gcc attributes

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,16 @@
+2013-02-28 Jernej Krempus <jkrempus@gmail.com>
+	* d-builtins.c(d_attribute_table): renamed it to
+	d_builtins_attribute_table.
+	* d-lang.cc(d_attribute_table): Added an empty table	
+	* d-lang.cc(LANG_HOOKS_COMMON_ATTRIBUTE_TABLE): defined it as
+	d_builtins_attribute_table
+	* d-lang.h(d_builtins_attribute_table): added a declaration
+	* d-codegen.cc(IRState::attributes): changed it so it goes through
+	in_attrs and looks for any @gcc.attribute.attribute("attr_name").
+	* d-objfile.cc, d-ctype.cc: Pass userAttributes instead of attributes
+	in all calls to IRState::attributes.
+	* libphobos/libdruntime/gcc/attribute.d: new file
+
 2013-02-15  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* Make-lang.in(GDC_EXTENDED_ASM_SYNTAX): Remove macro.

--- a/gcc/d/d-builtins.c
+++ b/gcc/d/d-builtins.c
@@ -1312,7 +1312,7 @@ d_builtin_function (tree decl)
 
 
 /* Table of machine-independent attributes supported in GIMPLE.  */
-const struct attribute_spec d_attribute_table[] =
+const struct attribute_spec d_builtins_attribute_table[] =
 {
   /* { name, min_len, max_len, decl_req, type_req, fn_type_req, handler,
        affects_type_identity } */

--- a/gcc/d/d-ctype.cc
+++ b/gcc/d/d-ctype.cc
@@ -181,8 +181,8 @@ TypeTypedef::toCtype (void)
       tree type_decl = build_decl (UNKNOWN_LOCATION, TYPE_DECL, ident, type_node);
       TYPE_NAME (type_node) = type_decl;
 
-      if (sym->attributes)
-	decl_attributes (&type_node, gen.attributes (sym->attributes), 0);
+      if (sym->userAttributes)
+	decl_attributes (&type_node, gen.attributes (sym->userAttributes), 0);
 
       ctype = type_node;
     }
@@ -222,8 +222,8 @@ TypeEnum::toCtype (void)
 	  TYPE_SIZE (ctype) = 0;
 	  TYPE_MAIN_VARIANT (ctype) = cmemtype;
 
-	  if (sym->attributes)
-	    decl_attributes (&ctype, gen.attributes (sym->attributes),
+	  if (sym->userAttributes)
+	    decl_attributes (&ctype, gen.attributes (sym->userAttributes),
 			     ATTR_FLAG_TYPE_IN_PLACE);
 
 	  TYPE_MIN_VALUE (ctype) = TYPE_MIN_VALUE (cmemtype);
@@ -287,8 +287,8 @@ TypeStruct::toCtype (void)
       // TYPE_ALIGN_UNIT is not an lvalue
       TYPE_PACKED (ctype) = TYPE_PACKED (ctype); // %% todo
 
-      if (sym->attributes)
-	decl_attributes (&ctype, gen.attributes (sym->attributes),
+      if (sym->userAttributes)
+	decl_attributes (&ctype, gen.attributes (sym->userAttributes),
 			 ATTR_FLAG_TYPE_IN_PLACE);
 
       compute_record_mode (ctype);
@@ -300,7 +300,7 @@ TypeStruct::toCtype (void)
 
       AggLayout agg_layout (sym, ctype);
       agg_layout.go();
-      agg_layout.finish (sym->attributes);
+      agg_layout.finish (sym->userAttributes);
     }
 
   return ctype;
@@ -578,7 +578,7 @@ TypeClass::toCtype (void)
 
       TYPE_CONTEXT (rec_type) = gen.declContext (sym);
 
-      agg_layout.finish (sym->attributes);
+      agg_layout.finish (sym->userAttributes);
     }
 
   return ctype;

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -41,6 +41,10 @@
 
 static char lang_name[6] = "GNU D";
 
+const struct attribute_spec d_attribute_table[] = { 
+  { NULL,                     0, 0, false, false, false, NULL, false }
+};
+
 /* Lang Hooks */
 #undef LANG_HOOKS_NAME
 #undef LANG_HOOKS_INIT
@@ -52,6 +56,7 @@ static char lang_name[6] = "GNU D";
 #undef LANG_HOOKS_HANDLE_OPTION
 #undef LANG_HOOKS_POST_OPTIONS
 #undef LANG_HOOKS_PARSE_FILE
+#undef LANG_HOOKS_COMMON_ATTRIBUTE_TABLE
 #undef LANG_HOOKS_ATTRIBUTE_TABLE
 #undef LANG_HOOKS_FORMAT_ATTRIBUTE_TABLE
 #undef LANG_HOOKS_TYPES_COMPATIBLE_P
@@ -73,7 +78,8 @@ static char lang_name[6] = "GNU D";
 #define LANG_HOOKS_HANDLE_OPTION		d_handle_option
 #define LANG_HOOKS_POST_OPTIONS			d_post_options
 #define LANG_HOOKS_PARSE_FILE			d_parse_file
-#define LANG_HOOKS_ATTRIBUTE_TABLE		d_attribute_table
+#define LANG_HOOKS_COMMON_ATTRIBUTE_TABLE       d_builtins_attribute_table
+#define LANG_HOOKS_ATTRIBUTE_TABLE              d_attribute_table
 #define LANG_HOOKS_FORMAT_ATTRIBUTE_TABLE	d_format_attribute_table
 #define LANG_HOOKS_TYPES_COMPATIBLE_P		d_types_compatible_p
 #define LANG_HOOKS_BUILTIN_FUNCTION		d_builtin_function

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -41,7 +41,8 @@
 
 static char lang_name[6] = "GNU D";
 
-const struct attribute_spec d_attribute_table[] = { 
+const struct attribute_spec d_attribute_table[] = 
+{ 
   { NULL,                     0, 0, false, false, false, NULL, false }
 };
 

--- a/gcc/d/d-lang.h
+++ b/gcc/d/d-lang.h
@@ -210,6 +210,7 @@ tree getdecls (void);
 
 /* In d-builtins.c */
 extern const struct attribute_spec d_builtins_attribute_table[];
+extern const struct attribute_spec d_attribute_table[];
 extern const struct attribute_spec d_format_attribute_table[];
 tree d_builtin_function (tree);
 void d_init_builtins (void);

--- a/gcc/d/d-lang.h
+++ b/gcc/d/d-lang.h
@@ -209,7 +209,7 @@ void set_block (tree);
 tree getdecls (void);
 
 /* In d-builtins.c */
-extern const struct attribute_spec d_attribute_table[];
+extern const struct attribute_spec d_builtins_attribute_table[];
 extern const struct attribute_spec d_format_attribute_table[];
 tree d_builtin_function (tree);
 void d_init_builtins (void);

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -325,8 +325,8 @@ ObjectFile::setupSymbolStorage (Dsymbol *dsym, tree decl_tree, bool force_static
       TREE_PUBLIC (decl_tree) = 0;
     }
 
-  if (real_decl && real_decl->attributes)
-    decl_attributes (&decl_tree, gen.attributes (real_decl->attributes), 0);
+  if (real_decl && real_decl->userAttributes)
+    decl_attributes (&decl_tree, gen.attributes (real_decl->userAttributes), 0);
   else if (DECL_ATTRIBUTES (decl_tree) != NULL)
     decl_attributes (&decl_tree, DECL_ATTRIBUTES (decl_tree), 0);
 }

--- a/libphobos/configure
+++ b/libphobos/configure
@@ -584,6 +584,7 @@ PACKAGE_URL=''
 
 ac_unique_file="std/algorithm.d"
 ac_unique_file="libdruntime/gcc/builtins.d"
+ac_unique_file="libdruntime/gcc/attribute.d"
 # Factoring default headers for most tests.
 ac_includes_default="\
 #include <stdio.h>
@@ -2270,6 +2271,7 @@ ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
 
 
 

--- a/libphobos/configure.in
+++ b/libphobos/configure.in
@@ -21,6 +21,7 @@ AC_PREREQ(2.64)
 AC_INIT(libphobos, version-unused)
 AC_CONFIG_SRCDIR(std/algorithm.d)
 AC_CONFIG_SRCDIR(libdruntime/gcc/builtins.d)
+AC_CONFIG_SRCDIR(libdruntime/gcc/attribute.d)
 AC_CONFIG_HEADERS(config.h)
 
 AC_CANONICAL_SYSTEM

--- a/libphobos/libdruntime/gcc/attribute.d
+++ b/libphobos/libdruntime/gcc/attribute.d
@@ -1,3 +1,21 @@
+/* GDC -- D front-end for GCC
+   Copyright (C) 2013 Free Software Foundation, Inc.
+
+   GCC is free software; you can redistribute it and/or modify it under
+   the terms of the GNU General Public License as published by the Free
+   Software Foundation; either version 3, or (at your option) any later
+   version.
+
+   GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+   for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with GCC; see the file COPYING3.  If not see
+   <http://www.gnu.org/licenses/>.
+*/
+
 module gcc.attribute;
 
 private struct Attribute(A...)

--- a/libphobos/libdruntime/gcc/attribute.d
+++ b/libphobos/libdruntime/gcc/attribute.d
@@ -1,0 +1,11 @@
+module gcc.attribute;
+
+struct Attribute(A...)
+{
+    A args;
+}
+
+auto attribute(A...)(A args)
+{
+    return Attribute!A(args);
+}

--- a/libphobos/libdruntime/gcc/attribute.d
+++ b/libphobos/libdruntime/gcc/attribute.d
@@ -1,11 +1,11 @@
 module gcc.attribute;
 
-struct Attribute(A...)
+private struct Attribute(A...)
 {
     A args;
 }
 
-auto attribute(A...)(A args)
+auto attribute(A...)(A args) if(A.length > 0 && is(A[0] == string))
 {
     return Attribute!A(args);
 }


### PR DESCRIPTION
This adds module gcc.attribute which contains function attribute(), which replaces pragma attribute and is used like this:

``` d
@attribute("attribute_name", arg1, arg2) foo(){}
```

This pull request does not remove the code that deals with GCC attributes from the front end.  The code is still there, but it basically does nothing - it would probably be a good idea to remove it too.
