### PR TITLE
Update gcc versym patches

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,9 @@
+2013-03-12  Johannes Pfau  <johannespfau@gmail.com>
+
+	* patch-versym-os-4.8.x(mingw32.h): Fix typo
+	* patch-versym-cpu-4.8.x(mips.h): Fix typo
+	Update version symbols to latest dlang specification.
+
 2013-03-10  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-decls.cc(FuncDeclaration::toSymbol): Delay setting TREE_TYPE as

--- a/gcc/d/patches/patch-versym-os-4.8.x
+++ b/gcc/d/patches/patch-versym-os-4.8.x
@@ -1,7 +1,7 @@
-From ca4e858708b1f7d6700e40e51c1fe3075f145cbd Mon Sep 17 00:00:00 2001
+From 332fc99de95ad3d5335e3783a008b8ad7464465a Mon Sep 17 00:00:00 2001
 From: Johannes Pfau <johannespfau@gmail.com>
 Date: Sat, 2 Feb 2013 22:53:21 +0100
-Subject: [PATCH] Implement D predefined OS versions
+Subject: [PATCH 2/2] Implement D predefined OS versions
 
 This implements the following official versions:
 * Windows
@@ -181,7 +181,7 @@ index 633009b..ef95b9a 100644
 +      builtin_define ("GNU_MinGW64");				\
 +    } while (0)
 diff --git a/config/i386/mingw32.h b/config/i386/mingw32.h
-index 1ac5544..f693210 100644
+index 1ac5544..0a88457 100644
 --- a/config/i386/mingw32.h
 +++ b/config/i386/mingw32.h
 @@ -53,6 +53,18 @@ along with GCC; see the file COPYING3.  If not see
@@ -197,7 +197,7 @@ index 1ac5544..f693210 100644
 +      if (TARGET_64BIT && ix86_abi == MS_ABI)			\
 +	  builtin_define ("Win64");				\
 +      else if (!TARGET_64BIT)					\
-+        builtin_define_std ("Win32");				\
++        builtin_define ("Win32");				\
 +    } while (0)
 +
  #ifndef TARGET_USE_PTHREAD_BY_DEFAULT


### PR DESCRIPTION
- Fix typo in config/i386/mingw32.h
- Fix typo in arch/mips/mips.h
- Update CPU versym symbols to reflect latest upstream changes
  (https://github.com/D-Programming-Language/d-programming-language.org/commit/0165e3ea54cc886b1da9c653497af68fce3dadad)
