### PR TITLE
Fix final interface calls

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2013-03-20  Johannes Pfau  <johannespfau@gmail.com>
+
+	* d-codegen.cc(IRState::objectInstanceMethod): Recursively check
+	for TOKsuper / TOKdottype. Do not ignore CastExp.
+
 2013-03-20  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-codegen.cc(IRState::objectInstanceMethod): Get function pointer


### PR DESCRIPTION
- Check recursively for TOKsuper / TOKdottype like dmd does.
- Also CastExp cannot be ignored like the original code
  did, we must call toCtype on the CastExp.
