### PR TITLE
Use libbacktrace for backtraces if it's available

### DIFF
--- a/gcc/d/config-lang.in
+++ b/gcc/d/config-lang.in
@@ -27,7 +27,7 @@ language="d"
 
 compilers="cc1d\$(exeext)"
 
-target_libs="target-libphobos target-zlib"
+target_libs="target-libphobos target-zlib target-libbacktrace"
 
 # The D frontend is written in C++, so we need to build the C++
 # compiler during stage 1.

--- a/libphobos/configure.ac
+++ b/libphobos/configure.ac
@@ -251,6 +251,75 @@ dnl Checks for header files.
 AC_CHECK_HEADER(stdio.h,:,
   [AC_MSG_ERROR([cannot find stdio.h.])])
 
+
+HAVE_DLADDR=false
+AC_CHECK_FUNC(dladdr, HAVE_DLADDR=true)
+#AC_CHECK_LIB(dl, dladdr, [HAVE_DLADDR=true])
+AC_SUBST(HAVE_DLADDR)
+
+BACKTRACE_SUPPORTED=false
+BACKTRACE_USES_MALLOC=false
+BACKTRACE_SUPPORTS_THREADS=false
+LIBBACKTRACE_LIB=""
+
+CPPFLAGS+=" -I../libbacktrace "
+
+AC_ARG_ENABLE(libbacktrace,
+ [  --disable-libbacktrace  Do not use libbacktrace for backtraces],
+ check_libbacktrace_h="$enableval", check_libbacktrace_h="yes")
+
+if test $check_libbacktrace_h = yes ; then
+  AC_CHECK_HEADER(backtrace-supported.h, have_libbacktrace_h=true,
+    have_libbacktrace_h=false)
+else
+  have_libbacktrace_h=false
+fi
+
+if $have_libbacktrace_h; then
+  AC_MSG_CHECKING([libbacktrace: BACKTRACE_SUPPORTED])
+  AC_EGREP_CPP(FOUND_LIBBACKTRACE_RESULT_GDC,
+  [
+  #include <backtrace-supported.h>
+  #if BACKTRACE_SUPPORTED
+    FOUND_LIBBACKTRACE_RESULT_GDC
+  #endif
+  ], BACKTRACE_SUPPORTED=true, BACKTRACE_SUPPORTED=false)
+  AC_MSG_RESULT($BACKTRACE_SUPPORTED)
+
+  AC_MSG_CHECKING([libbacktrace: BACKTRACE_USES_MALLOC])
+  AC_EGREP_CPP(FOUND_LIBBACKTRACE_RESULT_GDC,
+  [
+  #include <backtrace-supported.h>
+  #if BACKTRACE_USES_MALLOC
+    FOUND_LIBBACKTRACE_RESULT_GDC
+  #endif
+  ], BACKTRACE_USES_MALLOC=true, BACKTRACE_USES_MALLOC=false)
+  AC_MSG_RESULT($BACKTRACE_USES_MALLOC)
+
+  AC_MSG_CHECKING([libbacktrace: BACKTRACE_SUPPORTS_THREADS])
+  AC_EGREP_CPP(FOUND_LIBBACKTRACE_RESULT_GDC,
+  [
+  #include <backtrace-supported.h>
+  #if BACKTRACE_SUPPORTS_THREADS
+    FOUND_LIBBACKTRACE_RESULT_GDC
+  #endif
+  ], BACKTRACE_SUPPORTS_THREADS=true, BACKTRACE_SUPPORTS_THREADS=false)
+  AC_MSG_RESULT($BACKTRACE_SUPPORTS_THREADS)
+fi
+
+AM_CONDITIONAL([BACKTRACE_SUPPORTED], [$BACKTRACE_SUPPORTED])
+
+if $BACKTRACE_SUPPORTED; then
+  LIBBACKTRACE_LIB="../../libbacktrace/.libs/libbacktrace.a"
+else
+  LIBBACKTRACE_LIB=""
+fi
+
+AC_SUBST(LIBBACKTRACE_LIB)
+AC_SUBST(BACKTRACE_SUPPORTED)
+AC_SUBST(BACKTRACE_USES_MALLOC)
+AC_SUBST(BACKTRACE_SUPPORTS_THREADS)
+
 dnl AC_HEADER_STDC
 # TODO...
 
@@ -466,4 +535,4 @@ _EOF
 ])
 
 #TODO: Should be possible to get rid of libdruntime/phobos-ver-syms
-AC_OUTPUT([Makefile src/phobos-ver-syms libdruntime/phobos-ver-syms])
+AC_OUTPUT([Makefile src/phobos-ver-syms libdruntime/phobos-ver-syms libdruntime/gcc/libbacktrace.d])

--- a/libphobos/libdruntime/Makefile.am
+++ b/libphobos/libdruntime/Makefile.am
@@ -77,7 +77,7 @@ CORE_OBJS=core/atomic.o core/bitop.o core/cpuid.o core/demangle.o \
 	  core/sync/exception.o core/sync/mutex.o core/sync/rwmutex.o \
 	  core/sync/semaphore.o
 
-GCC_OBJS=gcc/atomics.o gcc/builtins.o gcc/deh.o gcc/unwind_pe.o
+GCC_OBJS=gcc/atomics.o gcc/backtrace.o gcc/builtins.o gcc/deh.o gcc/libbacktrace.o gcc/unwind_pe.o 
 
 UTIL_OBJS=rt/util/console.o rt/util/container.o rt/util/hash.o \
 	  rt/util/string.o rt/util/utf.o
@@ -183,11 +183,21 @@ CORE_IMPORTS=core/atomic.di core/bitop.di core/cpuid.di core/demangle.di \
 ALL_DRUNTIME_OBJS = $(DRUNTIME_OBJS) $(CORE_OBJS) $(D_GC_MODULES) $(GCC_OBJS)
 
 libgdruntime.a : $(ALL_DRUNTIME_OBJS) $(CMAIN_OBJS) $(subst core/,$(IMPORT)/core/,$(CORE_IMPORTS))
+if BACKTRACE_SUPPORTED
+	cp -f $(LIBBACKTRACE_LIB) $@
+	$(AR) -q $@ $(ALL_DRUNTIME_OBJS) $(CMAIN_OBJS)
+else
 	$(AR) -r $@ $(ALL_DRUNTIME_OBJS) $(CMAIN_OBJS)
+endif
 	$(RANLIB) $@
 
 libgdruntime_t.a : $(ALL_DRUNTIME_OBJS:.o=.t.o) $(CMAIN_OBJS:.o=.t.o)
+if BACKTRACE_SUPPORTED
+	cp -f $(LIBBACKTRACE_LIB) $@
+	$(AR) -q $@ $(ALL_DRUNTIME_OBJS:.o=.t.o) $(CMAIN_OBJS:.o=.t.o)
+else
 	$(AR) -r $@ $(ALL_DRUNTIME_OBJS:.o=.t.o) $(CMAIN_OBJS:.o=.t.o)
+endif
 	$(RANLIB) $@
 
 unittest: libgdruntime.a libgdruntime_t.a unittest.o
@@ -227,6 +237,7 @@ install-data-local: libgdruntime.a
 		$(INSTALL_HEADER) $(srcdir)/$$i $(DESTDIR)$(gdc_include_dir); \
 	done
 	$(INSTALL) phobos-ver-syms $(DESTDIR)$(gdc_include_dir)/$(host_alias)/$(MULTISUBDIR)
+	$(INSTALL_HEADER) gcc/libbacktrace.d $(DESTDIR)$(gdc_include_dir)/gcc;
 
 clean-local:
 	rm -f $(CMAIN_OBJS)

--- a/libphobos/libdruntime/gcc/backtrace.d
+++ b/libphobos/libdruntime/gcc/backtrace.d
@@ -1,0 +1,573 @@
+/* GDC -- D front-end for GCC
+   Copyright (C) 2013 Free Software Foundation, Inc.
+
+   GCC is free software; you can redistribute it and/or modify it under
+   the terms of the GNU General Public License as published by the Free
+   Software Foundation; either version 3, or (at your option) any later
+   version.
+
+   GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+   for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with GCC; see the file COPYING3.  If not see
+   <http://www.gnu.org/licenses/>.
+*/
+
+/* This module provides a backtrace implementation for gdc */
+module gcc.backtrace;
+
+import gcc.libbacktrace;
+
+
+version( Posix )
+{
+    // NOTE: The first 5 frames with the current implementation are
+    //       inside core.runtime and the object code, so eliminate
+    //       these for readability.  The alternative would be to
+    //       exclude the first N frames that are in a list of
+    //       mangled function names.
+    static enum FIRSTFRAME = 5;
+}
+else
+{
+    // NOTE: On Windows, the number of frames to exclude is based on
+    //       whether the exception is user or system-generated, so
+    //       it may be necessary to exclude a list of function names
+    //       instead.
+    static enum FIRSTFRAME = 0;
+}
+
+static if(BACKTRACE_SUPPORTED && !BACKTRACE_USES_MALLOC)
+{
+    import core.stdc.stdint, core.stdc.string, core.stdc.stdio;
+    enum MAXFRAMES = 128;
+
+    extern(C) int simpleCallback(void* data, uintptr_t pc)
+    {
+        auto context = cast(LibBacktrace)data;
+
+        if(context.numPCs == MAXFRAMES)
+            return 1;
+
+        context.pcs[context.numPCs++] = pc;
+        return 0;
+    }
+
+    /*
+     * Used for backtrace_create_state and backtrace_simple
+     */
+    extern(C) void simpleErrorCallback(void* data, const(char)* msg, int errnum)
+    {
+        if(data) //context is not available in backtrace_create_state
+        {
+            auto context = cast(LibBacktrace)data;
+            strncpy(context.errorBuf.ptr, msg, context.errorBuf.length - 1);
+            context.error = errnum;
+        }
+    }
+
+    /*
+     * Used for backtrace_pcinfo
+     */
+    extern(C) int pcinfoCallback(void* data, uintptr_t pc, const(char)* filename,
+        int lineno, const(char)* func)
+    {
+        auto context = cast(SymbolCallbackInfo*)data;
+
+        //Try to get the function name via backtrace_syminfo
+        if(func is null)
+        {
+            SymbolCallbackInfo2 info;
+            info.base = context;
+            info.filename = filename;
+            info.lineno = lineno;
+            if(backtrace_syminfo(context.state, pc, &syminfoCallback2, null, &info) != 0)
+            {
+                return context.retval;
+            }
+        }
+
+        auto sym = SymbolOrError(0, SymbolInfo(func, filename, lineno, cast(void*)pc));
+        context.retval = context.applyCB(context.num, sym);
+        context.num++;
+
+        return context.retval;
+    }
+
+    /*
+     * Used for backtrace_pcinfo and backtrace_syminfo
+     */
+    extern(C) void pcinfoErrorCallback(void* data, const(char)* msg, int errnum)
+    {
+        auto context = cast(SymbolCallbackInfo*)data;
+
+        if(errnum == -1)
+        {
+            context.noInfo = true;
+            return;
+        }
+
+        SymbolOrError symError;
+        symError.errnum = errnum;
+        symError.msg = msg;
+
+        size_t i = 0;
+        context.retval = context.applyCB(i, symError);
+    }
+
+    /*
+     * Used for backtrace_syminfo (in opApply)
+     */
+    extern(C) void syminfoCallback(void* data, uintptr_t pc,
+        const(char)* symname, uintptr_t symval)
+    {
+        auto context = cast(SymbolCallbackInfo*)data;
+
+        auto sym = SymbolOrError(0, SymbolInfo(symname, null, 0, cast(void*)pc));
+        context.retval = context.applyCB(context.num, sym);
+
+        context.num++;
+    }
+
+    /*
+     * This callback is used if backtrace_syminfo is called from the pcinfoCallback
+     * callback. It merges it's information with the information from pcinfoCallback.
+     */
+    extern(C) void syminfoCallback2(void* data, uintptr_t pc,
+        const(char)* symname, uintptr_t symval)
+    {
+        auto context = cast(SymbolCallbackInfo2*)data;
+
+        auto sym = SymbolOrError(0, SymbolInfo(symname, context.filename, context.lineno,
+            cast(void*)pc));
+        context.base.retval = context.base.applyCB(context.base.num, sym);
+
+        context.base.num++;
+    }
+
+    /*
+     * The callback type used with the opApply overload which returns a SymbolOrError
+     */
+    private alias scope int delegate(ref size_t, ref SymbolOrError) ApplyCallback;
+
+    /*
+     * Passed to syminfoCallback, pcinfoCallback and pcinfoErrorCallback
+     */
+    struct SymbolCallbackInfo
+    {
+        bool noInfo = false;       //True if debug info / symbol table is not available
+        size_t num = 0;            //Counter for opApply
+        int retval;                //Value returned by applyCB
+        backtrace_state* state;
+
+        //info.fileName / funcName / errmsg may become invalid after this delegate returned
+        ApplyCallback applyCB;
+
+        void reset()
+        {
+            noInfo = false;
+            num = 0;
+        }
+    }
+
+    /*
+     * Passed to the syminfoCallback2 callback. That function merges it's
+     * funcName with this information and updates base as all other callbacks do.
+     */
+    struct SymbolCallbackInfo2
+    {
+        SymbolCallbackInfo* base;
+        const(char)* filename;
+        int lineno;
+    }
+
+    /*
+     * Contains a valid symbol or an error message if errnum is != 0.
+     */
+    struct SymbolOrError
+    {
+        int errnum; // == 0: No error
+        union
+        {
+            SymbolInfo symbol;
+            const(char)* msg;
+        }
+    }
+
+    //FIXME: state is never freed as libbacktrace doesn't provide a free function...
+    public class LibBacktrace : Throwable.TraceInfo
+    {
+        enum MaxAlignment = (void*).alignof;
+
+        static void initLibBacktrace()
+        {
+            if(!initialized)
+            {
+                state = backtrace_create_state(null, false, &simpleErrorCallback, null);
+                initialized = true;
+            }
+        }
+
+        this(int firstFrame = FIRSTFRAME)
+        {
+            _firstFrame = firstFrame;
+
+            initLibBacktrace();
+
+            if(state)
+            {
+                backtrace_simple(state, _firstFrame, &simpleCallback,
+                    &simpleErrorCallback, cast(void*)this);
+            }
+        }
+
+        override int opApply( scope int delegate(ref const(char[])) dg ) const
+        {
+            return opApply( (ref size_t, ref const(char[]) buf)
+                            {
+                                return dg( buf );
+                            } );
+        }
+
+        override int opApply( scope int delegate(ref size_t, ref const(char[])) dg ) const
+        {
+            return opApply( (ref size_t i, ref SymbolOrError sym)
+                {
+                    char[512] buffer = '\0';
+                    char[] msg;
+                    if(sym.errnum != 0)
+                    {
+                        auto retval = snprintf(buffer.ptr, buffer.length,
+                            "libbacktrace error: '%s' errno: %d", sym.msg, sym.errnum);
+
+                        if(retval >= buffer.length)
+                            msg = buffer[0 .. $-1]; //Ignore zero terminator
+                        else if(retval > 0)
+                            msg = buffer[0 .. retval];
+                    }
+                    else
+                    {
+                        msg = formatLine(sym.symbol, buffer);
+                    }
+
+                    return dg(i, msg);
+                } );
+                return 0;
+        }
+
+        int opApply(ApplyCallback dg) const
+        {
+            //If backtrace_simple produced an error report it and exit
+            if(!state || error != 0)
+            {
+                size_t pos = 0;
+                SymbolOrError symError;
+                symError.errnum = error;
+                symError.msg = errorBuf.ptr;
+
+                return dg(pos, symError);
+            }
+
+            SymbolCallbackInfo cinfo;
+            cinfo.applyCB = dg;
+            cinfo.state = cast(backtrace_state*)state;
+
+            //Try using debug info first
+            foreach(i, pc; pcs[0 .. numPCs])
+            {
+                //FIXME: We may violate const guarantees here...
+                if(backtrace_pcinfo(cast(backtrace_state*)state, pc, &pcinfoCallback,
+                    &pcinfoErrorCallback, &cinfo) != 0)
+                {
+                    break; //User delegate requested abort or no debug info at all
+                }
+            }
+
+            //If no error or other error which has already been reported via callback
+            if(!cinfo.noInfo)
+                return cinfo.retval;
+
+            //Try using symbol table
+            cinfo.reset();
+            foreach(pc; pcs[0 .. numPCs])
+            {
+                if(backtrace_syminfo(cast(backtrace_state*)state, pc, &syminfoCallback,
+                    &pcinfoErrorCallback, &cinfo) == 0)
+                {
+                    break;
+                }
+            }
+
+            if(!cinfo.noInfo)
+                return cinfo.retval;
+
+            //No symbol table
+            foreach(i, pc; pcs[0 .. numPCs])
+            {
+                auto sym = SymbolOrError(0, SymbolInfo(null, null, 0, cast(void*)pc));
+                if(auto ret = dg(i, sym) != 0)
+                    return ret;
+            }
+
+            return 0;
+        }
+
+        override string toString() const
+        {
+            string buf;
+            foreach(i, const(char[]) line; this )
+                buf ~= i ? "\n" ~ line : line;
+            return buf;
+        }
+
+    private:
+        static backtrace_state* state = null;
+        static bool initialized       = false;
+        size_t                  numPCs = 0;
+        uintptr_t[MAXFRAMES]    pcs;
+
+        int                   error = 0;
+        int                   _firstFrame = 0;
+        char[128]             errorBuf;
+    }
+}
+else
+{
+    /*
+     * Our fallback backtrace implementation using libgcc's unwind
+     * and backtrace support. In theory libbacktrace should be available
+     * everywhere where this code works. We keep it anyway till libbacktrace
+     * is well-tested.
+     */
+    public class GDCBacktrace : Throwable.TraceInfo
+    {
+        this(int firstFrame = FIRSTFRAME)
+        {
+            _firstFrame = firstFrame;
+            _callstack = gdcBacktrace();
+            _framelist = gdcBacktraceSymbols(_callstack);
+        }
+
+        override int opApply( scope int delegate(ref const(char[])) dg ) const
+        {
+            return opApply( (ref size_t, ref const(char[]) buf)
+                            {
+                                return dg( buf );
+                            } );
+        }
+
+        override int opApply( scope int delegate(ref size_t, ref const(char[])) dg ) const
+        {
+            int ret = 0;
+            char[512] fixbuf = '\0';
+
+            for( int i = _firstFrame; i < _framelist.entries; ++i )
+            {
+                auto pos = cast(size_t)(i - _firstFrame);
+                auto buf = formatLine(_framelist.symbols[i], fixbuf);
+                ret = dg( pos, buf );
+                if( ret )
+                    break;
+            }
+            return ret;
+        }
+
+        override string toString() const
+        {
+            string buf;
+            foreach( i, line; this )
+                buf ~= i ? "\n" ~ line : line;
+            return buf;
+        }
+
+    private:
+        BTSymbolData     _framelist;
+        GDCBacktraceData _callstack;
+        int              _firstFrame = 0;
+    }
+
+    // Implementation details
+    private:
+        import gcc.unwind;
+
+        static enum MAXFRAMES = 128;
+
+        struct GDCBacktraceData
+        {
+            void*[MAXFRAMES] callstack;
+            int numframes = 0;
+        }
+
+        struct BTSymbolData
+        {
+            size_t entries;
+            SymbolInfo[MAXFRAMES] symbols;
+        }
+
+        static extern (C) _Unwind_Reason_Code unwindCB(_Unwind_Context *ctx, void *d)
+        {
+            GDCBacktraceData* bt = cast(GDCBacktraceData*)d;
+            if(bt.numframes >= MAXFRAMES)
+                return _URC_NO_REASON;
+
+            bt.callstack[bt.numframes] = cast(void*)_Unwind_GetIP(ctx);
+            bt.numframes++;
+            return _URC_NO_REASON;
+        }
+
+        GDCBacktraceData gdcBacktrace()
+        {
+            GDCBacktraceData stackframe;
+            _Unwind_Backtrace(&unwindCB, &stackframe);
+            return stackframe;
+        }
+
+        BTSymbolData gdcBacktraceSymbols(GDCBacktraceData data)
+        {
+            BTSymbolData symData;
+
+            for(auto i = 0; i < data.numframes; i++)
+            {
+                static if(HAVE_DLADDR)
+                {
+                    Dl_info funcInfo;
+
+                    if(data.callstack[i] !is null && dladdr(data.callstack[i], &funcInfo) != 0)
+                    {
+                        symData.symbols[symData.entries].funcName = funcInfo.dli_sname;
+
+                        symData.symbols[symData.entries].address = data.callstack[i];
+                        symData.entries++;
+                    }
+                    else
+                    {
+                        symData.symbols[symData.entries].address = data.callstack[i];
+                        symData.entries++;
+                    }
+                }
+                else
+                {
+                    symData.symbols[symData.entries].address = data.callstack[i];
+                    symData.entries++;
+                }
+            }
+
+            return symData;
+        }
+}
+
+/*
+ * Struct representing a symbol (function) in the backtrace
+ */
+struct SymbolInfo
+{
+    const(char)* funcName, fileName;
+    size_t line;
+    const(void)* address;
+}
+
+/*
+ * Format one output line for symbol sym.
+ * Returns a slice of fixbuf.
+ */
+char[] formatLine(const SymbolInfo sym, ref char[512] fixbuf)
+{
+    import core.demangle, core.stdc.config;
+    import core.stdc.stdio : snprintf, printf;
+    import core.stdc.string : strlen;
+
+    int ret;
+
+    ret = snprintf(fixbuf.ptr, fixbuf.sizeof, "0x%lx ", cast(c_ulong)sym.address);
+    if(ret >= fixbuf.sizeof)
+        return fixbuf[0 .. $-1]; //Ignore zero terminator
+
+    if(sym.funcName is null)
+    {
+        if(!(fixbuf.sizeof - ret > 3))
+            return fixbuf[0 .. ret];
+
+        fixbuf[ret] = fixbuf[ret+1] = fixbuf[ret+2] = '?';
+        ret += 3;
+    }
+    else
+    {
+        auto demangled = demangle(sym.funcName[0 .. strlen(sym.funcName)],
+            fixbuf[ret .. $-1]);
+
+        ret += demangled.length;
+        if(ret + 1 >= fixbuf.sizeof)
+            return fixbuf[0 .. $-1]; //Ignore zero terminator
+    }
+
+    ret += snprintf(fixbuf.ptr + ret, fixbuf.sizeof - ret, "\n\t%s:%d",
+        sym.fileName is null ? "???" : sym.fileName,
+        sym.line);
+
+    if(ret >= fixbuf.sizeof)
+        return fixbuf[0 .. $-1]; //Ignore zero terminator
+    else
+        return fixbuf[0 .. ret];
+}
+
+
+unittest
+{
+    char[512] sbuf = '\0';
+    char[] result;
+    string longString;
+    for(size_t i = 0; i < 60; i++)
+        longString ~= "abcdefghij";
+    longString ~= '\0';
+
+    auto symbol = SymbolInfo(null, null, 0, null);
+    result = formatLine(symbol, sbuf);
+    assert(result.length < 512 && result.ptr[result.length] == '\0' && sbuf[$-1] == '\0');
+
+    symbol = SymbolInfo(longString.ptr, null, 0, null);
+    result = formatLine(symbol, sbuf);
+    assert(result.length < 512 && result.ptr[result.length] == '\0' && sbuf[$-1] == '\0');
+
+    symbol = SymbolInfo("func", "test.d", 0, null);
+    result = formatLine(symbol, sbuf);
+    assert(result.length < 512 && result.ptr[result.length] == '\0' && sbuf[$-1] == '\0');
+
+    symbol = SymbolInfo("func", longString.ptr, 0, null);
+    result = formatLine(symbol, sbuf);
+    assert(result.length < 512 && result.ptr[result.length] == '\0' && sbuf[$-1] == '\0');
+
+    symbol = SymbolInfo(longString.ptr, "test.d", 0, null);
+    result = formatLine(symbol, sbuf);
+    assert(result.length < 512 && result.ptr[result.length] == '\0' && sbuf[$-1] == '\0');
+
+    symbol = SymbolInfo(longString.ptr, longString.ptr, 0, null);
+    result = formatLine(symbol, sbuf);
+    assert(result.length < 512 && result.ptr[result.length] == '\0' && sbuf[$-1] == '\0');
+
+    symbol = SymbolInfo("func", "test.d", 1000, null);
+    result = formatLine(symbol, sbuf);
+    assert(result.length < 512 && result.ptr[result.length] == '\0' && sbuf[$-1] == '\0');
+
+    symbol = SymbolInfo(null, (longString[0..500] ~ '\0').ptr, 100000000, null);
+    result = formatLine(symbol, sbuf);
+    assert(result.length < 512 && result.ptr[result.length] == '\0' && sbuf[$-1] == '\0');
+
+    symbol = SymbolInfo("func", "test.d", 0, cast(void*)0x100000);
+    result = formatLine(symbol, sbuf);
+    assert(result.length < 512 && result.ptr[result.length] == '\0' && sbuf[$-1] == '\0');
+
+    symbol = SymbolInfo("func", null, 0, cast(void*)0x100000);
+    result = formatLine(symbol, sbuf);
+    assert(result.length < 512 && result.ptr[result.length] == '\0' && sbuf[$-1] == '\0');
+
+    symbol = SymbolInfo(null, "test.d", 0, cast(void*)0x100000);
+    result = formatLine(symbol, sbuf);
+    assert(result.length < 512 && result.ptr[result.length] == '\0' && sbuf[$-1] == '\0');
+
+    symbol = SymbolInfo(longString.ptr, "test.d", 0, cast(void*)0x100000);
+    result = formatLine(symbol, sbuf);
+    assert(result.length < 512 && result.ptr[result.length] == '\0' && sbuf[$-1] == '\0');
+}

--- a/libphobos/libdruntime/gcc/libbacktrace.d.in
+++ b/libphobos/libdruntime/gcc/libbacktrace.d.in
@@ -1,0 +1,88 @@
+/* GDC -- D front-end for GCC
+   Copyright (C) 2013 Free Software Foundation, Inc.
+
+   GCC is free software; you can redistribute it and/or modify it under
+   the terms of the GNU General Public License as published by the Free
+   Software Foundation; either version 3, or (at your option) any later
+   version.
+
+   GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+   for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with GCC; see the file COPYING3.  If not see
+   <http://www.gnu.org/licenses/>.
+*/
+
+/* This module provides access to GCC libbacktrace functions */
+module gcc.libbacktrace;
+
+/*
+ * This is not part of libbacktrace, it's used for the temporary gdc fallback
+ * implementation. To avoid adding another autoconf module it's defined here
+ */
+
+enum HAVE_DLADDR = @HAVE_DLADDR@;
+static if (HAVE_DLADDR)
+{
+    extern(C):
+        int dladdr(void *addr, Dl_info *info);
+        struct Dl_info
+        {
+            const (char*) dli_fname;
+            void*         dli_fbase;
+            const (char*) dli_sname;
+            void*         dli_saddr;
+        }
+}
+
+/*
+ * Part of backtrace-supported.h: These are platform specific variables.
+ * They are obtained via the configure script
+ */
+
+enum BACKTRACE_SUPPORTED = @BACKTRACE_SUPPORTED@;
+enum BACKTRACE_USES_MALLOC = @BACKTRACE_USES_MALLOC@;
+enum BACKTRACE_SUPPORTS_THREADS = @BACKTRACE_SUPPORTS_THREADS@;
+
+/*
+ * libbacktrace.h
+ */
+
+static if(BACKTRACE_SUPPORTED)
+{
+    import core.stdc.stddef, core.stdc.stdio, core.stdc.stdint;
+
+    extern(C):
+        struct backtrace_state {}
+
+        alias extern(C) void function(void* data,
+            const(char)* msg, int errnum) backtrace_error_callback;
+
+        backtrace_state* backtrace_create_state( const(char)* filename, int threaded,
+            backtrace_error_callback error_callback, void* data);
+
+        alias extern(C) int function(void* data, uintptr_t pc,
+            const(char)* filename, int lineno, const(char)* func) backtrace_full_callback;
+
+        int backtrace_full(backtrace_state* state, int skip, backtrace_full_callback callback,
+            backtrace_error_callback error_callback, void* data);
+
+        alias extern(C) int function(void* data, uintptr_t pc) backtrace_simple_callback;
+
+        int backtrace_simple(backtrace_state* state, int skip, backtrace_simple_callback callback,
+            backtrace_error_callback error_callback, void* data);
+
+        void backtrace_print(backtrace_state* state, int skip, FILE* file);
+
+        int backtrace_pcinfo(backtrace_state* state, uintptr_t pc, backtrace_full_callback callback,
+            backtrace_error_callback error_callback,    void* data);
+
+        alias extern(C) void function(void* data, uintptr_t pc,
+            const(char)* symname, uintptr_t symval) backtrace_syminfo_callback;
+
+        int backtrace_syminfo(backtrace_state *state, uintptr_t pc, backtrace_syminfo_callback callback,
+            backtrace_error_callback error_callback, void* data);
+}


### PR DESCRIPTION
# Description

This pull adds support to use the new GCC libbacktrace which is part of gcc 4.8. Libbacktrace can use debug info as well as the symbol table to find function names, so it's way superior to our current solution. It's probably also more portable. This code obtains the symbol information lazily. At first it only obtains the pointers, the symbol name, line, etc are only obtained when the backtrace is being printed.

**I would not recommend merging this until the unittests work again but it's ready for review.**
# Performance

When actually obtaining the complete backtrace (e.g. calling .toString on the exception, dumping it to the console) this code is 2x slower than the current glib backtrace. It is still 2x faster than the dmd exception+glib backtrace code.

However, when not using the backtrace information by calling toString or similar functions the new code is 3.5x faster than the current (not lazy) glib backtrace code. This is as fast as a minimal backtrace implementation (only obtaining the frame addresses) can be.

BTW: Not using any exception backtrace at all by overwriting Runtime.traceHandler is still 3x faster than this minimal/lazy backtrace. G++ exceptions are slightly slower than D exceptions without backtraces.
# Example Output:

Example output (with -g)

```
std.conv.ConvException@/opt/gdc/include/d/4.8.1/std/conv.d(1811): Unexpected 'H' when converting from type string to type int
----------------
0x407fa5 void std.conv.convError!(immutable(char)[], int).convError(immutable(char)[], immutable(char)[], ulong)
    /opt/gdc/include/d/4.8.1/std/conv.d:52
0x407ea2 int std.conv.parse!(int, immutable(char)[]).parse(ref immutable(char)[])
    /opt/gdc/include/d/4.8.1/std/conv.d:1811
0x40a2e7 int std.conv.toImpl!(int, immutable(char)[]).toImpl(immutable(char)[])
    /opt/gdc/include/d/4.8.1/std/conv.d:1600
0x407330 int std.conv.to!(int).to!(immutable(char)[]).to(immutable(char)[])
    /opt/gdc/include/d/4.8.1/std/conv.d:276
0x403d9e int test.doSomeThing(immutable(char)[])
    /home/jpf/Dokumente/Code/gdc/objdir/test.d:10
0x403d66 _Dmain
    /home/jpf/Dokumente/Code/gdc/objdir/test.d:5
0x4142ee extern (C) int rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).void runMain()
    ../../../../gcc-4.8.1/libphobos/libdruntime/rt/dmain2.d:620
0x414a4e extern (C) int rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).void tryExec(scope void delegate())
    ../../../../gcc-4.8.1/libphobos/libdruntime/rt/dmain2.d:595
0x414c7f extern (C) int rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).void runAll()
    ../../../../gcc-4.8.1/libphobos/libdruntime/rt/dmain2.d:630
0x414a4e extern (C) int rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).void tryExec(scope void delegate())
    ../../../../gcc-4.8.1/libphobos/libdruntime/rt/dmain2.d:595
0x414be7 _d_run_main
----------------
```

Output without -g

```
std.conv.ConvException@/opt/gdc/include/d/4.8.1/std/conv.d(1811): Unexpected 'H' when converting from type string to type int
----------------
0x407fa5 void std.conv.convError!(immutable(char)[], int).convError(immutable(char)[], immutable(char)[], ulong)
    ???:0
0x407ea2 int std.conv.parse!(int, immutable(char)[]).parse(ref immutable(char)[])
    ???:0
0x40a2e7 int std.conv.toImpl!(int, immutable(char)[]).toImpl(immutable(char)[])
    ???:0
0x407330 int std.conv.to!(int).to!(immutable(char)[]).to(immutable(char)[])
    ???:0
0x403d9e int test.doSomeThing(immutable(char)[])
    ???:0
0x403d66 _Dmain
    ???:0
0x4142ee extern (C) int rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).void runMain()
    ../../../../gcc-4.8.1/libphobos/libdruntime/rt/dmain2.d:620
0x414a4e extern (C) int rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).void tryExec(scope void delegate())
    ../../../../gcc-4.8.1/libphobos/libdruntime/rt/dmain2.d:595
0x414c7f extern (C) int rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).void runAll()
    ../../../../gcc-4.8.1/libphobos/libdruntime/rt/dmain2.d:630
0x414a4e extern (C) int rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).void tryExec(scope void delegate())
    ../../../../gcc-4.8.1/libphobos/libdruntime/rt/dmain2.d:595
0x414be7 _d_run_main
    ../../../../gcc-4.8.1/libphobos/libdruntime/rt/dmain2.d:639
0x3ad6621734 ???
    ???:0
0x403c64 ???
    ???:0
----------------
```

Sample output for segmentation fault in unittests:
Before:

```
unittest, crashing...
./a.out[0x41f075]
/lib64/libpthread.so.0[0x3ad6e0efe0]
./a.out[0x40572a]
./a.out[0x405dcd]
./a.out[0x41f1c8]
./a.out[0x4190d9]
./a.out[0x41f2f1]
./a.out[0x418d2d]
./a.out[0x418b2f]
./a.out[0x418cc8]
/lib64/libc.so.6(__libc_start_main+0xf5)[0x3ad6621735]
./a.out[0x4055e5]
Speicherzugriffsfehler (Speicherabzug geschrieben)
```

After:

```
unittest, crashing...
Segmentation fault while running unittests:
0x41f021 extern (C) bool core.runtime.runModuleUnitTests().extern (C) void unittestSegvHandler(int, core.sys.posix.signal.siginfo_t*, void*)
    ../../../../gcc-4.8.1/libphobos/libdruntime/core/runtime.d:314
0x3ad6e0efdf ???
    ???:0
0x4056ca void test.__unittestL8_1()
    /home/jpf/Dokumente/Code/gdc/objdir/test.d:12
0x405d6c test._D4test9__modtestFZv
    /opt/gdc/include/d/4.8.1/std/conv.d:104
0x41f1a7 extern (C) bool core.runtime.runModuleUnitTests().int __foreachbody13(ref object.ModuleInfo*)
    ../../../../gcc-4.8.1/libphobos/libdruntime/core/runtime.d:383
0x419078 int rt.minfo.moduleinfos_apply(scope int delegate(ref object.ModuleInfo*))
    ../../../../gcc-4.8.1/libphobos/libdruntime/rt/minfo.d:116
0x41f2d0 runModuleUnitTests
    ../../../../gcc-4.8.1/libphobos/libdruntime/core/runtime.d:373
0x418ccc extern (C) int rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).void runAll()
    ../../../../gcc-4.8.1/libphobos/libdruntime/rt/dmain2.d:629
0x418ace extern (C) int rt.dmain2._d_run_main(int, char**, extern (C) int function(char[][])*).void tryExec(scope void delegate())
    ../../../../gcc-4.8.1/libphobos/libdruntime/rt/dmain2.d:595
0x418c67 _d_run_main
    ../../../../gcc-4.8.1/libphobos/libdruntime/rt/dmain2.d:639
0x3ad6621734 ???
    ???:0
0x405584 ???
    ???:0
Speicherzugriffsfehler (Speicherabzug geschrieben)
```
