### PR TITLE
allow compilation with -fversion=BareMetal

### DIFF
--- a/libphobos/libdruntime/core/demangle.d
+++ b/libphobos/libdruntime/core/demangle.d
@@ -14,12 +14,17 @@
  */
 module core.demangle;
 
-
-debug(trace) import core.stdc.stdio : printf;
-debug(info) import core.stdc.stdio : printf;
-import core.stdc.stdio : snprintf;
-import core.stdc.string : memmove;
-import core.stdc.stdlib : strtold;
+version(BareMetal)
+{
+}
+else
+{
+	debug(trace) import core.stdc.stdio : printf;
+	debug(info) import core.stdc.stdio : printf;
+	import core.stdc.stdio : snprintf;
+	import core.stdc.string : memmove;
+	import core.stdc.stdlib : strtold;
+}
 
 
 private struct Demangle
@@ -374,76 +379,81 @@ private struct Demangle
         return val;
     }
 
-
-    void parseReal()
+    version(BareMetal)
     {
-        debug(trace) printf( "parseReal+\n" );
-        debug(trace) scope(success) printf( "parseReal-\n" );
-
-        char[64] tbuf = void;
-        size_t   tlen = 0;
-        real     val  = void;
-
-        if( 'I' == tok() )
-        {
-            match( "INF" );
-            put( "real.infinity" );
-            return;
-        }
-        if( 'N' == tok() )
-        {
-            next();
-            if( 'I' == tok() )
-            {
-                match( "INF" );
-                put( "-real.infinity" );
-                return;
-            }
-            if( 'A' == tok() )
-            {
-                match( "AN" );
-                put( "real.nan" );
-                return;
-            }
-            tbuf[tlen++] = '-';
-        }
-
-        tbuf[tlen++] = '0';
-        tbuf[tlen++] = 'X';
-        if( !isHexDigit( tok() ) )
-            error( "Expected hex digit" );
-        tbuf[tlen++] = tok();
-        tbuf[tlen++] = '.';
-        next();
-
-        while( isHexDigit( tok() ) )
-        {
-            tbuf[tlen++] = tok();
-            next();
-        }
-        match( 'P' );
-        tbuf[tlen++] = 'p';
-        if( 'N' == tok() )
-        {
-            tbuf[tlen++] = '-';
-            next();
-        }
-        else
-        {
-            tbuf[tlen++] = '+';
-        }
-        while( isDigit( tok() ) )
-        {
-            tbuf[tlen++] = tok();
-            next();
-        }
-
-        tbuf[tlen] = 0;
-        debug(info) printf( "got (%s)\n", tbuf.ptr );
-        val = strtold( tbuf.ptr, null );
-        tlen = snprintf( tbuf.ptr, tbuf.length, "%#Lg", val );
-        debug(info) printf( "converted (%.*s)\n", cast(int) tlen, tbuf.ptr );
-        put( tbuf[0 .. tlen] );
+    }
+    else
+    {
+	    void parseReal()
+	    {
+	        debug(trace) printf( "parseReal+\n" );
+	        debug(trace) scope(success) printf( "parseReal-\n" );
+	
+	        char[64] tbuf = void;
+	        size_t   tlen = 0;
+	        real     val  = void;
+	
+	        if( 'I' == tok() )
+	        {
+	            match( "INF" );
+	            put( "real.infinity" );
+	            return;
+	        }
+	        if( 'N' == tok() )
+	        {
+	            next();
+	            if( 'I' == tok() )
+	            {
+	                match( "INF" );
+	                put( "-real.infinity" );
+	                return;
+	            }
+	            if( 'A' == tok() )
+	            {
+	                match( "AN" );
+	                put( "real.nan" );
+	                return;
+	            }
+	            tbuf[tlen++] = '-';
+	        }
+	
+	        tbuf[tlen++] = '0';
+	        tbuf[tlen++] = 'X';
+	        if( !isHexDigit( tok() ) )
+	            error( "Expected hex digit" );
+	        tbuf[tlen++] = tok();
+	        tbuf[tlen++] = '.';
+	        next();
+	
+	        while( isHexDigit( tok() ) )
+	        {
+	            tbuf[tlen++] = tok();
+	            next();
+	        }
+	        match( 'P' );
+	        tbuf[tlen++] = 'p';
+	        if( 'N' == tok() )
+	        {
+	            tbuf[tlen++] = '-';
+	            next();
+	        }
+	        else
+	        {
+	            tbuf[tlen++] = '+';
+	        }
+	        while( isDigit( tok() ) )
+	        {
+	            tbuf[tlen++] = tok();
+	            next();
+	        }
+	
+	        tbuf[tlen] = 0;
+	        debug(info) printf( "got (%s)\n", tbuf.ptr );
+	        val = strtold( tbuf.ptr, null );
+	        tlen = snprintf( tbuf.ptr, tbuf.length, "%#Lg", val );
+	        debug(info) printf( "converted (%.*s)\n", cast(int) tlen, tbuf.ptr );
+	        put( tbuf[0 .. tlen] );
+	    }
     }
 
 
@@ -1097,15 +1107,21 @@ private struct Demangle
             return;
         case 'e':
             next();
-            parseReal();
+
+            version(BareMetal) {}
+			else parseReal();
             return;
         case 'c':
             next();
-            parseReal();
-            put( "+" );
-            match( 'c' );
-            parseReal();
-            put( "i" );
+            version(BareMetal) {}
+			else
+			{
+	            parseReal();
+	            put( "+" );
+	            match( 'c' );
+	            parseReal();
+	            put( "i" );
+	        }
             return;
         case 'a': case 'w': case 'd':
             char t = tok();

--- a/libphobos/libdruntime/core/stdc/errno.d
+++ b/libphobos/libdruntime/core/stdc/errno.d
@@ -14,6 +14,10 @@
  */
 module core.stdc.errno;
 
+version(BareMetal) {}
+else:
+
+
 @trusted: // Only manipulates errno.
 nothrow:
 

--- a/libphobos/libdruntime/core/stdc/fenv.d
+++ b/libphobos/libdruntime/core/stdc/fenv.d
@@ -14,6 +14,9 @@
  */
 module core.stdc.fenv;
 
+version(BareMetal) {}
+else:
+
 extern (C):
 @system:
 nothrow:

--- a/libphobos/libdruntime/core/stdc/stdio.d
+++ b/libphobos/libdruntime/core/stdc/stdio.d
@@ -15,6 +15,10 @@
  */
 module core.stdc.stdio;
 
+version(BareMetal) {}
+
+else:
+
 private
 {
     import core.stdc.config;

--- a/libphobos/libdruntime/core/stdc/stdlib.d
+++ b/libphobos/libdruntime/core/stdc/stdlib.d
@@ -46,6 +46,7 @@ else version(linux)   enum RAND_MAX = 0x7fffffff;
 else version(OSX)     enum RAND_MAX = 0x7fffffff;
 else version(FreeBSD) enum RAND_MAX = 0x7fffffff;
 else version(Solaris) enum RAND_MAX = 0x7fff;
+else version(BareMetal) enum RAND_MAX = 0x7fff;
 else static assert( false, "Unsupported platform" );
 
 double  atof(in char* nptr);

--- a/libphobos/libdruntime/core/stdc/time.d
+++ b/libphobos/libdruntime/core/stdc/time.d
@@ -15,6 +15,10 @@
  */
 module core.stdc.time;
 
+version(BareMetal) {}
+else:
+
+
 private import core.stdc.config;
 private import core.stdc.stddef; // for size_t
 

--- a/libphobos/libdruntime/core/stdc/wchar_.d
+++ b/libphobos/libdruntime/core/stdc/wchar_.d
@@ -30,6 +30,9 @@ alias wchar_t wint_t;
 
 enum wchar_t WEOF = 0xFFFF;
 
+version(BareMetal) {}
+else:
+
 int fwprintf(FILE* stream, in wchar_t* format, ...);
 int fwscanf(FILE* stream, in wchar_t* format, ...);
 int swscanf(in wchar_t* s, in wchar_t* format, ...);

--- a/libphobos/libdruntime/core/sync/barrier.d
+++ b/libphobos/libdruntime/core/sync/barrier.d
@@ -15,6 +15,8 @@
  */
 module core.sync.barrier;
 
+version(BareMetal) {}
+else:
 
 public import core.sync.exception;
 private import core.sync.condition;

--- a/libphobos/libdruntime/core/sync/condition.d
+++ b/libphobos/libdruntime/core/sync/condition.d
@@ -15,6 +15,8 @@
  */
 module core.sync.condition;
 
+version(BareMetal) {}
+else:
 
 public import core.sync.exception;
 public import core.sync.mutex;

--- a/libphobos/libdruntime/core/sync/mutex.d
+++ b/libphobos/libdruntime/core/sync/mutex.d
@@ -15,6 +15,9 @@
  */
 module core.sync.mutex;
 
+version(BareMetal) {}
+else:
+
 
 public import core.sync.exception;
 

--- a/libphobos/libdruntime/core/sync/rwmutex.d
+++ b/libphobos/libdruntime/core/sync/rwmutex.d
@@ -15,6 +15,8 @@
  */
 module core.sync.rwmutex;
 
+version(BareMetal) {}
+else:
 
 public import core.sync.exception;
 private import core.sync.condition;

--- a/libphobos/libdruntime/core/sync/semaphore.d
+++ b/libphobos/libdruntime/core/sync/semaphore.d
@@ -14,6 +14,8 @@
  */
 module core.sync.semaphore;
 
+version(BareMetal) {}
+else:
 
 public import core.sync.exception;
 public import core.time;

--- a/libphobos/libdruntime/core/thread.d
+++ b/libphobos/libdruntime/core/thread.d
@@ -11,6 +11,8 @@
 
 module core.thread;
 
+version(BareMetal) {}
+else:
 
 public import core.time; // for Duration
 import core.exception : onOutOfMemoryError;

--- a/libphobos/libdruntime/core/thread.di
+++ b/libphobos/libdruntime/core/thread.di
@@ -15,6 +15,8 @@
  */
 module core.thread;
 
+version(BareMetal) {}
+else:
 
 public import core.time; // for Duration
 

--- a/libphobos/libdruntime/core/time.d
+++ b/libphobos/libdruntime/core/time.d
@@ -19,6 +19,9 @@
  +/
 module core.time;
 
+version(BareMetal) {}
+else:
+
 import core.exception;
 import core.stdc.time;
 import core.stdc.stdio;

--- a/libphobos/libdruntime/gc/bits.d
+++ b/libphobos/libdruntime/gc/bits.d
@@ -13,6 +13,9 @@
  */
 module gc.bits;
 
+version(BareMetal) {}
+else:
+
 
 import core.bitop;
 import core.stdc.string;

--- a/libphobos/libdruntime/gc/gc.d
+++ b/libphobos/libdruntime/gc/gc.d
@@ -13,6 +13,9 @@
  */
 module gc.gc;
 
+version(BareMetal) {}
+else:
+
 // D Programming Language Garbage Collector implementation
 
 /************** Debugging ***************************/

--- a/libphobos/libdruntime/gc/os.d
+++ b/libphobos/libdruntime/gc/os.d
@@ -13,6 +13,9 @@
  */
 module gc.os;
 
+version(BareMetal) {}
+else:
+
 
 version (Windows)
 {

--- a/libphobos/libdruntime/gc/proxy.d
+++ b/libphobos/libdruntime/gc/proxy.d
@@ -13,6 +13,9 @@
  */
 module gc.proxy;
 
+version(BareMetal) {}
+else:
+
 import gc.gc;
 import gc.stats;
 import core.stdc.stdlib;

--- a/libphobos/libdruntime/gc/stats.d
+++ b/libphobos/libdruntime/gc/stats.d
@@ -13,6 +13,9 @@
  */
 module gc.stats;
 
+version(BareMetal) {}
+else:
+
 
 /**
  *

--- a/libphobos/libdruntime/gcc/backtrace.d
+++ b/libphobos/libdruntime/gcc/backtrace.d
@@ -19,6 +19,9 @@
 /* This module provides a backtrace implementation for gdc */
 module gcc.backtrace;
 
+version(BareMetal) {}
+else:
+
 import gcc.libbacktrace;
 
 

--- a/libphobos/libdruntime/gcc/deh.d
+++ b/libphobos/libdruntime/gcc/deh.d
@@ -20,6 +20,14 @@
 
 module gcc.deh;
 
+//Stub, called alot :/
+version(BareMetal)
+{
+	extern (C) void _d_throw(Object obj) { }
+	extern (C) int __gdc_personality_v0(int iversion, int actions, int exception_class, void *ue_header, void *context) { return 0; }
+}
+else:
+
 import gcc.unwind;
 import gcc.unwind_pe;
 import gcc.builtins;

--- a/libphobos/libdruntime/gcc/unwind_arm.d
+++ b/libphobos/libdruntime/gcc/unwind_arm.d
@@ -20,6 +20,9 @@
 
 module gcc.unwind_arm;
 
+version(BareMetal) {}
+else:
+
 import gcc.builtins;
 import gcc.unwind_pe;
 

--- a/libphobos/libdruntime/gcc/unwind_generic.d
+++ b/libphobos/libdruntime/gcc/unwind_generic.d
@@ -21,6 +21,13 @@
 
 module gcc.unwind_generic;
 
+version(BareMetal)
+{
+	//Stub; mark functions @nothrow would be cleaner
+	extern(C) void _Unwind_Resume (void *) { }
+}
+else:
+
 private import gcc.builtins;
 private import core.stdc.stdlib; // for abort
 

--- a/libphobos/libdruntime/gcc/unwind_pe.d
+++ b/libphobos/libdruntime/gcc/unwind_pe.d
@@ -20,6 +20,9 @@
 
 module gcc.unwind_pe;
 
+version(BareMetal) {}
+else:
+
 import gcc.unwind;
 private import core.stdc.stdlib : abort;
 

--- a/libphobos/libdruntime/gcstub/gc.d
+++ b/libphobos/libdruntime/gcstub/gc.d
@@ -131,7 +131,9 @@ extern (C) void gc_init()
 {
     // NOTE: The GC must initialize the thread library before its first
     //       collection, and always before returning from gc_init().
-    thread_init();
+    
+    version(BareMetal) {}
+    else thread_init();
     initProxy();
 }
 

--- a/libphobos/libdruntime/object_.d
+++ b/libphobos/libdruntime/object_.d
@@ -1747,6 +1747,10 @@ void setMonitor(Object h, Monitor* m)
     h.__monitor = m;
 }
 
+version(BareMetal) {}
+else
+{
+
 void setSameMutex(shared Object ownee, shared Object owner)
 in
 {
@@ -1772,6 +1776,7 @@ body
     // If m.impl is set (ie. if this is a user-created monitor), assume
     // the monitor is garbage collected and simply copy the reference.
     ownee.__monitor = owner.__monitor;
+}
 }
 
 extern (C) void _d_monitor_create(Object);
@@ -1866,6 +1871,9 @@ extern (C) void _d_monitor_devt(Monitor* m, Object h)
     }
 }
 
+version(BareMetal) {}
+else
+{
 extern (C) void rt_attachDisposeEvent(Object h, DEvent e)
 {
     synchronized (h)
@@ -1912,6 +1920,7 @@ extern (C) void rt_detachDisposeEvent(Object h, DEvent e)
             }
         }
     }
+}
 }
 
 extern (C)

--- a/libphobos/libdruntime/rt/critical_.d
+++ b/libphobos/libdruntime/rt/critical_.d
@@ -13,6 +13,9 @@
  */
 module rt.critical_;
 
+version(BareMetal) {}
+else:
+
 private
 {
     debug(PRINTF) import core.stdc.stdio;

--- a/libphobos/libdruntime/rt/memory.d
+++ b/libphobos/libdruntime/rt/memory.d
@@ -12,6 +12,8 @@
 
 module rt.memory;
 
+version(BareMetal) {}
+else:
 
 import core.memory;
 private

--- a/libphobos/libdruntime/rt/monitor_.d
+++ b/libphobos/libdruntime/rt/monitor_.d
@@ -65,6 +65,15 @@ private
             pthread_mutex_t mon;
         }
     }
+    else version( BareMetal )
+    {
+        struct Monitor
+        {
+            IMonitor impl; // for user-level monitors
+            DEvent[] devt; // for internal monitors
+            size_t   refs; // reference count
+        }
+    }
     else
     {
         static assert(0, "Unsupported platform");
@@ -251,3 +260,30 @@ version( USE_PTHREADS )
     }
 }
 
+//Stubs
+version( BareMetal )
+{ 
+    extern (C) void _STI_monitor_staticctor()
+    {
+    }
+
+    extern (C) void _STD_monitor_staticdtor()
+    {
+    }
+
+    extern (C) void _d_monitor_create(Object h)
+    {
+    }
+
+    extern (C) void _d_monitor_destroy(Object h)
+    {
+    }
+
+    extern (C) void _d_monitor_lock(Object h)
+    {
+    }
+
+    extern (C) void _d_monitor_unlock(Object h)
+    {
+    }
+}

--- a/libphobos/libdruntime/rt/qsort.d
+++ b/libphobos/libdruntime/rt/qsort.d
@@ -63,6 +63,14 @@ else version (OSX)
         return a;
     }
 }
+else version (BareMetal)
+{
+	//Stub, should really implement generic
+    extern (C) void[] _adSort(void[] a, TypeInfo ti)
+    {
+    	return a;
+    }
+}
 else
 {
     private TypeInfo tiglobal;

--- a/libphobos/libdruntime/unittest.d
+++ b/libphobos/libdruntime/unittest.d
@@ -11,6 +11,9 @@
  *    (See accompanying file LICENSE or copy at
  *          http://www.boost.org/LICENSE_1_0.txt)
  */
+version(BareMetal) {}
+else:
+ 
 public import core.atomic;
 public import core.bitop;
 public import core.cpuid;


### PR DESCRIPTION
reduced dependency on posix calls if using -fversion=BareMetal
if working with objects will need implementation or stubs of malloc, calloc,
realloc and free.
a few string functions are too required ( memcpy, memmove, memcmp,
memset, memchr and strlen ).
i was too lazy to provide proper generics.
