### PR TITLE
Update for gdc-4.8

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,8 @@
 2014-01-05  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-ctype.cc(TypeEnum::toCtype): Don't push CONST_DECLs into current
+	function.
+
 	* config-lang.in: Add d-lang.cc to gtfiles.
 	* d-irstate.h(IRState::varsInScope): Change from Array to vec<> type.
 	(IRState::statementList_): Likewise.

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,11 @@
+2014-01-06  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-builtins.c(d_gcc_magic_module): Remove tdata.
+	* d-codegen.cc(build_interface_binfo): Likewise.
+	* d-ctype.cc(TypeEnum::toCtype): Likewise.
+	(TypeClass::toCtype): Likewise.
+	* d-lang.cc(deps_write): Likewise.
+
 2014-01-05  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-ctype.cc(TypeEnum::toCtype): Don't push CONST_DECLs into current

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -2,6 +2,13 @@
 
 	* d-ctype.cc(TypeEnum::toCtype): Don't push CONST_DECLs into current
 	function.
+	* d-decls.cc(FuncDeclaration::toThunkSymbol): Don't mark symbol as
+	TREE_PRIVATE, just TREE_PUBLIC as false.
+	(StructLiteralExp::toSymbol): Likewise.
+	(ClassReferenceExp::toSymbol): Likewise.
+	* d-objfile.cc(d_comdat_linkage): Likewise.
+	(d_finish_symbol): Likewise.
+	(build_moduleinfo): Likewise.
 
 	* config-lang.in: Add d-lang.cc to gtfiles.
 	* d-irstate.h(IRState::varsInScope): Change from Array to vec<> type.

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,8 @@
 2014-01-06  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-ctype.cc(TypeClass::toCtype): Don't add __monitor field for
+	extern(C++) classes.
+
 	* d-builtins.c(d_gcc_magic_module): Remove tdata.
 	* d-codegen.cc(build_interface_binfo): Likewise.
 	* d-ctype.cc(TypeEnum::toCtype): Likewise.

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2014-01-12  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-decls.cc(EnumDeclaration::toDebug): Build TYPE_DECL only for
+	enumeral types.
+
 2014-01-06  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-ctype.cc(TypeClass::toCtype): Don't add __monitor field for

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,73 @@
+2014-01-05  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* config-lang.in: Add d-lang.cc to gtfiles.
+	* d-irstate.h(IRState::varsInScope): Change from Array to vec<> type.
+	(IRState::statementList_): Likewise.
+	(IRState::scopes_): Likewise.
+	(IRState::loops_): Likewise.
+	(IRState::labels_): Likewise.
+	* d-lang.h(d_bi_builtin_func): Remove declaration.
+	(d_bi_builtin_type): Likewise.
+	(d_keep_list): Likewise.
+	* d-objfile.h(Symbol::thunks): Change from Array to vec<> type.
+	(ModuleInfo::classes): Likewise.
+	(ModuleInfo::ctors): Likewise.
+	(ModuleInfo::dtors): Likewise.
+	(ModuleInfo::ctorgates): Likewise.
+	(ModuleInfo::sharedctors): Likewise.
+	(ModuleInfo::shareddtors): Likewise.
+	(ModuleInfo::sharedctorgates): Likewise.
+	(ModuleInfo::unitTests): Likewise.
+	(build_simple_function): Remove declaration.
+	(build_call_function): Likewise.
+	(build_ctor_function): Likewise.
+	(build_dtor_function): Likewise.
+	(build_unittest_function): Likewise.
+	* d-builtins.c(bi_fn_list): Rename to gcc_builtins_functions.
+	(bi_lib_list): Rename to gcc_builtins_libfuncs.
+	(bi_type_list): Rename to gcc_builtins_types.
+	(builtin_converted_types): Remove.
+	(builtin_converted_decls): Change from Array to vec<> type.
+	(gcc_type_to_d_type): Update.
+	(d_bi_builtin_func): Remove and move to d_builtin_function.
+	(d_bi_builtin_type): Remove and move to d_register_builtin_type.
+	(d_gcc_magic_builtins_module): Update.
+	* d-ctype.cc(TypeClass::toCtype): Remove unused var.
+	* d-decls.cc(FuncDeclaration::toThunkSymbol): Update for change to
+	vec<> type.
+	* d-elem.cc(CatExp::toElem): Change stashed vars from Array to vec<>.
+	(Expression::toElemDtor): Update for change to vec<> type.
+	* d-irstate.cc(IRState::startFunction): Likewise.
+	(IRState::endFunction): Likewise.
+	(IRState::addExp): Likewise.
+	(IRState::pushStatementList): Likewise.
+	(IRState::popStatementList): Likewise.
+	(IRState::getLabelBlock): Likewise.
+	(IRState::getLoopForLabel): Likewise.
+	(IRState::beginFlow): Likewise.
+	(IRState::endFlow): Likewise.
+	(IRState::startScope): Likewise.
+	(IRState::pushLabel): Likewise.
+	(IRState::checkGoto): Likewise.
+	(IRState::checkPreviousGoto): Change from Array to Blocks type.
+	* d-lang.cc(global_declarations): Change from Array to vec<> type.
+	(d_add_global_declaration): Update for change to vec<> type.
+	(d_write_global_declarations): Likewise.
+	(d_keep_list): Make static to source file.
+	* d-objfile.cc(static_ctor_list): Change from Array to vec<> type.
+	(static_dtor_list): Likewise.
+	(Module::genobjfile): Update for change to vec<> type.
+	(d_finish_module): Likewise.
+	(d_finish_function): Likewise.
+	(deferred_thunks): Change from ArrayBase<> to vec<> type.
+	(write_deferred_thunks): Update for change to vec<> type.
+	(use_thunk): Likewise.
+	(build_simple_function): Make static to source file.
+	(build_call_function): Likewise.
+	(build_ctor_function): Likewise.
+	(build_dtor_function): Likewise.
+	(build_unittest_function): Likewise.
+
 2014-01-02  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-objfile.cc(setup_symbol_storage): Use output_module_p on template

--- a/gcc/d/config-lang.in
+++ b/gcc/d/config-lang.in
@@ -32,7 +32,7 @@ target_libs="target-libphobos target-zlib target-libbacktrace"
 # compiler during stage 1.
 lang_requires_boot_languages=c++
 
-gtfiles="\$(srcdir)/d/d-lang.h \$(srcdir)/d/d-builtins.c"
+gtfiles="\$(srcdir)/d/d-builtins.c \$(srcdir)/d/d-lang.cc \$(srcdir)/d/d-lang.h"
 
 # Do not build by default.
 build_by_default="no"

--- a/gcc/d/config-lang.in
+++ b/gcc/d/config-lang.in
@@ -32,7 +32,7 @@ target_libs="target-libphobos target-zlib target-libbacktrace"
 # compiler during stage 1.
 lang_requires_boot_languages=c++
 
-gtfiles="\$(srcdir)/d/d-builtins.c \$(srcdir)/d/d-lang.cc \$(srcdir)/d/d-lang.h"
+gtfiles="\$(srcdir)/d/d-builtins.c \$(srcdir)/d/d-lang.h"
 
 # Do not build by default.
 build_by_default="no"

--- a/gcc/d/d-builtins.c
+++ b/gcc/d/d-builtins.c
@@ -626,19 +626,19 @@ d_gcc_magic_module (Module *m)
 
   if (md->packages->dim == 1)
     {
-      if (!strcmp ((md->packages->tdata()[0])->string, "gcc"))
+      if (!strcmp ((*md->packages)[0]->string, "gcc"))
 	{
 	  if (!strcmp (md->id->string, "builtins"))
 	    d_gcc_magic_builtins_module (m);
 	}
-      else if (!strcmp ((md->packages->tdata()[0])->string, "core"))
+      else if (!strcmp ((*md->packages)[0]->string, "core"))
 	{
 	  if (!strcmp (md->id->string, "bitop"))
 	    std_intrinsic_module = m;
 	  else if (!strcmp (md->id->string, "math"))
 	    core_math_module = m;
 	}
-      else if (!strcmp ((md->packages->tdata()[0])->string, "std"))
+      else if (!strcmp ((*md->packages)[0]->string, "std"))
 	{
 	  if (!strcmp (md->id->string, "math"))
 	    std_math_module = m;
@@ -646,8 +646,8 @@ d_gcc_magic_module (Module *m)
     }
   else if (md->packages->dim == 2)
     {
-      if (!strcmp ((md->packages->tdata()[0])->string, "core")
-	  && !strcmp ((md->packages->tdata()[1])->string, "stdc"))
+      if (!strcmp ((*md->packages)[0]->string, "core")
+	  && !strcmp ((*md->packages)[1]->string, "stdc"))
 	{
 	  if (!strcmp (md->id->string, "stdarg"))
 	    d_gcc_magic_stdarg_module (m);

--- a/gcc/d/d-ctype.cc
+++ b/gcc/d/d-ctype.cc
@@ -251,7 +251,7 @@ TypeEnum::toCtype (void)
 	    {
 	      for (size_t i = 0; i < sym->members->dim; i++)
 		{
-		  EnumMember *member = (sym->members->tdata()[i])->isEnumMember();
+		  EnumMember *member = (*sym->members)[i]->isEnumMember();
 		  // Templated functions can seep through to the backend - just ignore for now.
 		  if (member == NULL)
 		    continue;
@@ -655,8 +655,9 @@ TypeClass::toCtype (void)
 	  else
 	    {
 	      ClassDeclaration *p = sym;
+
 	      while (p->baseclasses->dim)
-	        p = (p->baseclasses->tdata()[0])->base;
+	        p = (*p->baseclasses)[0]->base;
 
 	      DECL_FCONTEXT (vfield) = TREE_TYPE (p->type->toCtype());
 	    }

--- a/gcc/d/d-ctype.cc
+++ b/gcc/d/d-ctype.cc
@@ -267,8 +267,6 @@ TypeEnum::toCtype (void)
 		  TREE_READONLY (decl) = 1;
 		  DECL_INITIAL (decl) = value;
 
-		  d_pushdecl (decl);
-
 		  // Add this enumeration constant to the list for this type.
 		  enum_values = chainon (enum_values, build_tree_list (ident, decl));
 		}

--- a/gcc/d/d-ctype.cc
+++ b/gcc/d/d-ctype.cc
@@ -605,7 +605,6 @@ TypeClass::toCtype (void)
       else 
 	{
 	  tree rec_type;
-	  Array base_class_decls;
 	  bool inherited = sym->baseClass != 0;
 	  tree vfield;
 

--- a/gcc/d/d-decls.cc
+++ b/gcc/d/d-decls.cc
@@ -466,14 +466,14 @@ FuncDeclaration::toThunkSymbol (int offset)
       tree thunk_decl = build_decl (DECL_SOURCE_LOCATION (target_func_decl),
 				    FUNCTION_DECL, NULL_TREE, TREE_TYPE (target_func_decl));
       DECL_LANG_SPECIFIC (thunk_decl) = DECL_LANG_SPECIFIC (target_func_decl);
-      DECL_CONTEXT (thunk_decl) = d_decl_context (this); // from c++...
       TREE_READONLY (thunk_decl) = TREE_READONLY (target_func_decl);
       TREE_THIS_VOLATILE (thunk_decl) = TREE_THIS_VOLATILE (target_func_decl);
       TREE_NOTHROW (thunk_decl) = TREE_NOTHROW (target_func_decl);
 
-      /* Thunks inherit the public/private access of the function they are targetting.  */
+      DECL_CONTEXT (thunk_decl) = d_decl_context (this);
+
+      /* Thunks inherit the public access of the function they are targetting.  */
       TREE_PUBLIC (thunk_decl) = TREE_PUBLIC (target_func_decl);
-      TREE_PRIVATE (thunk_decl) = TREE_PRIVATE (target_func_decl);
       DECL_EXTERNAL (thunk_decl) = 0;
 
       /* Thunks are always addressable.  */
@@ -589,10 +589,10 @@ StructLiteralExp::toSymbol (void)
       get_unique_name (decl, "*");
       set_decl_location (decl, loc);
 
+      TREE_PUBLIC (decl) = 0;
       TREE_STATIC (decl) = 1;
       TREE_READONLY (decl) = 1;
       TREE_USED (decl) = 1;
-      TREE_PRIVATE (decl) = 1;
       DECL_ARTIFICIAL (decl) = 1;
 
       sym->Stree = decl;
@@ -620,10 +620,10 @@ ClassReferenceExp::toSymbol (void)
       DECL_NAME (decl) = get_identifier (ident);
       set_decl_location (decl, loc);
 
+      TREE_PUBLIC (decl) = 0;
       TREE_STATIC (decl) = 1;
       TREE_READONLY (decl) = 1;
       TREE_USED (decl) = 1;
-      TREE_PRIVATE (decl) = 1;
       DECL_ARTIFICIAL (decl) = 1;
 
       value->sym->Stree = decl;

--- a/gcc/d/d-decls.cc
+++ b/gcc/d/d-decls.cc
@@ -437,7 +437,7 @@ FuncDeclaration::toThunkSymbol (int offset)
      is a list of all thunks for a given function. */
   bool found = false;
 
-  for (size_t i = 0; i < csym->thunks.dim; i++)
+  for (size_t i = 0; i < csym->thunks.length(); i++)
     {
       thunk = csym->thunks[i];
       if (thunk->offset == offset)
@@ -451,7 +451,7 @@ FuncDeclaration::toThunkSymbol (int offset)
     {
       thunk = new Thunk();
       thunk->offset = offset;
-      csym->thunks.push (thunk);
+      csym->thunks.safe_push (thunk);
     }
 
   if (!thunk->symbol)

--- a/gcc/d/d-decls.cc
+++ b/gcc/d/d-decls.cc
@@ -795,7 +795,9 @@ EnumDeclaration::toDebug (void)
     return;
 
   tree ctype = type->toCtype();
-  build_type_decl (ctype, this);
+
+  if (TREE_CODE (ctype) == ENUMERAL_TYPE)
+    build_type_decl (ctype, this);
 
   // The ctype is not necessarily enum, which doesn't sit well with
   // rest_of_type_compilation.  Can call this on structs though.

--- a/gcc/d/d-irstate.cc
+++ b/gcc/d/d-irstate.cc
@@ -28,6 +28,20 @@ IRState::IRState (void)
   this->func = NULL;
   this->mod = NULL;
   this->sthis = NULL_TREE;
+  this->varsInScope = vNULL;
+  this->statementList_ = vNULL;
+  this->scopes_ = vNULL;
+  this->loops_ = vNULL;
+  this->labels_ = vNULL;
+}
+
+IRState::~IRState (void)
+{
+  this->varsInScope.release();
+  this->statementList_.release();
+  this->scopes_.release();
+  this->loops_.release();
+  this->labels_.release();
 }
 
 IRState *

--- a/gcc/d/d-irstate.h
+++ b/gcc/d/d-irstate.h
@@ -88,11 +88,6 @@ struct Flow
 };
 
 
-typedef ArrayBase<Label> Labels;
-typedef ArrayBase<Flow> Flows;
-
-
-
 // IRState contains the core functionality of code generation utilities.
 //
 // Currently, each function gets its own IRState when emitting code.  There is
@@ -123,7 +118,7 @@ struct IRState
   void endFunction (void);
 
   // Variables that are in scope that will need destruction later.
-  VarDeclarations *varsInScope;
+  auto_vec<VarDeclaration *> varsInScope;
 
   // ** Statement Lists
   void addExp (tree e);
@@ -133,7 +128,7 @@ struct IRState
   // ** Labels
   // It is only valid to call this while the function in which the label is defined
   // is being compiled.
-  tree    getLabelTree (LabelDsymbol *label);
+  tree getLabelTree (LabelDsymbol *label);
   Label *getLabelBlock (LabelDsymbol *label, Statement *from = NULL);
 
   bool isReturnLabel (Identifier *ident)
@@ -148,8 +143,8 @@ struct IRState
 
   Flow *currentFlow (void)
   {
-    gcc_assert (this->loops_.dim);
-    return (Flow *) this->loops_.tos();
+    gcc_assert (!this->loops_.is_empty());
+    return this->loops_.last();
   }
 
   void doLabel (tree t_label);
@@ -172,8 +167,8 @@ struct IRState
 
   unsigned *currentScope (void)
   {
-    gcc_assert (this->scopes_.dim);
-    return (unsigned *) this->scopes_.tos();
+    gcc_assert (!this->scopes_.is_empty());
+    return this->scopes_.last();
   }
 
   void startBindings (void);
@@ -206,7 +201,7 @@ struct IRState
   void doJump (Statement *stmt, tree t_label);
   void pushLabel (LabelDsymbol *l);
   void checkGoto (Statement *stmt, LabelDsymbol *label);
-  void checkPreviousGoto (Array *refs);
+  void checkPreviousGoto (Blocks *refs);
 
   // ** Switch statements.
   void startCase (Statement *stmt, tree t_cond, int has_vars = 0);
@@ -227,10 +222,10 @@ struct IRState
   void doReturn (tree t_value);
 
  protected:
-  Array statementList_;	// of tree
-  Array scopes_;	// of unsigned *
-  Flows loops_;
-  Labels labels_;
+  auto_vec<tree> statementList_;
+  auto_vec<unsigned *> scopes_;
+  auto_vec<Flow *> loops_;
+  auto_vec<Label *> labels_;
 };
 
 

--- a/gcc/d/d-irstate.h
+++ b/gcc/d/d-irstate.h
@@ -106,6 +106,7 @@ struct IRState
   IRState *parent;
 
   IRState (void);
+  ~IRState (void);
 
   // ** Functions
   FuncDeclaration *func;
@@ -118,7 +119,7 @@ struct IRState
   void endFunction (void);
 
   // Variables that are in scope that will need destruction later.
-  auto_vec<VarDeclaration *> varsInScope;
+  vec<VarDeclaration *> varsInScope;
 
   // ** Statement Lists
   void addExp (tree e);
@@ -222,10 +223,10 @@ struct IRState
   void doReturn (tree t_value);
 
  protected:
-  auto_vec<tree> statementList_;
-  auto_vec<unsigned *> scopes_;
-  auto_vec<Flow *> loops_;
-  auto_vec<Label *> labels_;
+  vec<tree> statementList_;
+  vec<unsigned *> scopes_;
+  vec<Flow *> loops_;
+  vec<Label *> labels_;
 };
 
 

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -776,11 +776,11 @@ deps_write (Module *m)
 
 	  if (md && md->packages)
 	    {
-	      if (strcmp ((md->packages->tdata()[0])->string, "core") == 0)
+	      if (strcmp ((*md->packages)[0]->string, "core") == 0)
 		continue;
-	      if (strcmp ((md->packages->tdata()[0])->string, "std") == 0)
+	      if (strcmp ((*md->packages)[0]->string, "std") == 0)
 		continue;
-	      if (strcmp ((md->packages->tdata()[0])->string, "gcc") == 0)
+	      if (strcmp ((*md->packages)[0]->string, "gcc") == 0)
 		continue;
 	    }
 	  else if (md && md->id && md->packages == NULL)

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -627,29 +627,27 @@ d_post_options (const char ** fn)
 }
 
 // Array of all global declarations to pass back to the middle-end.
-static Array globalDeclarations;
+static GTY(()) vec<tree, va_gc> *global_declarations;
 
 void
 d_add_global_declaration (tree decl)
 {
-  globalDeclarations.push (decl);
+  vec_safe_push (global_declarations, decl);
 }
 
 // Write out globals.
-
 static void
 d_write_global_declarations (void)
 {
-  tree *vec = (tree *) globalDeclarations.data;
-  int len = globalDeclarations.dim;
-
-  gcc_assert (len >= 0);
-
-  d_finish_compilation (vec, len);
+  if (vec_safe_length (global_declarations) != 0)
+    {
+      d_finish_compilation (global_declarations->address(),
+			    global_declarations->length());
+    }
 }
 
 
-/* Gimplification of expression trees.  */
+// Gimplification of D specific expression trees.
 int
 d_gimplify_expr (tree *expr_p, gimple_seq *pre_p ATTRIBUTE_UNUSED,
 		 gimple_seq *post_p ATTRIBUTE_UNUSED)
@@ -1638,8 +1636,8 @@ build_d_decl_lang_specific (Declaration *d)
 }
 
 
-// This preserves tree we create from the garbage collector.
-tree d_keep_list = NULL_TREE;
+// This preserves trees we create from the garbage collector.
+static GTY(()) tree d_keep_list = NULL_TREE;
 
 void
 d_keep (tree t)
@@ -1774,3 +1772,5 @@ d_handle_target_attribute (tree *node, tree name, tree args, int flags,
 }
 
 struct lang_hooks lang_hooks = LANG_HOOKS_INITIALIZER;
+
+#include "gt-d-d-lang.h"

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -627,7 +627,7 @@ d_post_options (const char ** fn)
 }
 
 // Array of all global declarations to pass back to the middle-end.
-static GTY(()) vec<tree, va_gc> *global_declarations;
+vec<tree, va_gc> *global_declarations;
 
 void
 d_add_global_declaration (tree decl)
@@ -1637,7 +1637,7 @@ build_d_decl_lang_specific (Declaration *d)
 
 
 // This preserves trees we create from the garbage collector.
-static GTY(()) tree d_keep_list = NULL_TREE;
+tree d_keep_list = NULL_TREE;
 
 void
 d_keep (tree t)
@@ -1772,5 +1772,3 @@ d_handle_target_attribute (tree *node, tree name, tree args, int flags,
 }
 
 struct lang_hooks lang_hooks = LANG_HOOKS_INITIALIZER;
-
-#include "gt-d-d-lang.h"

--- a/gcc/d/d-lang.h
+++ b/gcc/d/d-lang.h
@@ -210,18 +210,12 @@ void d_register_builtin_type (tree, const char *);
 void d_backend_init (void);
 void d_backend_term (void);
 
-void d_bi_builtin_func (tree);
-void d_bi_builtin_type (tree);
-
 bool is_intrinsic_module_p (Module *);
 bool is_math_module_p (Module *);
 
 class Dsymbol;
 bool is_builtin_va_arg_p (Dsymbol *, bool);
 bool is_builtin_va_start_p (Dsymbol *);
-
-/* protect from garbage collection */
-extern GTY(()) tree d_keep_list;
 
 #include "d-dmd-gcc.h"
 

--- a/gcc/d/d-lang.h
+++ b/gcc/d/d-lang.h
@@ -217,6 +217,12 @@ class Dsymbol;
 bool is_builtin_va_arg_p (Dsymbol *, bool);
 bool is_builtin_va_start_p (Dsymbol *);
 
+/* protect from garbage collection */
+extern GTY(()) tree d_keep_list;
+
+// Array of all global declarations to pass back to the middle-end.
+extern GTY(()) vec<tree, va_gc> *global_declarations;
+
 #include "d-dmd-gcc.h"
 
 #endif

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -1667,19 +1667,14 @@ d_comdat_linkage (tree decl)
     }
   else if (TREE_CODE (decl) == FUNCTION_DECL
 	   || (VAR_P (decl) && DECL_ARTIFICIAL (decl)))
-    {
-      // We can just emit function and compiler-generated variables
-      // statically; having multiple copies is (for the most part) only
-      // a waste of space.
-      TREE_PUBLIC (decl) = 0;
-      TREE_PRIVATE (decl) = 1;
-    }
+    // We can just emit function and compiler-generated variables
+    // statically; having multiple copies is (for the most part) only
+    // a waste of space.
+    TREE_PUBLIC (decl) = 0;
   else if (DECL_INITIAL (decl) == NULL_TREE
 	   || DECL_INITIAL (decl) == error_mark_node)
-    {
-      // Fallback, cannot have multiple copies.
-      DECL_COMMON (decl) = 1;
-    }
+    // Fallback, cannot have multiple copies.
+    DECL_COMMON (decl) = 1;
 
   DECL_COMDAT (decl) = 1;
 }
@@ -1794,8 +1789,8 @@ d_finish_symbol (Symbol *sym)
 
       DECL_INITIAL (var) = init;
       TREE_STATIC (var) = 1;
+      TREE_PUBLIC (var) = 0;
       TREE_USED (var) = 1;
-      TREE_PRIVATE (var) = 1;
       DECL_IGNORED_P (var) = 1;
       DECL_ARTIFICIAL (var) = 1;
 
@@ -2343,7 +2338,7 @@ build_moduleinfo (Symbol *sym)
 
   DECL_ARTIFICIAL (modref) = 1;
   DECL_IGNORED_P (modref) = 1;
-  TREE_PRIVATE (modref) = 1;
+  TREE_PUBLIC (modref) = 0;
   TREE_STATIC (modref) = 1;
 
   vec<constructor_elt, va_gc> *ce = NULL;

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -40,6 +40,30 @@ static Symbol *build_ctor_function (const char *, vec<FuncDeclaration *>, vec<Va
 static Symbol *build_dtor_function (const char *, vec<FuncDeclaration *>);
 static Symbol *build_unittest_function (const char *, vec<FuncDeclaration *>);
 
+ModuleInfo::ModuleInfo (void)
+{
+  this->classes = vNULL;
+  this->ctors = vNULL;
+  this->dtors = vNULL;
+  this->ctorgates = vNULL;
+  this->sharedctors = vNULL;
+  this->shareddtors = vNULL;
+  this->sharedctorgates = vNULL;
+  this->unitTests = vNULL;
+}
+
+ModuleInfo::~ModuleInfo (void)
+{
+  this->classes.release();
+  this->ctors.release();
+  this->dtors.release();
+  this->ctorgates.release();
+  this->sharedctors.release();
+  this->shareddtors.release();
+  this->sharedctorgates.release();
+  this->unitTests.release();
+}
+
 // Construct a new Symbol.
 
 Symbol::Symbol (void)
@@ -57,8 +81,13 @@ Symbol::Symbol (void)
   this->SnamedResult = NULL_TREE;
 
   this->frameInfo = NULL;
+  this->thunks = vNULL;
 }
 
+Symbol::~Symbol (void)
+{
+  this->thunks.release();
+}
 
 void
 Dsymbol::toObjFile (int)

--- a/gcc/d/d-objfile.h
+++ b/gcc/d/d-objfile.h
@@ -41,7 +41,7 @@ enum ModuleInfoFlags
 };
 
 struct FuncFrameInfo;
-typedef ArrayBase<struct Thunk> Thunks;
+struct Thunk;
 typedef tree_node dt_t;
 
 struct Symbol
@@ -68,7 +68,7 @@ struct Symbol
   tree SnamedResult;
 
   // For FuncDeclarations:
-  Thunks thunks;
+  auto_vec<Thunk *> thunks;
   FuncFrameInfo *frameInfo;
 };
 
@@ -93,16 +93,16 @@ extern void build_moduleinfo (Symbol *sym);
 
 struct ModuleInfo
 {
-  ClassDeclarations classes;
-  FuncDeclarations ctors;
-  FuncDeclarations dtors;
-  VarDeclarations ctorgates;
+  auto_vec<ClassDeclaration *> classes;
+  auto_vec<FuncDeclaration *> ctors;
+  auto_vec<FuncDeclaration *> dtors;
+  auto_vec<VarDeclaration *> ctorgates;
 
-  FuncDeclarations sharedctors;
-  FuncDeclarations shareddtors;
-  VarDeclarations sharedctorgates;
+  auto_vec<FuncDeclaration *> sharedctors;
+  auto_vec<FuncDeclaration *> shareddtors;
+  auto_vec<VarDeclaration *> sharedctorgates;
 
-  FuncDeclarations unitTests;
+  auto_vec<FuncDeclaration *> unitTests;
 };
 
 extern ModuleInfo *current_module_info;
@@ -139,12 +139,6 @@ extern bool output_module_p (Module *mod);
 extern void write_deferred_thunks (void);
 extern void use_thunk (tree thunk_decl, tree target_decl, int offset);
 extern void finish_thunk (tree thunk_decl, tree target_decl, int offset);
-
-extern FuncDeclaration *build_simple_function (const char *, tree, bool);
-extern FuncDeclaration *build_call_function (const char *, FuncDeclarations *, bool);
-extern Symbol *build_ctor_function (const char *, FuncDeclarations *, VarDeclarations *);
-extern Symbol *build_dtor_function (const char *, FuncDeclarations *);
-extern Symbol *build_unittest_function (const char *, FuncDeclarations *);
 
 #endif
 

--- a/gcc/d/d-objfile.h
+++ b/gcc/d/d-objfile.h
@@ -47,6 +47,7 @@ typedef tree_node dt_t;
 struct Symbol
 {
   Symbol (void);
+  ~Symbol (void);
 
   const char *Sident;
   const char *prettyIdent;
@@ -68,7 +69,7 @@ struct Symbol
   tree SnamedResult;
 
   // For FuncDeclarations:
-  auto_vec<Thunk *> thunks;
+  vec<Thunk *> thunks;
   FuncFrameInfo *frameInfo;
 };
 
@@ -93,16 +94,19 @@ extern void build_moduleinfo (Symbol *sym);
 
 struct ModuleInfo
 {
-  auto_vec<ClassDeclaration *> classes;
-  auto_vec<FuncDeclaration *> ctors;
-  auto_vec<FuncDeclaration *> dtors;
-  auto_vec<VarDeclaration *> ctorgates;
+  ModuleInfo (void);
+  ~ModuleInfo (void);
 
-  auto_vec<FuncDeclaration *> sharedctors;
-  auto_vec<FuncDeclaration *> shareddtors;
-  auto_vec<VarDeclaration *> sharedctorgates;
+  vec<ClassDeclaration *> classes;
+  vec<FuncDeclaration *> ctors;
+  vec<FuncDeclaration *> dtors;
+  vec<VarDeclaration *> ctorgates;
 
-  auto_vec<FuncDeclaration *> unitTests;
+  vec<FuncDeclaration *> sharedctors;
+  vec<FuncDeclaration *> shareddtors;
+  vec<VarDeclaration *> sharedctorgates;
+
+  vec<FuncDeclaration *> unitTests;
 };
 
 extern ModuleInfo *current_module_info;


### PR DESCRIPTION
This could use a quick review as I had to revert some of the `ArrayBase` -> `vec<>` changes.
- `auto_vec` is not available in gcc-4.8
- `dlang.cc` can't be added to gtfiles, `.cc` files are not accepted in gcc-4.8
