### PR TITLE
Sync thread.d / thread.di for fibers

### DIFF
--- a/libphobos/libdruntime/core/thread.d
+++ b/libphobos/libdruntime/core/thread.d
@@ -4248,7 +4248,44 @@ private:
 }
 
 // These must be kept in sync with core/thread.di
-version (GNU) {} else
+version (GNU)
+{
+    version (D_LP64)
+    {
+        version (Windows)
+            static assert(__traits(classInstanceSize, Fiber) == 88);
+        else version (OSX)
+            static assert(__traits(classInstanceSize, Fiber) == 88);
+        else version (Posix)
+        {
+            version(X86_64)
+                static assert(__traits(classInstanceSize, Fiber) == 1032);
+            else
+                static assert(__traits(classInstanceSize, Fiber) == 88);
+        }
+        else
+            static assert(0, "Platform not supported.");
+    }
+    else
+    {
+        static assert((void*).sizeof == 4); // 32-bit
+    
+        version (Windows)
+            static assert(__traits(classInstanceSize, Fiber) == 44);
+        else version (OSX)
+            static assert(__traits(classInstanceSize, Fiber) == 44);
+        else version (Posix)
+        {
+            version(X86)
+                static assert(__traits(classInstanceSize, Fiber) == 396);
+            else
+                static assert(__traits(classInstanceSize, Fiber) == 44);
+        }
+        else
+            static assert(0, "Platform not supported.");
+    }
+}
+else
 version (D_LP64)
 {
     version (Windows)

--- a/libphobos/libdruntime/core/thread.di
+++ b/libphobos/libdruntime/core/thread.di
@@ -1077,7 +1077,38 @@ class Fiber
 
 private:
     // These must be kept in sync with core/thread.d
-    version (D_LP64)
+    version (GNU)
+    {
+        version (D_LP64)
+        {
+            version (Windows)      enum FiberSize = 88;
+            else version (OSX)     enum FiberSize = 88;
+            else version (Posix)
+            {
+                version(X86_64) 
+                    enum FiberSize = 1032;
+                else
+                    enum FiberSize = 88;
+            }
+            else static assert(0, "Platform not supported.");
+        }
+        else
+        {
+            static assert((void*).sizeof == 4); // 32-bit
+    
+            version (Windows)      enum FiberSize = 44;
+            else version (OSX)     enum FiberSize = 44;
+            else version (Posix)
+            {
+                version(X86)
+                    enum FiberSize = 396;
+                else
+                    enum FiberSize = 44;
+            }
+            else static assert(0, "Platform not supported.");
+        }
+    }
+    else version (D_LP64)
     {
         version (Windows)      enum FiberSize = 88;
         else version (OSX)     enum FiberSize = 88;


### PR DESCRIPTION
I think we should probably include these tests as well.

@Iain can you check if this works for X32?
