### PR TITLE
Initial MinGW support

### DIFF
--- a/README-MINGW.md
+++ b/README-MINGW.md
@@ -1,0 +1,19 @@
+GDC should build for MINGW and MINGW64 targets, however not much
+testing has been done.
+
+## Building ##
+
+The following patches are required for binutils / gcc to fix TLS support:
+ * https://github.com/venix1/MinGW-GDC/blob/master/patches/mingw-tls-binutils-2.23.1.patch
+ * https://github.com/venix1/MinGW-GDC/blob/master/patches/mingw-tls-gcc-4.8.patch
+
+This patch is required to fix a bug in GCC buildscripts:
+ * https://github.com/venix1/MinGW-GDC/blob/master/patches/gcc/0001-Remove-fPIC-for-MinGW.patch
+
+## SEH ##
+GCC supports SEH for Windows 64 bit targets, but GDC has not been tested with SEH
+enabled. It also does not compile right now because no SEH personality routine has
+been written yet (__gdc_personality_seh0).
+
+Configure gcc with --enable-sjlj-exceptions to use SJLJ execptions for win64 targets.
+DWARF exceptions are untested.

--- a/gcc/d/dfrontend/mtype.c
+++ b/gcc/d/dfrontend/mtype.c
@@ -2305,8 +2305,10 @@ Identifier *Type::getTypeInfoIdent(int internal)
     assert(strlen(name) < namelen);     // don't overflow the buffer
 
     size_t off = 0;
+#ifndef IN_GCC
     if (global.params.isOSX || global.params.isWindows && !global.params.is64bit)
         ++off;                 // C mangling will add '_' back in
+#endif
     Identifier *id = Lexer::idPool(name + off);
 
     if (name != namebuf)

--- a/gcc/d/target-ver-syms.sh
+++ b/gcc/d/target-ver-syms.sh
@@ -52,5 +52,6 @@ mingw32*)
   echo "#define TARGET_WINDOS    1"
   echo "#define THREAD_LIBRARY   \"\""
   echo "#define TIME_LIBRARY     \"\""
+  echo "#define MATH_LIBRARY     \"\""
   ;;
 esac

--- a/libphobos/libdruntime/core/sys/posix/sys/wait.d
+++ b/libphobos/libdruntime/core/sys/posix/sys/wait.d
@@ -14,12 +14,12 @@
  */
 module core.sys.posix.sys.wait;
 
+version (Posix):
 private import core.sys.posix.config;
 public import core.sys.posix.sys.types; // for id_t, pid_t
 public import core.sys.posix.signal;    // for siginfo_t (XSI)
 //public import core.sys.posix.resource; // for rusage (XSI)
 
-version (Posix):
 extern (C):
 
 //

--- a/libphobos/libdruntime/core/sys/windows/threadaux.d
+++ b/libphobos/libdruntime/core/sys/windows/threadaux.d
@@ -166,21 +166,39 @@ private:
         {
             version(Win32)
             {
-                asm
+                version(GNU_InlineAsm)
                 {
-                    naked;
-                    mov EAX,FS:[0x18];
-                    ret;
+                    void** teb;
+                    asm { "movl %%fs:0x18, %0;" : "=r" teb; }
+                    return teb;
+                }
+                else
+                {
+                    asm
+                    {
+                        naked;
+                        mov EAX,FS:[0x18];
+                        ret;
+                    }
                 }
             }
             else version(Win64)
             {
-                asm
+                version(GNU_InlineAsm)
                 {
-                    naked;
-                    mov RAX,0x30;
-                    mov RAX,GS:[RAX]; // immediate value causes fixup
-                    ret;
+                    void** teb;
+                    asm { "movq %%gs:0x30, %0;" : "=r" teb; }
+                    return teb;
+                }
+                else
+                {
+                    asm
+                    {
+                        naked;
+                        mov RAX,0x30;
+                        mov RAX,GS:[RAX]; // immediate value causes fixup
+                        ret;
+                    }
                 }
             }
             else

--- a/libphobos/libdruntime/core/sys/windows/windows.d
+++ b/libphobos/libdruntime/core/sys/windows/windows.d
@@ -1579,20 +1579,42 @@ export BOOL SwitchToThread();
 
 // Synchronization
 
-export
+version (MinGW)
 {
-LONG InterlockedIncrement(LPLONG lpAddend);
-LONG InterlockedDecrement(LPLONG lpAddend);
-LONG InterlockedExchange(LPLONG Target, LONG Value);
-LONG InterlockedExchangeAdd(LPLONG Addend, LONG Value);
-LONG InterlockedCompareExchange(LONG *Destination, LONG Exchange, LONG Comperand);
+    version (X86_64)
+        version = MinGW64RT;
+}
 
-void InitializeCriticalSection(CRITICAL_SECTION * lpCriticalSection);
-void EnterCriticalSection(CRITICAL_SECTION * lpCriticalSection);
-BOOL TryEnterCriticalSection(CRITICAL_SECTION * lpCriticalSection);
-void LeaveCriticalSection(CRITICAL_SECTION * lpCriticalSection);
-void DeleteCriticalSection(CRITICAL_SECTION * lpCriticalSection);
+version (MinGW64RT)
+{
+    LONG InterlockedIncrement(LPLONG lpAddend);
+    LONG InterlockedDecrement(LPLONG lpAddend);
+    LONG InterlockedExchange(LPLONG Target, LONG Value);
+    LONG InterlockedExchangeAdd(LPLONG Addend, LONG Value);
+    LONG InterlockedCompareExchange(LONG *Destination, LONG Exchange, LONG Comperand);
 
+    void InitializeCriticalSection(CRITICAL_SECTION * lpCriticalSection);
+    void EnterCriticalSection(CRITICAL_SECTION * lpCriticalSection);
+    BOOL TryEnterCriticalSection(CRITICAL_SECTION * lpCriticalSection);
+    void LeaveCriticalSection(CRITICAL_SECTION * lpCriticalSection);
+    void DeleteCriticalSection(CRITICAL_SECTION * lpCriticalSection);
+}
+else
+{
+    export
+    {
+        LONG InterlockedIncrement(LPLONG lpAddend);
+        LONG InterlockedDecrement(LPLONG lpAddend);
+        LONG InterlockedExchange(LPLONG Target, LONG Value);
+        LONG InterlockedExchangeAdd(LPLONG Addend, LONG Value);
+        LONG InterlockedCompareExchange(LONG *Destination, LONG Exchange, LONG Comperand);
+
+        void InitializeCriticalSection(CRITICAL_SECTION * lpCriticalSection);
+        void EnterCriticalSection(CRITICAL_SECTION * lpCriticalSection);
+        BOOL TryEnterCriticalSection(CRITICAL_SECTION * lpCriticalSection);
+        void LeaveCriticalSection(CRITICAL_SECTION * lpCriticalSection);
+        void DeleteCriticalSection(CRITICAL_SECTION * lpCriticalSection);
+    }
 }
 
 

--- a/libphobos/libdruntime/core/thread.d
+++ b/libphobos/libdruntime/core/thread.d
@@ -2779,6 +2779,19 @@ private void* getStackBottom()
                  mov RAX, GS:[RAX];
                  ret;
             }
+        else version (GNU_InlineAsm)
+        {
+            void *bottom;
+
+            version( X86 )
+                asm{ "movl %%fs:4, %0;" : "=r" bottom; }
+            else version( X86_64 )
+                asm{ "movq %%gs:8, %0;" : "=r" bottom; }
+            else
+                static assert(false, "Platform not supported.");
+
+            return bottom;
+        }
         else
             static assert(false, "Architecture not supported.");
     }

--- a/libphobos/libdruntime/core/thread.d
+++ b/libphobos/libdruntime/core/thread.d
@@ -126,6 +126,23 @@ version( Windows )
         extern (Windows) alias uint function(void*) btex_fptr;
         extern (C) uintptr_t _beginthreadex(void*, uint, btex_fptr, void*, uint, uint*);
 
+        version (MinGW)
+        {
+            import gcc.builtins;
+
+            // NOTE: The memory between the addresses of _tls_start and _tls_end
+            //       is the storage for thread-local data in MinGW.  Both of
+            //       these are defined in tlssup.c.
+            extern (C)
+            {
+                extern int _tls_start;
+                extern int _tls_end;
+            }
+
+            alias _tls_start _tlsstart;
+            alias _tls_end _tlsend;
+        }
+
         //
         // Entry point for Windows threads
         //
@@ -3052,6 +3069,21 @@ private
             version = AlignFiberStackTo16Byte;
         }
     }
+    else version (GNU_InlineAsm)
+    {
+        version (MinGW64)
+        {
+            version = GNU_AsmX86_64_Windows;
+            version = AlignFiberStackTo16Byte;
+            version = AsmExternal;
+        }
+        else version (MinGW)
+        {
+            version = GNU_AsmX86_Windows;
+            version = AlignFiberStackTo16Byte;
+            version = AsmExternal;
+        }
+    }
     else version( PPC )
     {
         version( Posix )
@@ -4310,6 +4342,46 @@ private:
              * Position the stack pointer above the lr register
              */
             pstack += int.sizeof * 1;
+        }
+        else version (GNU_AsmX86_Windows)
+        {
+            version( StackGrowsDown ) {} else static assert( false );
+
+            // Currently, MinGW doesn't utilize SEH exceptions.
+            // See DMD AsmX86_Windows If this code ever becomes fails and SEH is used.
+
+            push( 0x00000000 );                                     // Return address of fiber_entryPoint call
+            push( cast(size_t) &fiber_entryPoint );                 // EIP
+            push( 0x00000000 );                                     // EBP
+            push( 0x00000000 );                                     // EDI
+            push( 0x00000000 );                                     // ESI
+            push( 0x00000000 );                                     // EBX
+            push( 0xFFFFFFFF );                                     // FS:[0] - Current SEH frame
+            push( cast(size_t) m_ctxt.bstack );                     // FS:[4] - Top of stack
+            push( cast(size_t) m_ctxt.bstack - m_size );            // FS:[8] - Bottom of stack
+            push( 0x00000000 );                                     // EAX
+        }
+        else version (GNU_AsmX86_64_Windows)
+        {
+            push( 0x00000000_00000000 );                            // Return address of fiber_entryPoint call
+            push( cast(size_t) &fiber_entryPoint );                 // RIP
+            push( 0x00000000_00000000 );                            // RBP
+            push( 0x00000000_00000000 );                            // RBX
+            push( 0x00000000_00000000 );                            // R12
+            push( 0x00000000_00000000 );                            // R13
+            push( 0x00000000_00000000 );                            // R14
+            push( 0x00000000_00000000 );                            // R15
+            push( 0xFFFFFFFF_FFFFFFFF );                            // GS:[0] - Current SEH frame
+            version( StackGrowsDown )
+            {
+                push( cast(size_t) m_ctxt.bstack );                 // GS:[8]  - Top of stack
+                push( cast(size_t) m_ctxt.bstack - m_size );        // GS:[16] - Bottom of stack
+            }
+            else
+            {
+                push( cast(size_t) m_ctxt.bstack );                 // GS:[8]  - Top of stack
+                push( cast(size_t) m_ctxt.bstack + m_size );        // GS:[16] - Bottom of stack
+            }
         }
         else static if( __traits( compiles, ucontext_t ) )
         {

--- a/libphobos/libdruntime/core/threadasm.S
+++ b/libphobos/libdruntime/core/threadasm.S
@@ -409,3 +409,74 @@ fiber_switchContext:
     mov pc, r1
     .fnend
 #endif
+/************************************************************************************
+ * GDC MinGW ASM BITS
+ ************************************************************************************/
+#if defined(__x86_64__) && defined(__MINGW32__)
+.global fiber_switchContext
+fiber_switchContext:
+    pushq %RBP;
+    movq %RSP, %RBP;
+    pushq %RBX;
+    pushq %R12;
+    pushq %R13;
+    pushq %R14;
+    pushq %R15;
+    pushq %GS:0;
+    pushq %GS:8;
+    pushq %GS:16;
+
+    // store oldp
+    movq %RSP, (%RCX);
+    // load newp to begin context switch
+    movq %RDX, %RSP;
+
+    // load saved state from new stack
+    popq %GS:16;
+    popq %GS:8;
+    popq %GS:0;
+    popq %R15;
+    popq %R14;
+    popq %R13;
+    popq %R12;
+    popq %RBX;
+    popq %RBP;
+
+    // 'return' to complete switch
+    popq %RCX;
+    jmp *%RCX;
+#endif
+#if defined(_X86_) && defined(__MINGW32__)
+.global _fiber_switchContext
+_fiber_switchContext:
+    // Save current stack state.save current stack state
+    // Standard CDECL prologue.
+    push %EBP;
+    mov  %ESP, %EBP;
+    push %EDI;
+    push %ESI;
+    push %EBX;
+    push %FS:0;
+    push %FS:4;
+    push %FS:8;
+    push %EAX;
+
+    // store oldp again with more accurate address
+    mov 8(%EBP), %EAX;
+    mov %ESP, (%EAX);
+    // load newp to begin context switch
+    mov 12(%EBP), %ESP;
+
+    // load saved state from new stack
+    pop %EAX;
+    pop %FS:8;
+    pop %FS:4;
+    pop %FS:0;
+    pop %EBX;
+    pop %ESI;
+    pop %EDI;
+    pop %EBP;
+
+    // 'return' to complete switch
+    ret;
+#endif

--- a/libphobos/libdruntime/gcc/gthreads/win32.d
+++ b/libphobos/libdruntime/gcc/gthreads/win32.d
@@ -67,7 +67,7 @@ version (MinGW)
 {
   // Mingw runtime >= v0.3 provides a magic variable that is set to nonzero
   // if -mthreads option was specified, or 0 otherwise.
-  extern int _CRT_MT;
+  extern __gshared int _CRT_MT;
   extern int __mingwthr_key_dtor(ULONG, void function(void*));
 }
 

--- a/libphobos/libdruntime/rt/memory.d
+++ b/libphobos/libdruntime/rt/memory.d
@@ -22,10 +22,24 @@ private
         {
             extern __gshared
             {
-                int _data_start__;
-                int _data_end__;
-                int _bss_start__;
-                int _bss_end__;
+                // We need to alias __data_*__ and __bss_*__ to correct
+                // symbols on Win64. Binutils exports the same symbol for
+                // both Win32 and Win64, where-as the ABI says no _ should be
+                // prefixed.
+                version (X86)
+                {
+                    int _data_start__;
+                    int _data_end__;
+                    int _bss_start__;
+                    int _bss_end__;
+                }
+                else version (X86_64)
+                {
+                    pragma(mangle, "__data_start__") int _data_start__;
+                    pragma(mangle, "__data_end__") int _data_end__;
+                    pragma(mangle, "__bss_start__") int _bss_start__;
+                    pragma(mangle, "__bss_end__") int _bss_end__;
+                }
             }
         }
     }

--- a/libphobos/src/Makefile.am
+++ b/libphobos/src/Makefile.am
@@ -108,7 +108,7 @@ FREEBSD_OBJS=std/c/freebsd/socket.o
 WINDOWS_OBJS=std/c/windows/com.o std/c/windows/stat.o std/c/wcharh.o \
 	     std/c/windows/windows.o std/c/windows/winsock.o \
 	     std/windows/charset.o std/windows/iunknown.o std/windows/registry.o \
-	     std/windows/syserror.o std/__fileinit.o std/internal/windows/advapi32.o
+	     std/windows/syserror.o std/internal/windows/advapi32.o
 
 D_EXTRA_OBJS=@D_EXTRA_OBJS@
 

--- a/libphobos/src/Makefile.in
+++ b/libphobos/src/Makefile.in
@@ -276,7 +276,7 @@ FREEBSD_OBJS = std/c/freebsd/socket.o
 WINDOWS_OBJS = std/c/windows/com.o std/c/windows/stat.o std/c/wcharh.o \
 	     std/c/windows/windows.o std/c/windows/winsock.o \
 	     std/windows/charset.o std/windows/iunknown.o std/windows/registry.o \
-	     std/windows/syserror.o std/__fileinit.o std/internal/windows/advapi32.o
+	     std/windows/syserror.o std/internal/windows/advapi32.o
 
 ALL_PHOBOS_OBJS = $(D_EXTRA_OBJS) $(MAIN_OBJS) $(ZLIB_OBJS)
 

--- a/libphobos/src/std/format.d
+++ b/libphobos/src/std/format.d
@@ -5015,16 +5015,25 @@ void doFormat(void delegate(dchar) putc, TypeInfo[] arguments, va_list argptr)
             //doFormat(putc, (&valti)[0 .. 1], p);
             version (Win64)
             {
-                void* q = void;
-
-                if (tsize > 8 && m != Mangle.Tsarray)
-                {   q = p;
-                    argptr = &q;
+                version (GNU)
+                {
+                    __va_list va;
+                    va.stack_args = p;
+                    argptr = *cast(va_list*) &va;
                 }
                 else
-                argptr = p;
-                formatArg('s');
-                p += tsize;
+                {
+                    void* q = void;
+
+                    if (tsize > 8 && m != Mangle.Tsarray)
+                    {   q = p;
+                        argptr = &q;
+                    }
+                    else
+                    argptr = p;
+                    formatArg('s');
+                    p += tsize;
+                }
             }
             else
             {
@@ -5084,13 +5093,22 @@ void doFormat(void delegate(dchar) putc, TypeInfo[] arguments, va_list argptr)
                     argptr = cast(va_list) pkey;
                 else version (Win64)
                 {
-                    void* q = void;
-                    if (keysize > 8 && m != Mangle.Tsarray)
-                    {   q = pkey;
-                        argptr = &q;
+                    version (GNU)
+                    {
+                        __va_list va;
+                        va.stack_args = pkey;
+                        argptr = *cast(va_list*) &va;
                     }
                     else
-                        argptr = pkey;
+                    {
+                        void* q = void;
+                        if (keysize > 8 && m != Mangle.Tsarray)
+                        {   q = pkey;
+                            argptr = &q;
+                        }
+                        else
+                            argptr = pkey;
+                    }
                 }
                 else version (X86_64)
                 {   __va_list va;
@@ -5111,14 +5129,23 @@ void doFormat(void delegate(dchar) putc, TypeInfo[] arguments, va_list argptr)
                     argptr = cast(va_list) pvalue;
                 else version (Win64)
                 {
-                    void* q2 = void;
-                    auto valuesize = valti.tsize;
-                    if (valuesize > 8 && m != Mangle.Tsarray)
-                    {   q2 = pvalue;
-                        argptr = &q2;
+                    version (GNU)
+                    {
+                        __va_list va2;
+                        va2.stack_args = pvalue;
+                        argptr = *cast(va_list*) &va2;
                     }
                     else
-                        argptr = pvalue;
+                    {
+                        void* q2 = void;
+                        auto valuesize = valti.tsize;
+                        if (valuesize > 8 && m != Mangle.Tsarray)
+                        {   q2 = pvalue;
+                            argptr = &q2;
+                        }
+                        else
+                            argptr = pvalue;
+                    }
                 }
                 else version (X86_64)
                 {   __va_list va2;

--- a/libphobos/src/std/math.d
+++ b/libphobos/src/std/math.d
@@ -65,6 +65,12 @@
  */
 module std.math;
 
+version (Win64)
+{
+    version (D_InlineAsm_X86_64)
+        version = Win64_DMD_InlineAsm;
+}
+
 import core.stdc.math;
 import std.range, std.traits;
 
@@ -2185,7 +2191,7 @@ unittest
  */
 int ilogb(real x)  @trusted nothrow
 {
-    version (Win64)
+    version (Win64_DMD_InlineAsm)
     {
         asm
         {
@@ -2735,7 +2741,7 @@ unittest
  */
 real logb(real x) @trusted nothrow
 {
-    version (Win64)
+    version (Win64_DMD_InlineAsm)
     {
         asm
         {
@@ -2859,7 +2865,10 @@ real cbrt(real x) @trusted nothrow
 {
     version (Win64)
     {
-        return copysign(exp2(yl2x(fabs(x), 1.0L/3.0L)), x);
+        version (INLINE_YL2X)
+            return copysign(exp2(yl2x(fabs(x), 1.0L/3.0L)), x);
+        else
+            return core.stdc.math.cbrtl(x);
     }
     else
         return core.stdc.math.cbrtl(x);
@@ -2989,7 +2998,7 @@ unittest
  */
 real ceil(real x)  @trusted pure nothrow
 {
-    version (Win64)
+    version (Win64_DMD_InlineAsm)
     {
         asm
         {
@@ -3042,7 +3051,7 @@ unittest
  */
 real floor(real x) @trusted pure nothrow
 {
-    version (Win64)
+    version (Win64_DMD_InlineAsm)
     {
         asm
         {
@@ -3392,7 +3401,7 @@ version(Posix)
  */
 real trunc(real x) @trusted nothrow
 {
-    version (Win64)
+    version (Win64_DMD_InlineAsm)
     {
         asm
         {


### PR DESCRIPTION
This adds enough of @venix1 changes to make GDC and phobos build for MinGW and MinGW64 and allows to build 32/64bit hello world applications. No further testing has been done.

I do not really want to support a complete MinGW port, but once we get DDMD we'll need a basic MinGW GDC compiler to build the `windows host --> other target` cross compilers.

@venix1 Do you want to be added as the GIT_AUTHOR of these commits or shall I only add a comment
to the extended commit description? This is mostly your work after all.
Would be great if you could do a quick review as well, in case I screwed something up.

OT: @ibuclaw I published the configuration files for the binary builds at gdcproject.org/downloads here:
https://github.com/jpf91/gdc-build-configs/
If you want to you can fork this into the D-Programming-GDC organization.
There's still some stuff missing (most important: The build tool, website template and sqlite database of all builds, crosstool-NG patches). I'll publish that stuff later on.
