### PR TITLE
Bug 134: gcc/d/dfrontend/outbuffer.c needs alloca.h on Solarish systems

### DIFF
--- a/gcc/d/dfrontend/port.h
+++ b/gcc/d/dfrontend/port.h
@@ -13,6 +13,10 @@
 #include <stdlib.h> // for alloca
 #include <stdint.h>
 
+#ifdef __sun
+#include <alloca.h>
+#endif
+
 #include "longdouble.h"
 
 #if _MSC_VER

--- a/gcc/d/patches/patch-versym-os-4.8.x
+++ b/gcc/d/patches/patch-versym-os-4.8.x
@@ -233,6 +233,23 @@ These official OS versions are not implemented:
 +
  #undef GNU_USER_DYNAMIC_LINKER
  #define GNU_USER_DYNAMIC_LINKER "/lib/ld.so.1"
+--- gcc/config/sol2.h	2014-06-13 22:32:59.642262618 -0500
++++ gcc/config/sol2.h	2014-06-13 22:35:08.125209793 -0500
+@@ -98,6 +98,14 @@
+ 	TARGET_SUB_OS_CPP_BUILTINS();			\
+     } while (0)
+ 
++#define	TARGET_OS_D_BUILTINS()				\
++  do							\
++    {							\
++      builtin_define ("Solaris");			\
++      builtin_define ("Posix");				\
++    }							\
++  while (0)
++
+ #define SUBTARGET_OVERRIDE_OPTIONS			\
+   do {							\
+     solaris_override_options ();			\
 --- gcc/config/linux-android.h	2013-07-04 20:28:59.561658533 +0200
 +++ gcc/config/linux-android.h	2013-07-04 18:30:36.000000000 +0200
 @@ -25,6 +25,12 @@

--- a/libphobos/libdruntime/core/runtime.d
+++ b/libphobos/libdruntime/core/runtime.d
@@ -58,6 +58,8 @@ private
         import core.sys.osx.execinfo;
     else version( FreeBSD )
         import core.sys.freebsd.execinfo;
+    else version( Solaris )
+        import core.sys.solaris.execinfo;
     else version( Windows )
         import core.sys.windows.stacktrace;
 

--- a/libphobos/libdruntime/core/stdc/errno_.c
+++ b/libphobos/libdruntime/core/stdc/errno_.c
@@ -11,6 +11,12 @@
  *    (See accompanying file LICENSE or copy at
  *          http://www.boost.org/LICENSE_1_0.txt)
  */
+
+#if __sun
+/* Without this, you get the errno of the initial thread everywhere */
+#define	_REENTRANT
+#endif
+
 #include <errno.h>
 
 

--- a/libphobos/libdruntime/core/stdc/fenv.d
+++ b/libphobos/libdruntime/core/stdc/fenv.d
@@ -124,6 +124,25 @@ else version ( FreeBSD )
 
     alias ushort fexcept_t;
 }
+else version( Solaris )
+{
+    import core.stdc.config;
+
+    enum FEX_NUM_EXC = 12;
+
+    struct fex_handler_t
+    {
+        int             __mode;
+        void function() __handler;
+    }
+    struct fenv_t
+    {
+        fex_handler_t[FEX_NUM_EXC]  __handlers;
+	c_ulong                     __fsr;
+    }
+    alias int fexcept_t;
+}
+
 else
 {
     static assert( false, "Unsupported platform" );
@@ -162,6 +181,11 @@ else version( FreeBSD )
 {
     private extern const fenv_t __fe_dfl_env;
     const fenv_t* FE_DFL_ENV = &__fe_dfl_env;
+}
+else version( Solaris )
+{
+    private extern const fenv_t __fenv_dfl_env;
+    const fenv_t* FE_DFL_ENV = &__fenv_dfl_env;
 }
 else
 {

--- a/libphobos/libdruntime/core/stdc/locale.d
+++ b/libphobos/libdruntime/core/stdc/locale.d
@@ -91,9 +91,19 @@ else version(FreeBSD)
     enum LC_TIME           = 5;
     enum LC_MESSAGES       = 6;
 }
+else version(Solaris)
+{
+    enum LC_ALL            = 6;
+    enum LC_COLLATE        = 3;
+    enum LC_CTYPE          = 0;
+    enum LC_MONETARY       = 4;
+    enum LC_NUMERIC        = 1;
+    enum LC_TIME           = 2;
+    enum LC_MESSAGES       = 5;
+}
 else
 {
-    static assert(false);
+    static assert(false, "Unsupported platform");
 }
 
 @system char*  setlocale(int category, in char* locale);

--- a/libphobos/libdruntime/core/stdc/math.d
+++ b/libphobos/libdruntime/core/stdc/math.d
@@ -544,6 +544,25 @@ else version( FreeBSD )
     int signbit(real x)         { return __signbit(x); }
   }
 }
+else version( Solaris )
+{
+    int __isnanf(float x);
+    int __isnan(double x);
+    int __isnanl(real x);
+
+  extern (D)
+  {
+    //int isnan(real-floating x);
+    int isnan(float x)          { return __isnanf(x);  }
+    int isnan(double x)         { return __isnan(x);   }
+    int isnan(real x)
+    {
+        return (real.sizeof == double.sizeof)
+            ? __isnan(x)
+            : __isnanl(x);
+    }
+  }
+}
 
 extern (D)
 {

--- a/libphobos/libdruntime/core/stdc/string.d
+++ b/libphobos/libdruntime/core/stdc/string.d
@@ -41,6 +41,7 @@ pure char*  strrchr(in char* s, int c);
 pure size_t strspn(in char* s1, in char* s2);
 pure char*  strstr(in char* s1, in char* s2);
 char*  strtok(char* s1, in char* s2);
-char*  strerror(int errnum);
+// probably not entirely correct
+pure char*  strerror(int errnum);
 pure size_t strlen(in char* s);
 char*  strdup(in char *s);

--- a/libphobos/libdruntime/core/stdc/time.d
+++ b/libphobos/libdruntime/core/stdc/time.d
@@ -81,7 +81,12 @@ else version (linux)
 {
     enum clock_t CLOCKS_PER_SEC = 1000000;
 }
-
+else version (Solaris)
+{
+    // technically, this should be the output of
+    // sysconf(_SC_CLK_TCK), but should work for now
+    enum clock_t CLOCKS_PER_SEC = 100;
+}
 clock_t clock();
 double  difftime(time_t time1, time_t time0);
 time_t  mktime(tm* timeptr);

--- a/libphobos/libdruntime/core/sync/condition.d
+++ b/libphobos/libdruntime/core/sync/condition.d
@@ -193,6 +193,22 @@ class Condition
             }
             return timedWait( cast(uint) val.total!"msecs" );
         }
+        else version( Solaris )
+        {
+            timespec t = void;
+            mvtspec( t, val );
+
+            // Solaris uses relative timeouts inside of libc.
+            // Avoid unnesessary relative->clock->relative conversion
+            int rc = pthread_cond_reltimedwait_np( &m_hndl,
+                                                   m_assocMutex.handleAddr(),
+                                                   &t);
+            if( !rc )
+                return true;
+            if( rc == ETIMEDOUT )
+                return false;
+            throw new SyncException( "Unable to wait for condition" );
+        }
         else version( Posix )
         {
             timespec t = void;

--- a/libphobos/libdruntime/core/sys/posix/arpa/inet.d
+++ b/libphobos/libdruntime/core/sys/posix/arpa/inet.d
@@ -115,6 +115,28 @@ else version( FreeBSD )
     const(char)*    inet_ntop(int, in void*, char*, socklen_t);
     int             inet_pton(int, in char*, void*);
 }
+else version( Solaris )
+{
+    alias uint16_t in_port_t;
+    alias uint32_t in_addr_t;
+
+    struct in_addr
+    {
+        in_addr_t s_addr;
+    }
+
+    enum INET_ADDRSTRLEN = 16;
+
+    uint32_t htonl(uint32_t);
+    uint16_t htons(uint16_t);
+    uint32_t ntohl(uint32_t);
+    uint16_t ntohs(uint16_t);
+
+    in_addr_t       inet_addr(in char*);
+    char*           inet_ntoa(in_addr);
+    const(char)*    inet_ntop(int, in void*, char*, socklen_t);
+    int             inet_pton(int, in char*, void*);
+}
 
 //
 // IPV6 (IP6)
@@ -125,16 +147,7 @@ NOTE: The following must must be defined in core.sys.posix.arpa.inet to break
 
 INET6_ADDRSTRLEN // from core.sys.posix.netinet.in_
 */
-
-version( linux )
+version( Posix )
 {
-    enum INET6_ADDRSTRLEN = 46;
-}
-else version( OSX )
-{
-    enum INET6_ADDRSTRLEN = 46;
-}
-else version( FreeBSD )
-{
-    enum INET6_ADDRSTRLEN = 46;
+   enum INET6_ADDRSTRLEN = 46;
 }

--- a/libphobos/libdruntime/core/sys/posix/dirent.d
+++ b/libphobos/libdruntime/core/sys/posix/dirent.d
@@ -142,12 +142,15 @@ else version( FreeBSD )
 }
 else version (Solaris)
 {
+    enum DT_UNKNOWN = 0;
+
     struct dirent
     {
         ino_t d_ino;
         off_t d_off;
         ushort d_reclen;
         char[1] d_name;
+	extern (D) @property ubyte d_type() { return DT_UNKNOWN; }
     }
 
     struct DIR

--- a/libphobos/libdruntime/core/sys/posix/dlfcn.d
+++ b/libphobos/libdruntime/core/sys/posix/dlfcn.d
@@ -148,4 +148,24 @@ else version( FreeBSD )
         const(char)* dli_sname;
         void*        dli_saddr;
     }
+} else version(Solaris)
+{
+    enum RTLD_LAZY   = 0x00001;
+    enum RTLD_NOW    = 0x00002;
+    enum RTLD_GLOBAL = 0x00100;
+    enum RTLD_LOCAL  = 0x00000;
+
+    int     dlclose(void*);
+    char*   dlerror();
+    void*   dlopen(in char*, int);
+    void*   dlsym(void*, in char*);
+    int     dladdr(const(void)* addr, Dl_info* info);
+
+    struct Dl_info
+    {
+        const(char)*    dli_fname;
+        void*           dli_fbase;
+        const(char)*    dli_sname;
+        void*           dli_saddr;
+    }
 }

--- a/libphobos/libdruntime/core/sys/posix/netinet/in_.d
+++ b/libphobos/libdruntime/core/sys/posix/netinet/in_.d
@@ -166,7 +166,37 @@ else version( FreeBSD )
 
     //enum INET_ADDRSTRLEN       = 16;
 }
+else version ( Solaris )
+{
+    //alias uint16_t in_port_t;
+    //alias uint32_t in_addr_t;
 
+    //struct in_addr
+    //{
+    //    in_addr_t s_addr;
+    //}
+
+    struct sockaddr_in
+    {
+        sa_family_t sin_family;
+        in_port_t   sin_port;
+        in_addr     sin_addr;
+        ubyte[8]    sin_zero;
+    }
+
+    enum
+    {
+        IPPROTO_IP   = 0,
+        IPPROTO_ICMP = 1,
+        IPPROTO_TCP  = 6,
+        IPPROTO_UDP  = 17
+    }
+
+    enum uint INADDR_ANY       = 0x00000000;
+    enum uint INADDR_BROADCAST = 0xffffffff;
+
+    //enum INET_ADDRSTRLEN       = 16;
+}
 
 //
 // IPV6 (IP6)
@@ -610,7 +640,144 @@ else version( FreeBSD )
                __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_GLOBAL;
     }
 }
+else version ( Solaris )
+{
+    struct in6_addr
+    {
+        union
+        {
+            uint8_t[16] s6_addr;
+            uint32_t[4] s6_addr32;
+        }
+    }
 
+    struct sockaddr_in6
+    {
+        sa_family_t sin6_family;
+        in_port_t   sin6_port;
+        uint32_t    sin6_flowinfo;
+        in6_addr    sin6_addr;
+        uint32_t    sin6_scope_id;
+        uint32_t    __sin6_src_id;
+    }
+
+    extern __gshared immutable in6_addr in6addr_any;
+    extern __gshared immutable in6_addr in6addr_loopback;
+
+    struct ipv6_mreq
+    {
+        in6_addr    ipv6mr_multiaddr;
+        uint        ipv6mr_interface;
+    }
+
+    enum : uint
+    {
+        IPPROTO_IPV6        = 41,
+
+        //INET6_ADDRSTRLEN    = 46,
+
+        IPV6_JOIN_GROUP     = 0x9,
+        IPV6_LEAVE_GROUP    = 0xa,
+        IPV6_MULTICAST_HOPS = 0x7,
+        IPV6_MULTICAST_IF   = 0x6,
+        IPV6_MULTICAST_LOOP = 0x8,
+        IPV6_UNICAST_HOPS   = 0x5,
+        IPV6_V6ONLY         = 0x27,
+    }
+
+    private enum
+    {
+        __IPV6_ADDR_SCOPE_NODELOCAL     = 0x01,
+        __IPV6_ADDR_SCOPE_INTFACELOCAL  = 0x01,
+        __IPV6_ADDR_SCOPE_LINKLOCAL     = 0x02,
+        __IPV6_ADDR_SCOPE_SITELOCAL     = 0x05,
+        __IPV6_ADDR_SCOPE_ORGLOCAL      = 0x08,
+        __IPV6_ADDR_SCOPE_GLOBAL        = 0x0e,
+    }
+
+    // macros
+    extern (D) int IN6_IS_ADDR_UNSPECIFIED( in in6_addr* a )
+    {
+        return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
+               (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
+               (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[8]) == 0) &&
+               (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) == 0);
+    }
+
+    extern (D) int IN6_IS_ADDR_LOOPBACK( in in6_addr* a )
+    {
+        return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
+               (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
+               (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[8]) == 0) &&
+               (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) == ntohl(1));
+    }
+
+    extern (D) int IN6_IS_ADDR_V4COMPAT( in in6_addr* a )
+    {
+        return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
+               (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
+               (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[8]) == 0) &&
+               (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) != 0) &&
+               (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[12]) != ntohl(1));
+    }
+
+    extern (D) int IN6_IS_ADDR_V4MAPPED( in in6_addr* a )
+    {
+        return (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[0]) == 0) &&
+               (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[4]) == 0) &&
+               (*cast(const uint32_t*) cast(const void*) (&a.s6_addr[8]) == ntohl(0x0000ffff));
+    }
+
+    extern (D) int IN6_IS_ADDR_LINKLOCAL( in in6_addr* a )
+    {
+        return a.s6_addr[0] == 0xfe && (a.s6_addr[1] & 0xc0) == 0x80;
+    }
+
+    extern (D) int IN6_IS_ADDR_SITELOCAL( in in6_addr* a )
+    {
+        return a.s6_addr[0] == 0xfe && (a.s6_addr[1] & 0xc0) == 0xc0;
+    }
+
+    extern (D) int IN6_IS_ADDR_MULTICAST( in in6_addr* a )
+    {
+        return a.s6_addr[0] == 0xff;
+    }
+
+    extern (D) uint8_t __IPV6_ADDR_MC_SCOPE( in in6_addr* a )
+    {
+        return a.s6_addr[1] & 0x0f;
+    }
+
+    extern (D) int IN6_IS_ADDR_MC_NODELOCAL( in in6_addr* a )
+    {
+        return IN6_IS_ADDR_MULTICAST(a) &&
+               __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_NODELOCAL;
+    }
+
+    extern (D) int IN6_IS_ADDR_MC_LINKLOCAL( in in6_addr* a )
+    {
+        return IN6_IS_ADDR_MULTICAST(a) &&
+               __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_LINKLOCAL;
+    }
+
+    extern (D) int IN6_IS_ADDR_MC_SITELOCAL( in in6_addr* a )
+    {
+        return IN6_IS_ADDR_MULTICAST(a) &&
+               __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_SITELOCAL;
+    }
+
+    extern (D) int IN6_IS_ADDR_MC_ORGLOCAL( in in6_addr* a )
+    {
+        return IN6_IS_ADDR_MULTICAST(a) &&
+               __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_ORGLOCAL;
+    }
+
+    extern (D) int IN6_IS_ADDR_MC_GLOBAL( in in6_addr* a )
+    {
+        return IN6_IS_ADDR_MULTICAST(a) &&
+               __IPV6_ADDR_MC_SCOPE(a) == __IPV6_ADDR_SCOPE_GLOBAL;
+    }
+}
 
 //
 // Raw Sockets (RS)
@@ -628,6 +795,10 @@ else version( OSX )
     enum uint IPPROTO_RAW = 255;
 }
 else version( FreeBSD )
+{
+    enum uint IPPROTO_RAW = 255;
+}
+else version( Solaris )
 {
     enum uint IPPROTO_RAW = 255;
 }

--- a/libphobos/libdruntime/core/sys/posix/netinet/tcp.d
+++ b/libphobos/libdruntime/core/sys/posix/netinet/tcp.d
@@ -38,3 +38,7 @@ else version( FreeBSD )
 {
     enum TCP_NODELAY = 1;
 }
+else version( Solaris )
+{
+    enum TCP_NODELAY = 1;
+}

--- a/libphobos/libdruntime/core/sys/posix/pthread.d
+++ b/libphobos/libdruntime/core/sys/posix/pthread.d
@@ -390,6 +390,8 @@ version( Posix )
     int pthread_cond_init(in pthread_cond_t*, pthread_condattr_t*);
     int pthread_cond_signal(pthread_cond_t*);
     int pthread_cond_timedwait(pthread_cond_t*, pthread_mutex_t*, in timespec*);
+    version( Solaris )
+        int pthread_cond_reltimedwait_np(pthread_cond_t*, pthread_mutex_t*, in timespec*);
     int pthread_cond_wait(pthread_cond_t*, pthread_mutex_t*);
     int pthread_condattr_destroy(pthread_condattr_t*);
     int pthread_condattr_init(pthread_condattr_t*);

--- a/libphobos/libdruntime/core/sys/posix/semaphore.d
+++ b/libphobos/libdruntime/core/sys/posix/semaphore.d
@@ -132,6 +132,7 @@ else version( FreeBSD )
 else version (Solaris)
 {
     int sem_timedwait(sem_t*, in timespec*);
+    int sem_reltimedwait_np(sem_t*, in timespec*);
 }
 else
 {

--- a/libphobos/libdruntime/core/sys/posix/signal.d
+++ b/libphobos/libdruntime/core/sys/posix/signal.d
@@ -104,11 +104,23 @@ version( Posix )
         void*   sival_ptr;
     }
 
-    private extern (C) int __libc_current_sigrtmin();
-    private extern (C) int __libc_current_sigrtmax();
+    version(Solaris)
+    {
+        import core.sys.posix.unistd;
+        private int current_sigrtmin() { return cast(int) sysconf(_SC_SIGRT_MIN); }
+        private int current_sigrtmax() { return cast(int) sysconf(_SC_SIGRT_MAX); }
 
-    alias __libc_current_sigrtmin SIGRTMIN;
-    alias __libc_current_sigrtmax SIGRTMAX;
+        alias current_sigrtmin SIGRTMIN;
+        alias current_sigrtmax SIGRTMAX;
+    }
+    else
+    {
+        private extern (C) int __libc_current_sigrtmin();
+        private extern (C) int __libc_current_sigrtmax();
+
+        alias __libc_current_sigrtmin SIGRTMIN;
+        alias __libc_current_sigrtmax SIGRTMAX;
+    }
 }
 
 version( linux )
@@ -381,6 +393,8 @@ else version (Solaris)
         }
 
         sigset_t sa_mask;
+        version (X86)
+            int[2] sa_resv;
     }
 }
 else version( Posix )

--- a/libphobos/libdruntime/core/sys/posix/stdlib.d
+++ b/libphobos/libdruntime/core/sys/posix/stdlib.d
@@ -89,6 +89,10 @@ else version( FreeBSD )
 {
     int posix_memalign(void**, size_t, size_t);
 }
+else version( Solaris )
+{
+    int posix_memalign(void**, size_t, size_t);
+}
 
 //
 // C Extension (CX)
@@ -119,6 +123,13 @@ else version( FreeBSD )
 
     void* valloc(size_t); // LEGACY non-standard
 }
+else version( Solaris )
+{
+    int setenv(in char*, in char*, int);
+    int unsetenv(in char*);
+
+    void* valloc(size_t); // LEGACY non-standard
+}
 
 //
 // Thread-Safe Functions (TSF)
@@ -136,6 +147,10 @@ else version( OSX )
     int rand_r(uint*);
 }
 else version( FreeBSD )
+{
+    int rand_r(uint*);
+}
+else version( Solaris )
 {
     int rand_r(uint*);
 }
@@ -313,4 +328,54 @@ else version( FreeBSD )
     void   srand48(c_long);
     void   srandom(uint);
     int    unlockpt(int);
+}
+version( Solaris )
+{
+    //WNOHANG     (defined in core.sys.posix.sys.wait)
+    //WUNTRACED   (defined in core.sys.posix.sys.wait)
+    //WEXITSTATUS (defined in core.sys.posix.sys.wait)
+    //WIFEXITED   (defined in core.sys.posix.sys.wait)
+    //WIFSIGNALED (defined in core.sys.posix.sys.wait)
+    //WIFSTOPPED  (defined in core.sys.posix.sys.wait)
+    //WSTOPSIG    (defined in core.sys.posix.sys.wait)
+    //WTERMSIG    (defined in core.sys.posix.sys.wait)
+
+    c_long a64l(in char*);
+    double drand48();
+    char*  ecvt(double, int, int *, int *); // LEGACY
+    double erand48(ref ushort[3]);
+    char*  fcvt(double, int, int *, int *); // LEGACY
+    char*  gcvt(double, int, char*); // LEGACY
+    int    getsubopt(char**, in char**, char**);
+    int    grantpt(int);
+    char*  initstate(uint, char*, size_t);
+    c_long jrand48(ref ushort[3]);
+    char*  l64a(c_long);
+    void   lcong48(ref ushort[7]);
+    c_long lrand48();
+    char*  mktemp(char*); // LEGACY
+    //int    mkstemp(char*);
+    c_long mrand48();
+    c_long nrand48(ref ushort[3]);
+    int    posix_openpt(int);
+    char*  ptsname(int);
+    int    putenv(char*);
+    c_long random();
+    char*  realpath(in char*, char*);
+    ushort seed48(ref ushort[3]);
+    void   setkey(in char*);
+    char*  setstate(in char*);
+    void   srand48(c_long);
+    void   srandom(uint);
+    int    unlockpt(int);
+
+  static if( __USE_LARGEFILE64 )
+  {
+    int    mkstemp64(char*);
+    alias  mkstemp64 mkstemp;
+  }
+  else
+  {
+    int    mkstemp(char*);
+  }
 }

--- a/libphobos/libdruntime/core/sys/posix/sys/mman.d
+++ b/libphobos/libdruntime/core/sys/posix/sys/mman.d
@@ -80,6 +80,12 @@ else version( FreeBSD )
 }
 else version (Solaris)
 {
+    enum POSIX_MADV_NORMAL      = 0;
+    enum POSIX_MADV_RANDOM      = 1;
+    enum POSIX_MADV_SEQUENTIAL  = 2;
+    enum POSIX_MADV_WILLNEED    = 3;
+    enum POSIX_MADV_DONTNEED    = 4;
+    int posix_madvise(void *addr, size_t len, int advice);
 }
 else
 {
@@ -158,7 +164,13 @@ else version( FreeBSD )
 }
 else version (Solaris)
 {
-    void* mmap(void*, size_t, int, int, int, off_t);
+    version (D_LP64) {
+        void* mmap(void*, size_t, int, int, int, off_t);
+        alias mmap64 = mmap;
+    } else {
+        void* mmap64(void*, size_t, int, int, int, off64_t);
+        alias mmap = mmap64;
+    }
     int   munmap(void*, size_t);
 }
 else

--- a/libphobos/libdruntime/core/sys/posix/sys/stat.d
+++ b/libphobos/libdruntime/core/sys/posix/sys/stat.d
@@ -663,6 +663,12 @@ else version (Solaris)
             timestruc_t st_atim;
             timestruc_t st_mtim;
             timestruc_t st_ctim;
+	    extern (D)
+	    {
+		    @property ref time_t st_atime() { return st_atim.tv_sec; }
+		    @property ref time_t st_mtime() { return st_mtim.tv_sec; }
+		    @property ref time_t st_ctime() { return st_ctim.tv_sec; }
+	    }
             blksize_t st_blksize;
             blkcnt_t st_blocks;
             char[_ST_FSTYPSZ] st_fstype;
@@ -688,6 +694,12 @@ else version (Solaris)
             timestruc_t st_atim;
             timestruc_t st_mtim;
             timestruc_t st_ctim;
+	    extern (D)
+	    {
+		    @property ref time_t st_atime() { return st_atim.tv_sec; }
+		    @property ref time_t st_mtime() { return st_mtim.tv_sec; }
+		    @property ref time_t st_ctime() { return st_ctim.tv_sec; }
+	    }
             blksize_t st_blksize;
             blkcnt_t st_blocks;
             char[_ST_FSTYPSZ] st_fstype;
@@ -710,6 +722,12 @@ else version (Solaris)
             timestruc_t st_atim;
             timestruc_t st_mtim;
             timestruc_t st_ctim;
+	    extern (D)
+	    {
+		    @property ref time_t st_atime() { return st_atim.tv_sec; }
+		    @property ref time_t st_mtime() { return st_mtim.tv_sec; }
+		    @property ref time_t st_ctime() { return st_ctim.tv_sec; }
+	    }
             blksize_t st_blksize;
             blkcnt64_t st_blocks;
             char[_ST_FSTYPSZ] st_fstype;

--- a/libphobos/libdruntime/core/sys/posix/sys/stat.d
+++ b/libphobos/libdruntime/core/sys/posix/sys/stat.d
@@ -814,22 +814,30 @@ version( linux )
 }
 else version (Solaris)
 {
-    static if (__USE_LARGEFILE64)
-    {
-        int   fstat64(int, stat_t*);
-        alias fstat64 fstat;
+    version (X86) {
+        static if (__USE_LARGEFILE64)
+        {
+            int   fstat64(int, stat_t*);
+            alias fstat64 fstat;
 
-        int   lstat64(in char*, stat_t*);
-        alias lstat64 lstat;
+            int   lstat64(in char*, stat_t*);
+            alias lstat64 lstat;
 
-        int   stat64(in char*, stat_t*);
-        alias stat64 stat;
+            int   stat64(in char*, stat_t*);
+            alias stat64 stat;
+        }
+        else
+        {
+            int fstat(int, stat_t*);
+            int lstat(in char*, stat_t*);
+            int stat(in char*, stat_t*);
+	}
     }
-    else
+    else version (X86_64)
     {
         int fstat(int, stat_t*);
-        int lstat(in char*, stat_t*);
-        int stat(in char*, stat_t*);
+	int lstat(in char*, stat_t*);
+	int stat(in char*, stat_t*);
     }
 }
 else version( Posix )

--- a/libphobos/libdruntime/core/sys/posix/sys/un.d
+++ b/libphobos/libdruntime/core/sys/posix/sys/un.d
@@ -58,3 +58,11 @@ else version( FreeBSD )
         byte[104]   sun_path;
     }
 }
+else version( Solaris )
+{
+    struct sockaddr_un
+    {
+        sa_family_t sun_family;
+	byte[108]   sun_path;
+    }
+}

--- a/libphobos/libdruntime/core/sys/posix/time.d
+++ b/libphobos/libdruntime/core/sys/posix/time.d
@@ -240,6 +240,7 @@ else version (Solaris)
         timespec it_value;
     }
 
+    enum CLOCK_REALTIME = 0x3;
     enum TIMER_ABSOLUTE = 0x1;
 
     alias int clockid_t;

--- a/libphobos/libdruntime/core/sys/posix/ucontext.d
+++ b/libphobos/libdruntime/core/sys/posix/ucontext.d
@@ -608,13 +608,14 @@ else version( Solaris )
     version ( X86_64 )
     {
         private enum _NGREG = 28;
+        alias long greg_t;
     }
     else version ( X86 )
     {
         private enum _NGREG = 19;
+        alias int greg_t;
     }
 
-    alias c_long greg_t;
     alias greg_t[_NGREG] gregset_t;
 
     version ( X86_64 )
@@ -655,9 +656,9 @@ else version( Solaris )
     {
         struct fpregset_t
         {
-            union fp_reg_set
+            union u_fp_reg_set
             {
-                struct fpchip_state
+                struct s_fpchip_state
                 {
                     uint[27]        state;
                     uint            status;
@@ -666,13 +667,17 @@ else version( Solaris )
                     uint[2]         __pad;
                     upad128_t[8]    xmm;
                 }
-                struct fp_emul_space
+                s_fpchip_state    fpchip_state;
+
+                struct s_fp_emul_space
                 {
                     ubyte[246]  fp_emul;
                     ubyte[2]    fp_epad;
                 }
-                uint[95]    f_fpregs;
+                s_fp_emul_space   fp_emul_space;
+                uint[95]        f_fpregs;
             }
+        u_fp_reg_set fp_reg_set;
         }
     }
 
@@ -689,7 +694,7 @@ else version( Solaris )
         sigset_t    uc_sigmask;
         stack_t     uc_stack;
         mcontext_t  uc_mcontext;
-        c_ulong[5]  uc_filler;
+        c_long[5]   uc_filler;
     }
 }
 

--- a/libphobos/libdruntime/core/sys/posix/unistd.d
+++ b/libphobos/libdruntime/core/sys/posix/unistd.d
@@ -117,6 +117,27 @@ else version( FreeBSD )
     off_t lseek(int, off_t, int);
     int   ftruncate(int, off_t);
 }
+version( Solaris )
+{
+  static if( __USE_FILE_OFFSET64 )
+  {
+    off_t lseek64(int, off_t, int);
+    alias lseek64 lseek;
+  }
+  else
+  {
+    off_t lseek(int, off_t, int);
+  }
+  static if( __USE_LARGEFILE64 )
+  {
+    int   ftruncate64(int, off_t);
+    alias ftruncate64 ftruncate;
+  }
+  else
+  {
+    int   ftruncate(int, off_t);
+  }
+}
 else version( Posix )
 {
     off_t lseek(int, off_t, int);
@@ -462,6 +483,289 @@ else version( FreeBSD )
     enum F_TLOCK    = 2;
     enum F_TEST     = 3;
 }
+else version( Solaris )
+{
+    enum F_OK       = 0;
+    enum R_OK       = 4;
+    enum W_OK       = 2;
+    enum X_OK       = 1;
+
+    enum
+    {
+        // large file compilation environment configuration
+        _CS_LFS_CFLAGS                  = 68,
+        _CS_LFS_LDFLAGS                 = 69,
+        _CS_LFS_LIBS                    = 70,
+        _CS_LFS_LINTFLAGS               = 71,
+        // transitional large file interface configuration
+        _CS_LFS64_CFLAGS                = 72,
+        _CS_LFS64_LDFLAGS               = 73,
+        _CS_LFS64_LIBS                  = 74,
+        _CS_LFS64_LINTFLAGS             = 75,
+
+        // UNIX 98
+        _CS_XBS5_ILP32_OFF32_CFLAGS     = 700,
+        _CS_XBS5_ILP32_OFF32_LDFLAGS    = 701,
+        _CS_XBS5_ILP32_OFF32_LIBS       = 702,
+        _CS_XBS5_ILP32_OFF32_LINTFLAGS  = 703,
+        _CS_XBS5_ILP32_OFFBIG_CFLAGS    = 705,
+        _CS_XBS5_ILP32_OFFBIG_LDFLAGS   = 706,
+        _CS_XBS5_ILP32_OFFBIG_LIBS      = 707,
+        _CS_XBS5_ILP32_OFFBIG_LINTFLAGS = 708,
+        _CS_XBS5_LP64_OFF64_CFLAGS      = 709,
+        _CS_XBS5_LP64_OFF64_LDFLAGS     = 710,
+        _CS_XBS5_LP64_OFF64_LIBS        = 711,
+        _CS_XBS5_LP64_OFF64_LINTFLAGS   = 712,
+        _CS_XBS5_LPBIG_OFFBIG_CFLAGS    = 713,
+        _CS_XBS5_LPBIG_OFFBIG_LDFLAGS   = 714,
+        _CS_XBS5_LPBIG_OFFBIG_LIBS      = 715,
+        _CS_XBS5_LPBIG_OFFBIG_LINTFLAGS = 716,
+
+        // UNIX 03
+        _CS_POSIX_V6_ILP32_OFF32_CFLAGS         = 800,
+        _CS_POSIX_V6_ILP32_OFF32_LDFLAGS        = 801,
+        _CS_POSIX_V6_ILP32_OFF32_LIBS           = 802,
+        _CS_POSIX_V6_ILP32_OFF32_LINTFLAGS      = 803,
+        _CS_POSIX_V6_ILP32_OFFBIG_CFLAGS        = 804,
+        _CS_POSIX_V6_ILP32_OFFBIG_LDFLAGS       = 805,
+        _CS_POSIX_V6_ILP32_OFFBIG_LIBS          = 806,
+        _CS_POSIX_V6_ILP32_OFFBIG_LINTFLAGS     = 807,
+        _CS_POSIX_V6_LP64_OFF64_CFLAGS          = 808,
+        _CS_POSIX_V6_LP64_OFF64_LDFLAGS         = 809,
+        _CS_POSIX_V6_LP64_OFF64_LIBS            = 810,
+        _CS_POSIX_V6_LP64_OFF64_LINTFLAGS       = 811,
+        _CS_POSIX_V6_LPBIG_OFFBIG_CFLAGS        = 812,
+        _CS_POSIX_V6_LPBIG_OFFBIG_LDFLAGS       = 813,
+        _CS_POSIX_V6_LPBIG_OFFBIG_LIBS          = 814,
+        _CS_POSIX_V6_LPBIG_OFFBIG_LINTFLAGS     = 815,
+        _CS_POSIX_V6_WIDTH_RESTRICTED_ENVS      = 816
+    }
+
+    enum {
+        _SC_ARG_MAX                     = 1,
+        _SC_CHILD_MAX                   = 2,
+        _SC_CLK_TCK                     = 3,
+        _SC_NGROUPS_MAX                 = 4,
+        _SC_OPEN_MAX                    = 5,
+        _SC_JOB_CONTROL                 = 6,
+        _SC_SAVED_IDS                   = 7,
+        _SC_VERSION                     = 8,
+
+        // SVR4 names
+        _SC_PASS_MAX                    = 9,
+        _SC_LOGNAME_MAX                 = 10,
+        _SC_PAGESIZE                    = 11,
+        _SC_XOPEN_VERSION               = 12,
+        // 13 reserved for SVr4-ES/MP _SC_NACLS_MAX
+        _SC_NPROCESSORS_CONF            = 14,
+        _SC_NPROCESSORS_ONLN            = 15,
+        _SC_STREAM_MAX                  = 16,
+        _SC_TZNAME_MAX                  = 17,
+
+        // POSIX.4 names
+        _SC_AIO_LISTIO_MAX              = 18,
+        _SC_AIO_MAX                     = 19,
+        _SC_AIO_PRIO_DELTA_MAX          = 20,
+        _SC_ASYNCHRONOUS_IO             = 21,
+        _SC_DELAYTIMER_MAX              = 22,
+        _SC_FSYNC                       = 23,
+        _SC_MAPPED_FILES                = 24,
+        _SC_MEMLOCK                     = 25,
+        _SC_MEMLOCK_RANGE               = 26,
+        _SC_MEMORY_PROTECTION           = 27,
+        _SC_MESSAGE_PASSING             = 28,
+        _SC_MQ_OPEN_MAX                 = 29,
+        _SC_MQ_PRIO_MAX                 = 30,
+        _SC_PRIORITIZED_IO              = 31,
+        _SC_PRIORITY_SCHEDULING         = 32,
+        _SC_REALTIME_SIGNALS            = 33,
+        _SC_RTSIG_MAX                   = 34,
+        _SC_SEMAPHORES                  = 35,
+        _SC_SEM_NSEMS_MAX               = 36,
+        _SC_SEM_VALUE_MAX               = 37,
+        _SC_SHARED_MEMORY_OBJECTS       = 38,
+        _SC_SIGQUEUE_MAX                = 39,
+        _SC_SIGRT_MIN                   = 40,
+        _SC_SIGRT_MAX                   = 41,
+        _SC_SYNCHRONIZED_IO             = 42,
+        _SC_TIMERS                      = 43,
+        _SC_TIMER_MAX                   = 44,
+
+        // XPG4 names
+        _SC_2_C_BIND                    = 45,
+        _SC_2_C_DEV                     = 46,
+        _SC_2_C_VERSION                 = 47,
+        _SC_2_FORT_DEV                  = 48,
+        _SC_2_FORT_RUN                  = 49,
+        _SC_2_LOCALEDEF                 = 50,
+        _SC_2_SW_DEV                    = 51,
+        _SC_2_UPE                       = 52,
+        _SC_2_VERSION                   = 53,
+        _SC_BC_BASE_MAX                 = 54,
+        _SC_BC_DIM_MAX                  = 55,
+        _SC_BC_SCALE_MAX                = 56,
+        _SC_BC_STRING_MAX               = 57,
+        _SC_COLL_WEIGHTS_MAX            = 58,
+        _SC_EXPR_NEST_MAX               = 59,
+        _SC_LINE_MAX                    = 60,
+        _SC_RE_DUP_MAX                  = 61,
+        _SC_XOPEN_CRYPT                 = 62,
+        _SC_XOPEN_ENH_I18N              = 63,
+        _SC_XOPEN_SHM                   = 64,
+        _SC_2_CHAR_TERM                 = 66,
+        _SC_XOPEN_XCU_VERSION           = 67,
+
+        // additional XPG4v2 (UNIX 95) command names
+        _SC_ATEXIT_MAX                  = 76,
+        _SC_IOV_MAX                     = 77,
+        _SC_XOPEN_UNIX                  = 78,
+
+        // defined for XTI (XNS Issue 5) */
+        _SC_T_IOV_MAX                   = 79, // Must be same in <xti.h>
+
+        _SC_PHYS_PAGES                  = 500,
+        _SC_AVPHYS_PAGES                = 501,
+
+        // Hardware specific items
+        // Note that not all items are supported on all architectures
+        _SC_COHER_BLKSZ         = 503,     // Coherence block size
+        _SC_SPLIT_CACHE         = 504,     // != 0 iff a split cache
+        _SC_ICACHE_SZ           = 505,     // Instruction cache size (bytes)
+        _SC_DCACHE_SZ           = 506,     // Data cache size (bytes)
+        _SC_ICACHE_LINESZ       = 507,     // Instruction cache line size
+        _SC_DCACHE_LINESZ       = 508,     // Data cache line size
+        _SC_ICACHE_BLKSZ        = 509,     // Block size invalidated for icache
+        _SC_DCACHE_BLKSZ        = 510,     // Block size for dcache
+        _SC_DCACHE_TBLKSZ       = 511,     // Block size for dcache prefetch
+        _SC_ICACHE_ASSOC        = 512,     // Icache associativity 1, 2, 3 etc
+        _SC_DCACHE_ASSOC        = 513,     // Dcache associativity 1, 2, 3 etc
+
+        _SC_MAXPID              = 514,     // maximum pid value
+        _SC_STACK_PROT          = 515,     // default stack protection
+        _SC_NPROCESSORS_MAX     = 516,     // maximum # of processors
+        _SC_CPUID_MAX           = 517,     // maximum CPU id
+        _SC_EPHID_MAX           = 518,     // maximum ephemeral id
+
+        // POSIX.1c (pthreads) names. These values are defined above
+        // the sub-500 range. See psarc case 1995/257.
+        _SC_THREAD_DESTRUCTOR_ITERATIONS = 568,
+        _SC_GETGR_R_SIZE_MAX            = 569,
+        _SC_GETPW_R_SIZE_MAX            = 570,
+        _SC_LOGIN_NAME_MAX              = 571,
+        _SC_THREAD_KEYS_MAX             = 572,
+        _SC_THREAD_STACK_MIN            = 573,
+        _SC_THREAD_THREADS_MAX          = 574,
+        _SC_TTY_NAME_MAX                = 575,
+        _SC_THREADS                     = 576,
+        _SC_THREAD_ATTR_STACKADDR       = 577,
+        _SC_THREAD_ATTR_STACKSIZE       = 578,
+        _SC_THREAD_PRIORITY_SCHEDULING  = 579,
+        _SC_THREAD_PRIO_INHERIT         = 580,
+        _SC_THREAD_PRIO_PROTECT         = 581,
+        _SC_THREAD_PROCESS_SHARED       = 582,
+        _SC_THREAD_SAFE_FUNCTIONS       = 583,
+
+        // UNIX 98
+        _SC_XOPEN_LEGACY                = 717,
+        _SC_XOPEN_REALTIME              = 718,
+        _SC_XOPEN_REALTIME_THREADS      = 719,
+        _SC_XBS5_ILP32_OFF32            = 720,
+        _SC_XBS5_ILP32_OFFBIG           = 721,
+        _SC_XBS5_LP64_OFF64             = 722,
+        _SC_XBS5_LPBIG_OFFBIG           = 723,
+
+        // UNIX 03
+        _SC_2_PBS                       = 724,
+        _SC_2_PBS_ACCOUNTING            = 725,
+        _SC_2_PBS_CHECKPOINT            = 726,
+        _SC_2_PBS_LOCATE                = 728,
+        _SC_2_PBS_MESSAGE               = 729,
+        _SC_2_PBS_TRACK                 = 730,
+        _SC_ADVISORY_INFO               = 731,
+        _SC_BARRIERS                    = 732,
+        _SC_CLOCK_SELECTION             = 733,
+        _SC_CPUTIME                     = 734,
+        _SC_HOST_NAME_MAX               = 735,
+        _SC_MONOTONIC_CLOCK             = 736,
+        _SC_READER_WRITER_LOCKS         = 737,
+        _SC_REGEXP                      = 738,
+        _SC_SHELL                       = 739,
+        _SC_SPAWN                       = 740,
+        _SC_SPIN_LOCKS                  = 741,
+        _SC_SPORADIC_SERVER             = 742,
+        _SC_SS_REPL_MAX                 = 743,
+        _SC_SYMLOOP_MAX                 = 744,
+        _SC_THREAD_CPUTIME              = 745,
+        _SC_THREAD_SPORADIC_SERVER      = 746,
+        _SC_TIMEOUTS                    = 747,
+        _SC_TRACE                       = 748,
+        _SC_TRACE_EVENT_FILTER          = 749,
+        _SC_TRACE_EVENT_NAME_MAX        = 750,
+        _SC_TRACE_INHERIT               = 751,
+        _SC_TRACE_LOG                   = 752,
+        _SC_TRACE_NAME_MAX              = 753,
+        _SC_TRACE_SYS_MAX               = 754,
+        _SC_TRACE_USER_EVENT_MAX        = 755,
+        _SC_TYPED_MEMORY_OBJECTS        = 756,
+        _SC_V6_ILP32_OFF32              = 757,
+        _SC_V6_ILP32_OFFBIG             = 758,
+        _SC_V6_LP64_OFF64               = 759,
+        _SC_V6_LPBIG_OFFBIG             = 760,
+        _SC_XOPEN_STREAMS               = 761,
+        _SC_IPV6                        = 762,
+        _SC_RAW_SOCKETS                 = 763,
+    }
+    enum _SC_PAGE_SIZE = _SC_PAGESIZE;
+
+    // command names for POSIX pathconf
+    enum {
+        // POSIX.1 names
+        _PC_LINK_MAX            = 1,
+        _PC_MAX_CANON           = 2,
+        _PC_MAX_INPUT           = 3,
+        _PC_NAME_MAX            = 4,
+        _PC_PATH_MAX            = 5,
+        _PC_PIPE_BUF            = 6,
+        _PC_NO_TRUNC            = 7,
+        _PC_VDISABLE            = 8,
+        _PC_CHOWN_RESTRICTED    = 9,
+
+        // POSIX.4 names
+        _PC_ASYNC_IO            = 10,
+        _PC_PRIO_IO             = 11,
+        _PC_SYNC_IO             = 12,
+
+        // UNIX 03 names
+        _PC_ALLOC_SIZE_MIN      = 13,
+        _PC_REC_INCR_XFER_SIZE  = 14,
+        _PC_REC_MAX_XFER_SIZE   = 15,
+        _PC_REC_MIN_XFER_SIZE   = 16,
+        _PC_REC_XFER_ALIGN      = 17,
+        _PC_SYMLINK_MAX         = 18,
+        _PC_2_SYMLINKS          = 19,
+        _PC_ACL_ENABLED         = 20,
+        _PC_MIN_HOLE_SIZE       = 21,
+        _PC_CASE_BEHAVIOR       = 22,
+        _PC_SATTR_ENABLED       = 23,
+        _PC_SATTR_EXISTS        = 24,
+        _PC_ACCESS_FILTERING    = 25,
+
+        // UNIX 08 names
+        _PC_TIMESTAMP_RESOLUTION = 26,
+
+        // Large File Summit names
+        //
+        // This value matches the MIPS ABI choice, but leaves a large gap in th
+        // value space.
+        _PC_FILESIZEBITS        = 67,
+
+        //Extended attributes
+        _PC_XATTR_ENABLED       = 100,
+        _PC_XATTR_EXISTS        = 101
+    }
+
+    enum _PC_LAST = 101;
+}
 
 //
 // File Synchronization (FSC)
@@ -479,6 +783,10 @@ else version( OSX )
     int fsync(int);
 }
 else version( FreeBSD )
+{
+    int fsync(int);
+}
+else version( Solaris )
 {
     int fsync(int);
 }
@@ -619,4 +927,51 @@ else version( FreeBSD )
     useconds_t ualarm(useconds_t, useconds_t);
     int        usleep(useconds_t);
     pid_t      vfork();
+}
+else version( Solaris )
+{
+    char*      crypt(in char*, in char*);
+    char*      ctermid(char*);
+    void       encrypt(ref char[64], int);
+    int        fchdir(int);
+    c_long     gethostid();
+    pid_t      getpgid(pid_t);
+    pid_t      getsid(pid_t);
+    char*      getwd(char*); // LEGACY
+    int        lchown(in char*, uid_t, gid_t);
+    int        lockf(int, int, off_t);
+    int        nice(int);
+    ssize_t    pread(int, void*, size_t, off_t);
+    ssize_t    pwrite(int, in void*, size_t, off_t);
+    pid_t      setpgrp();
+    int        setregid(gid_t, gid_t);
+    int        setreuid(uid_t, uid_t);
+    void       swab(in void*, void*, ssize_t);
+    void       sync();
+    int        truncate(in char*, off_t);
+    useconds_t ualarm(useconds_t, useconds_t);
+    int        usleep(useconds_t);
+    pid_t      vfork();
+
+    static if( __USE_FILE_OFFSET64 )
+    {
+      int        lockf64(int, int, off_t);
+      alias      lockf64 lockf;
+
+      ssize_t    pread64(int, void*, size_t, off_t);
+      alias      pread64 pread;
+
+      ssize_t    pwrite64(int, in void*, size_t, off_t);
+      alias      pwrite64 pwrite;
+
+      int        truncate64(in char*, off_t);
+      alias      truncate64 truncate;
+    }
+    else
+    {
+      int        lockf(int, int, off_t);
+      ssize_t    pread(int, void*, size_t, off_t);
+      ssize_t    pwrite(int, in void*, size_t, off_t);
+      int        truncate(in char*, off_t);
+    }
 }

--- a/libphobos/libdruntime/core/sys/posix/utime.d
+++ b/libphobos/libdruntime/core/sys/posix/utime.d
@@ -63,3 +63,13 @@ else version( FreeBSD )
 
     int utime(in char*, in utimbuf*);
 }
+else version( Solaris )
+{
+    struct utimbuf
+    {
+        time_t  actime;
+        time_t  modtime;
+    }
+
+    int utime(in char*, in utimbuf*);
+}

--- a/libphobos/libdruntime/core/sys/solaris/dlfcn.d
+++ b/libphobos/libdruntime/core/sys/solaris/dlfcn.d
@@ -1,0 +1,120 @@
+module core.sys.solaris.dlfcn;
+
+version(Solaris):
+extern(C):
+nothrow:
+
+import core.sys.posix.dlfcn;
+import core.stdc.config;
+import core.sys.solaris.sys.auxv;
+import core.sys.solaris.sys.mman;
+
+// struct Dl_info in core.sys.posix.dlfcn
+alias Dl_info Dl_info_t;
+
+// Values for dlsym()
+enum RTLD_NEXT    = cast(void*) -1;
+enum RTLD_DEFAULT = cast(void*) -2;
+enum RTLD_SELF    = cast(void*) -3;
+enum RTLD_PROBE   = cast(void*) -4;
+
+// Additional flags to dlopen
+enum RTLD_PARENT   = 0x00200;
+enum RTLD_GROUP    = 0x00400;
+enum RTLD_WORLD    = 0x00800;
+enum RTLD_NODELETE = 0x01000;
+enum RTLD_FIRST    = 0x02000;
+enum RTLD_CONFGEN  = 0x10000;
+
+struct Dl_serpath_t
+{
+    char*   dls_name;
+    uint    dls_flags;
+}
+
+struct Dl_serinfo_t
+{
+    size_t              dls_size;
+    uint                dls_cnt;
+    Dl_serpath_t[1]     dls_serpath;
+}
+
+struct Dl_argsinfo_t
+{
+    c_long  dla_argc;
+    char**  dla_argv;
+    char**  dla_envp;
+    auxv_t* dla_auxv;
+}
+
+struct Dl_mapinfo_t
+{
+    mmapobj_result_t*   dlm_maps;
+    uint                dlm_acnt;
+    uint                dlm_rcnt;
+}
+
+// Flags for Dl_amd64_unwindinfo.dlfi_flags
+enum DLUI_FLG_NOUNWIND = 0x0001;
+enum DLUI_FLG_NOOBJ    = 0x0002;
+
+struct Dl_amd64_unwindinfo_t
+{
+    uint        dlui_version;
+    uint        dlui_flags;
+    char*       dlui_objname;
+    void*       dlui_unwindstart;
+    void*       dlui_unwindend;
+    void*       dlui_segstart;
+    void*       dlui_segend;
+}
+
+struct Dl_definfo_t
+{
+    const(char)*    dld_refname;
+    const(char)*    dld_depname;
+}
+
+alias c_ulong Lmid_t;
+void*   dlmopen(Lmid_t, in char*, int);
+
+// Values for dladdr1() flags
+enum RTLD_DL_SYMENT  = 1;
+enum RTLD_DL_LINKMAP = 2;
+enum RTLD_DL_MASK    = 0xffff;
+int     dladdr1(void* address, Dl_info_t* dlip, void** info, int flags);
+
+// Values for dldump flags
+enum RTLD_REL_RELATIVE = 0x00001;
+enum RTLD_REL_EXEC     = 0x00002;
+enum RTLD_REL_DEPENDS  = 0x00004;
+enum RTLD_REL_PRELOAD  = 0x00008;
+enum RTLD_REL_SELF     = 0x00010;
+enum RTLD_REL_WEAK     = 0x00020;
+enum RTLD_REL_ALL      = 0x00fff;
+enum RTLD_REL_MEMORY   = 0x01000;
+enum RTLD_STRIP        = 0x02000;
+enum RTLD_NOHEAP       = 0x04000;
+enum RTLD_CONFSET      = 0x10000;
+int     dldump(in char*, in char*, int);
+
+// Argumens for dlinfo()
+enum {
+    RTLD_DI_LMID = 1,
+    RTLD_DI_LINKMAP,
+    RTLD_DI_CONFIGADDR,
+    RTLD_DI_SERINFO,
+    RTLD_DI_SERINFOSIZE,
+    RTLD_DI_ORIGIN,
+    RTLD_DI_PROFILENAME,
+    RTLD_DI_PROFILEOUT,
+    RTLD_DI_GETSIGNAL,
+    RTLD_DI_ARGSINFO,
+    RTLD_DI_MMAPS,
+    RTLD_DI_MMAPCNT,
+    RTLD_DI_DEFERRED,
+    RTLD_DI_DEFERRED_SYM
+}
+enum RTLD_DI_MAX = RTLD_DI_DEFERRED_SYM;
+
+int     dlinfo(void*, int, void*);

--- a/libphobos/libdruntime/core/sys/solaris/execinfo.d
+++ b/libphobos/libdruntime/core/sys/solaris/execinfo.d
@@ -1,0 +1,15 @@
+/**
+ * D header file for Solaris.
+ *
+ * Copyright: Copyright Martin Nowak 2012.
+ * License:   $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost License 1.0)
+ * Authors:   Martin Nowak
+ */
+module core.sys.solaris.execinfo;
+
+version (Solaris):
+extern (C):
+
+int backtrace(void** buffer, int size);
+char** backtrace_symbols(const(void*)* buffer, int size);
+void backtrace_symbols_fd(const(void*)* buffer, int size, int fd);

--- a/libphobos/libdruntime/core/sys/solaris/sys/auxv.d
+++ b/libphobos/libdruntime/core/sys/solaris/sys/auxv.d
@@ -1,0 +1,103 @@
+module core.sys.solaris.sys.auxv;
+
+import core.stdc.config;
+
+version(Solaris):
+extern (C):
+nothrow:
+
+struct auxv_t {
+    int     a_type;
+    union __a_un {
+        c_long          a_val;
+        void*           a_ptr;
+        void function() a_fcn;
+    }
+    __a_un  a_un;
+}
+
+version (X86) {
+    version = V386;
+}
+version (X86_64) {
+    version = V386;
+}
+enum {
+    AT_NULL             = 0,
+    AT_IGNORE           = 1,
+    AT_EXECFD           = 2,
+    AT_PHDR             = 3,
+    AT_PHENT            = 4,
+    AT_PHNUM            = 5,
+    AT_PAGESZ           = 6,
+    AT_BASE             = 7,
+    AT_FLAGS            = 8,
+    AT_ENTRY            = 9,
+
+    // Sun extensions
+    AT_SUN_UID          = 2000,
+    AT_SUN_RUID         = 2001,
+    AT_SUN_GID          = 2002,
+    AT_SUN_RGID         = 2003,
+    AT_SUN_LDELF        = 2004,
+    AT_SUN_LDSHDR       = 2005,
+    AT_SUN_LDNAME       = 2006,
+    AT_SUN_LPAGESZ      = 2007,
+    AT_SUN_PLATFORM     = 2008,
+    AT_SUN_HWCAP        = 2009,
+    AT_SUN_HWCAP2       = 2023,
+    AT_SUN_IFLUSH       = 2010,
+    AT_SUN_CPU          = 2011,
+    AT_SUN_EXECNAME     = 2014,
+    AT_SUN_MMU          = 2015,
+    AT_SUN_LDDATA       = 2016,
+    AT_SUN_AUXFLAGS     = 2017,
+    AT_SUN_EMULATOR     = 2018,
+    AT_SUN_BRANDNAME    = 2019,
+    AT_SUN_BRAND_AUX1   = 2020,
+    AT_SUN_BRAND_AUX2   = 2021,
+    AT_SUN_BRAND_AUX3   = 2022,
+
+    AT_SUN_SETUGID      = 0x00000001,
+    AT_SUN_HWCAPVERIFY  = 0x00000002,
+    AT_SUN_SUN_NOPLM    = 0x00000004,
+}
+
+version (V386) {
+    enum {
+        AV_386_FPU          = 0x00001,
+        AV_386_TSC          = 0x00002,
+        AV_386_CX8          = 0x00004,
+        AV_386_SEP          = 0x00008,
+        AV_386_AMD_SYSC     = 0x00010,
+        AV_386_CMOV         = 0x00020,
+        AV_386_MMX          = 0x00040,
+        AV_386_AMD_MMX      = 0x00080,
+        AV_386_AMD_3DNow    = 0x00100,
+        AV_386_AMD_3DNowx   = 0x00200,
+        AV_386_FXSR         = 0x00400,
+        AV_386_SSE          = 0x00800,
+        AV_386_SSE2         = 0x01000,
+                           // 0x02000 withdrawn
+        AV_386_SSE3         = 0x04000,
+                           // 0x08000 withdrawn
+        AV_386_CX16         = 0x10000,
+        AV_386_AHF          = 0x20000,
+        AV_386_TSCP         = 0x40000,
+        AV_386_AMD_SSE4A    = 0x80000,
+        AV_386_POPCNT       = 0x100000,
+        AV_386_AMD_LZCNT    = 0x200000,
+        AV_386_SSSE3        = 0x400000,
+        AV_386_SSE4_1       = 0x800000,
+        AV_386_SSE4_2       = 0x1000000,
+        AV_386_MOVBE        = 0x2000000,
+        AV_386_AES          = 0x40000000,
+        AV_386_PCLMULQDQ    = 0x80000000,
+        AV_386_XSAVE        = 0x100000000,
+        AV_386_AVX          = 0x200000000,
+        AV_386_VMX          = 0x400000000,
+        AV_386_AMD_SVM      = 0x800000000,
+    }
+}
+
+// XXX: add sparc?

--- a/libphobos/libdruntime/core/sys/solaris/sys/mman.d
+++ b/libphobos/libdruntime/core/sys/solaris/sys/mman.d
@@ -1,0 +1,16 @@
+module core.sys.solaris.sys.mman;
+
+import core.sys.posix.sys.types : caddr_t;
+
+version(Solaris):
+extern (C):
+nothrow:
+
+struct mmapobj_result_t {
+    caddr_t     mr_addr;
+    size_t      mr_msize;
+    size_t      mr_fsize;
+    size_t      mr_offset;
+    size_t      mr_prot;
+    size_t      mr_flags;
+}

--- a/libphobos/libdruntime/core/sys/solaris/sys/priocntl.d
+++ b/libphobos/libdruntime/core/sys/solaris/sys/priocntl.d
@@ -1,0 +1,97 @@
+module core.sys.solaris.sys.priocntl;
+
+import core.sys.posix.sys.types : caddr_t, id_t;
+import core.stdc.config : c_long;
+import core.sys.solaris.sys.procset;
+import core.sys.solaris.sys.types : pri_t;
+
+version(Solaris):
+nothrow:
+extern (C):
+
+c_long priocntl(idtype_t, id_t, int, ...);
+c_long priocntlset(procset_t*, int, ...);
+
+enum PC_GETCID       = 0;       /* Get class ID */
+enum PC_GETCLINFO    = 1;       /* Get info about a configured class */
+enum PC_SETPARMS     = 2;       /* Set scheduling parameters */
+enum PC_GETPARMS     = 3;       /* Get scheduling parameters */
+enum PC_ADMIN        = 4;       /* Scheduler administration (used by */
+                                /* dispadmin(1M), not for general use) */
+enum PC_GETPRIRANGE  = 5;       /* Get priority range for a class */
+                                /* posix.4; scheduling, not for general use */
+enum PC_DONICE       = 6;       /* Set or get nice value */
+enum PC_SETXPARMS    = 7;       /* Set extended scheduling parameters */
+enum PC_GETXPARMS    = 8;       /* Get extended scheduling parameters */
+enum PC_SETDFLCL     = 9;       /* Set default class, not for general use */
+enum PC_GETDFLCL     = 10;      /* Get default class, not for general use */
+enum PC_DOPRIO       = 11;      /* Set or get priority, not for general use */
+
+enum PC_CLNULL       = -1;
+
+enum PC_CLNMSZ       = 16;
+enum PC_CLINFOSZ     = (32 / int.sizeof);
+enum PC_CLPARMSZ     = (32 / int.sizeof);
+
+enum PC_GETNICE = 0;
+enum PC_SETNICE = 1;
+
+enum PC_GETPRIO      = 0;
+enum PC_SETPRIO      = 1;
+
+struct pcinfo_t
+{
+    id_t                pc_cid;     // class id
+    char[PC_CLNMSZ]     pc_clname;  // class name
+    int[PC_CLINFOSZ]    pc_clinfo;  // class information
+}
+
+struct pcparms_t
+{
+    id_t                pc_cid;     // process class
+    int[PC_CLPARMSZ]    pc_clparms; //class specific parameters
+}
+
+struct pcnice_t
+{
+    int pc_val; // nice value
+    int pc_op;  // type of operation, set or get
+}
+
+struct pcprio_t
+{
+    int     pc_op;  // type of operation, set or get
+    id_t    pc_cid; // class id
+    int     pc_val; // priority value
+}
+
+// Used by the priocntl varargs interface
+// PC_SETXPARMS and PC_GETXPARMS
+enum PC_VAPARMCNT = 8;  // max # of kv pairs
+enum PC_KY_NULL   = 0;  // kv chain terminator
+enum PC_KY_CLNAME = 1;  // get the class name of a process or LWP
+
+struct pc_vaparm_t {
+    int     pc_key;
+    ulong   pc_parm;
+}
+
+struct pc_vaparms_t
+{
+    int                         pc_vaparmscnt; // # of kv pairs
+    pc_vaparm_t[PC_VAPARMCNT]   pc_parm;
+}
+
+// Not for general use
+struct pcpri_t
+{
+    id_t    pc_cid;
+    pri_t   pc_clpmax;
+    pri_t   pc_clpmin;
+}
+
+struct pcadmin_t
+{
+    id_t    pc_cid;
+    caddr_t pc_cladmin;
+}

--- a/libphobos/libdruntime/core/sys/solaris/sys/procset.d
+++ b/libphobos/libdruntime/core/sys/solaris/sys/procset.d
@@ -1,0 +1,36 @@
+module core.sys.solaris.sys.procset;
+
+import core.sys.posix.sys.types : id_t;
+import core.sys.posix.sys.wait : idtype_t;
+
+version (Solaris):
+nothrow:
+
+enum P_INITPID  = 1;
+enum P_INITUID  = 0;
+enum P_INITPGID = 0;
+
+enum idop_t {
+    POP_DIFF,
+    POP_AND,
+    POP_OR,
+    POP_XOR
+}
+
+struct procset_t {
+    idop_t      p_op;
+    idtype_t    p_lidtype;
+    id_t        p_lid;
+    idtype_t    p_ridtype;
+    id_t        p_rid;
+}
+
+void setprocset(ref procset_t psp, idop_t op, idtype_t ltype, id_t lid, idtype_t rtype, id_t rid)
+{
+    psp.p_op = op;
+    psp.p_lidtype = ltype;
+    psp.p_lid = lid;
+    psp.p_ridtype = rtype;
+    psp.p_rid = rid;
+}
+

--- a/libphobos/libdruntime/core/sys/solaris/sys/types.d
+++ b/libphobos/libdruntime/core/sys/solaris/sys/types.d
@@ -1,0 +1,5 @@
+module core.sys.solaris.sys.types;
+
+alias short pri_t;
+
+enum P_MYID = -1;

--- a/libphobos/src/std/c/solaris/socket.d
+++ b/libphobos/src/std/c/solaris/socket.d
@@ -1,0 +1,44 @@
+// Written in the D programming language.
+
+/*
+ * This module is just for making std.socket work under Solaris, and these
+ * definitions should actually be in druntime. (core.sys.posix.netdb or sth)
+ */
+module std.c.solaris.socket;
+
+public import core.sys.posix.netdb;
+import core.sys.posix.sys.socket;
+
+extern(C):
+
+enum
+{
+    AF_APPLETALK    = 16,
+    AF_IPX          = 23,
+}
+
+//enum // <sys/socket.h>
+//{
+//    SOCK_RDM        = 4,
+//}
+
+//enum
+//{
+//    MSG_NOSIGNAL    = 0x20000,
+//}
+
+enum
+{
+    IPPROTO_IGMP    = 2,
+    IPPROTO_GGP     = 3,
+    IPPROTO_PUP     = 12,
+    IPPROTO_IDP     = 22,
+    IPPROTO_ND      = 77,
+    IPPROTO_MAX     = 256,
+}
+
+enum // <netinet/in.h>
+{
+    INADDR_LOOPBACK = 0x7f000001,
+    INADDR_NONE     = 0xffffffff,
+}

--- a/libphobos/src/std/c/string.d
+++ b/libphobos/src/std/c/string.d
@@ -32,3 +32,8 @@ version (FreeBSD)
 {
     int strerror_r(int errnum, char* buf, size_t buflen);
 }
+
+version (Solaris)
+{
+    int strerror_r(int errnum, char* buf, size_t buflen);
+}

--- a/libphobos/src/std/datetime.d
+++ b/libphobos/src/std/datetime.d
@@ -27756,6 +27756,7 @@ auto tz = TimeZone.getTimeZone("America/Los_Angeles");
             version(FreeBSD) enum utcZone = "Etc/UTC";
             version(linux)   enum utcZone = "UTC";
             version(OSX)     enum utcZone = "UTC";
+            version(Solaris) enum utcZone = "UTC";
 
             auto tzs = [testTZ("America/Los_Angeles", "PST", "PDT", dur!"hours"(-8), dur!"hours"(1)),
                         testTZ("America/New_York", "EST", "EDT", dur!"hours"(-5), dur!"hours"(1)),
@@ -29245,7 +29246,11 @@ public:
     }
 
 
-    version(Posix)
+    version(Solaris)
+    {
+        enum defaultTZDatabaseDir = "/usr/share/lib/zoneinfo/";
+    }
+    else version(Posix)
     {
         /++
             The default directory where the TZ Database files are. It's empty

--- a/libphobos/src/std/file.d
+++ b/libphobos/src/std/file.d
@@ -1721,6 +1721,10 @@ else version (FreeBSD)
 
         return buffer.assumeUnique;
     }
+    else version(Solaris)
+    {
+	    return readLink("/proc/self/object/a.out");
+    }
     else
         static assert(0, "thisExePath is not supported on this platform");
 }

--- a/libphobos/src/std/parallelism.d
+++ b/libphobos/src/std/parallelism.d
@@ -171,6 +171,15 @@ else version(useSysctlbyname)
     }
 
 }
+else version(Solaris)
+{
+	import core.sys.posix.unistd;
+
+	shared static this()
+	{
+		totalCPUs = cast(uint) sysconf(_SC_NPROCESSORS_ONLN);
+	}
+}
 else
 {
     static assert(0, "Don't know how to get N CPUs on this OS.");

--- a/libphobos/src/std/socket.d
+++ b/libphobos/src/std/socket.d
@@ -90,6 +90,15 @@ else version(Posix)
         private enum SD_SEND    = SHUT_WR;
         private enum SD_BOTH    = SHUT_RDWR;
     }
+    else version(Solaris)
+    {
+        import core.sys.posix.sys.socket;
+	import core.sys.posix.sys.select;
+	import std.c.solaris.socket;
+	private enum SD_RECEIVE = SHUT_RD;
+	private enum SD_SEND    = SHUT_WR;
+	private enum SD_BOTH    = SHUT_RDWR;
+    }
     else
         static assert(false);
 
@@ -182,6 +191,14 @@ string formatSocketError(int err)
                 return "Socket error " ~ to!string(err);
         }
         else version (FreeBSD)
+        {
+            auto errs = strerror_r(err, buf.ptr, buf.length);
+            if (errs == 0)
+                cs = buf.ptr;
+            else
+                return "Socket error " ~ to!string(err);
+        }
+        else version (Solaris)
         {
             auto errs = strerror_r(err, buf.ptr, buf.length);
             if (errs == 0)

--- a/libphobos/src/std/stdio.d
+++ b/libphobos/src/std/stdio.d
@@ -68,6 +68,11 @@ version (FreeBSD)
     version = GENERIC_IO;
 }
 
+version (Solaris)
+{
+    version = GENERIC_IO;
+}
+
 version (MinGW)
 {
     version = MINGW_IO;


### PR DESCRIPTION
This will allow gdc to build on Solarish platforms.  There will be more work needed in the bundled phobos libraries though to get it build.
