### PR TITLE
Implement __builtin_volatile_load and __builtin_volatile_store

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,12 @@
+2014-08-01  Johannes Pfau  <johannespfau@gmail.com>
+
+	* d-builtins.cc(build_volatile_load_builtin): New function.
+	(build_volatile_store_builtin): New function.
+	(d_build_builtins_module): Implement __builtin_volatile_load
+	and __builtin_volatile_store.
+	* d-codegen.cc(expand_intrinsic): Likewise.
+	* d-intrinsics.def: Likewise.
+
 2014-07-29  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-elem.cc(NewExp::toElem): Check for opaque structs before

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -796,9 +796,10 @@ d_fe_attribute_p (const char* name)
     {
       // Build the table of frontend only attributes exposed to the language.
       table = new StringTable();
-      table->_init(2);
+      table->_init(3);
       table->insert("notypeinfo", strlen("notypeinfo"));
       table->insert("nocode", strlen("nocode"));
+      table->insert("noinit", strlen("noinit"));
     }
 
   return table->lookup(name, strlen(name)) != NULL;

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -2746,6 +2746,7 @@ expand_intrinsic (tree callexp)
 {
   CallExpr ce (callexp);
   tree callee = ce.callee();
+  tree volatile_type;
 
   if (POINTER_TYPE_P (TREE_TYPE (callee)))
     callee = TREE_OPERAND (callee, 0);
@@ -2842,6 +2843,22 @@ expand_intrinsic (tree callexp)
 	  op1 = ce.nextArg();
 	  op2 = ce.nextArg();
 	  return expand_intrinsic_vastart (callexp, op1, op2);
+
+	case INTRINSIC_VOLATILE_LOAD:
+	  op1 = ce.nextArg();
+	  volatile_type = build_qualified_type (TREE_TYPE (callexp), TYPE_QUAL_VOLATILE);
+	  callexp = indirect_ref (volatile_type, op1);
+	  TREE_THIS_VOLATILE (callexp) = true;
+	  return callexp;
+
+	case INTRINSIC_VOLATILE_STORE:
+	  op1 = ce.nextArg();
+	  op2 = ce.nextArg();
+	  volatile_type = build_qualified_type (TREE_TYPE (op2), TYPE_QUAL_VOLATILE);
+	  callexp = indirect_ref (volatile_type, op1);
+	  TREE_THIS_VOLATILE (callexp) = true;
+	  callexp = modify_expr (volatile_type, callexp, op2);
+	  return callexp;
 
 	default:
 	  gcc_unreachable();

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -798,6 +798,7 @@ d_fe_attribute_p (const char* name)
       table = new StringTable();
       table->_init(2);
       table->insert("notypeinfo", strlen("notypeinfo"));
+      table->insert("nocode", strlen("nocode"));
     }
 
   return table->lookup(name, strlen(name)) != NULL;

--- a/gcc/d/d-codegen.h
+++ b/gcc/d/d-codegen.h
@@ -113,6 +113,7 @@ extern tree d_array_type (Type *d_type, uinteger_t size);
 extern tree insert_type_attribute (tree type, const char *attrname, tree value = NULL_TREE);
 extern void insert_decl_attribute (tree type, const char *attrname, tree value = NULL_TREE);
 extern tree build_attributes (Expressions *in_attrs);
+extern StructLiteralExp *getUDA (const char* name, UserAttributeDeclaration *declattrs);
 extern tree insert_type_modifiers (tree type, unsigned mod);
 
 extern tree build_two_field_type (tree t1, tree t2, Type *type, const char *n1, const char *n2);

--- a/gcc/d/d-intrinsics.def
+++ b/gcc/d/d-intrinsics.def
@@ -42,6 +42,7 @@
 #define CORE_VARARG     "core.stdc.stdarg"
 #define CORE_MATH	"core.math"
 #define STD_MATH	"std.math"
+#define GCC_BUILTINS	"gcc.builtins"
 
 // Signature decorations
 #define FN_SAFE_PURE_NOTHROW	"FNaNbNf"   // @safe pure nothrow function
@@ -116,12 +117,16 @@ DEF_D_INTRINSIC (VA_ARG, VA_ARG, "va_arg", CORE_VARARG, "void(ref va_list ap, re
 DEF_D_INTRINSIC (C_VA_ARG, C_VA_ARG, "va_arg", CORE_VARARG, "T(ref va_list ap)")
 DEF_D_INTRINSIC (VASTART, VASTART, "va_start", CORE_VARARG, "void(out va_list ap, ref T parmn)")
 
+// volatile load/store intrinsics (actually in gcc.builtins)
+DEF_D_INTRINSIC (VOLATILE_LOAD, VOLATILE_LOAD, "__builtin_volatile_load", GCC_BUILTINS, "nothrow @system T(T*)")
+DEF_D_INTRINSIC (VOLATILE_STORE, VOLATILE_STORE, "__builtin_volatile_store", GCC_BUILTINS, "nothrow @system void(T*, T)")
 
 // Remove helper macros
 #undef DEF_D_INTRINSIC
 #undef CORE_BITOP
 #undef CORE_VARARG
 #undef CORE_MATH
+#undef GCC_BUILTINS
 #undef STD_MATH
 #undef FN_SAFE_PURE_NOTHROW
 #undef FN_PURE_NOTHROW

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -1648,6 +1648,9 @@ d_handle_forceinline_attribute (tree *node, tree name,
       DECL_DECLARED_INLINE_P (*node) = 1;
       DECL_NO_INLINE_WARNING_P (*node) = 1;
       DECL_DISREGARD_INLINE_LIMITS (*node) = 1;
+      TREE_PUBLIC (*node) = 0;
+      DECL_WEAK (*node) = 0;
+      DECL_COMDAT (*node) = 0;
     }
   else
     {

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -1114,6 +1114,8 @@ FuncDeclaration::toObjFile (int)
 {
   if (!global.params.useUnitTests && isUnitTestDeclaration())
     return;
+  if (getUDA("nocode", userAttribDecl))
+    return;
 
   // Already generated the function.
   if (semanticRun >= PASSobj)

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -192,7 +192,8 @@ StructDeclaration::toObjFile (int)
     toDebug();
 
   // Generate TypeInfo
-  type->getTypeInfo (NULL);
+  if (!getUDA("notypeinfo", userAttribDecl))
+    type->getTypeInfo (NULL);
 
   // Generate static initialiser
   toInitializer();
@@ -251,7 +252,8 @@ ClassDeclaration::toObjFile (int)
   d_finish_symbol (sinit);
 
   // Put out the TypeInfo
-  type->getTypeInfo (NULL);
+  if (!getUDA("notypeinfo", userAttribDecl))
+    type->getTypeInfo (NULL);
 
   // must be ClassInfo.size
   size_t offset = CLASSINFO_SIZE;
@@ -602,7 +604,8 @@ InterfaceDeclaration::toObjFile (int)
   toSymbol();
 
   // Put out the TypeInfo
-  type->getTypeInfo (NULL);
+  if (!getUDA("notypeinfo", userAttribDecl))
+    type->getTypeInfo (NULL);
   type->vtinfo->toObjFile (0);
 
   /* Put out the ClassInfo.
@@ -731,7 +734,8 @@ EnumDeclaration::toObjFile (int)
     toDebug();
 
   // Generate TypeInfo
-  type->getTypeInfo (NULL);
+  if (!getUDA("notypeinfo", userAttribDecl))
+    type->getTypeInfo (NULL);
 
   TypeEnum *tc = (TypeEnum *) type;
   if (tc->sym->members && !type->isZeroInit())
@@ -856,7 +860,8 @@ TypedefDeclaration::toObjFile (int)
     toDebug();
 
   // Generate TypeInfo
-  type->getTypeInfo (NULL);
+  if (!getUDA("notypeinfo", userAttribDecl))
+    type->getTypeInfo (NULL);
 
   TypeTypedef *tc = (TypeTypedef *) type;
   if (tc->sym->init && !type->isZeroInit())

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -1458,7 +1458,7 @@ Module::genobjfile (int)
 
   // Default behaviour is to always generate module info because of templates.
   // Can be switched off for not compiling against runtime library.
-  if (!global.params.betterC && ident != Id::entrypoint)
+  if (!nomoduleinfo && !global.params.betterC && ident != Id::entrypoint)
     {
       ModuleInfo *mi = current_module_info;
 

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -196,11 +196,13 @@ StructDeclaration::toObjFile (int)
     type->getTypeInfo (NULL);
 
   // Generate static initialiser
-  toInitializer();
-  toDt (&sinit->Sdt);
-
-  sinit->Sreadonly = true;
-  d_finish_symbol (sinit);
+  if (!getUDA("notypeinfo", userAttribDecl))
+    {
+      toInitializer();
+      toDt (&sinit->Sdt);
+      sinit->Sreadonly = true;
+      d_finish_symbol (sinit);
+    }
 
   // Put out the members
   for (size_t i = 0; i < members->dim; i++)
@@ -244,12 +246,15 @@ ClassDeclaration::toObjFile (int)
   // Generate C symbols
   toSymbol();
   toVtblSymbol();
-  sinit = toInitializer();
 
   // Generate static initialiser
-  toDt (&sinit->Sdt);
-  sinit->Sreadonly = true;
-  d_finish_symbol (sinit);
+  if (!getUDA("noinit", userAttribDecl))
+    {
+      sinit = toInitializer();
+      toDt (&sinit->Sdt);
+      sinit->Sreadonly = true;
+      d_finish_symbol (sinit);
+    }
 
   // Put out the TypeInfo
   if (!getUDA("notypeinfo", userAttribDecl))
@@ -738,7 +743,7 @@ EnumDeclaration::toObjFile (int)
     type->getTypeInfo (NULL);
 
   TypeEnum *tc = (TypeEnum *) type;
-  if (tc->sym->members && !type->isZeroInit())
+  if (tc->sym->members && !type->isZeroInit() && !getUDA("noinit", userAttribDecl))
     {
       // Generate static initialiser
       toInitializer();
@@ -864,7 +869,7 @@ TypedefDeclaration::toObjFile (int)
     type->getTypeInfo (NULL);
 
   TypeTypedef *tc = (TypeTypedef *) type;
-  if (tc->sym->init && !type->isZeroInit())
+  if (tc->sym->init && !type->isZeroInit() && !getUDA("notypeinfo", userAttribDecl))
     {
       // Generate static initialiser
       toInitializer();

--- a/gcc/d/dfrontend/attrib.c
+++ b/gcc/d/dfrontend/attrib.c
@@ -1174,6 +1174,16 @@ void PragmaDeclaration::semantic(Scope *sc)
 #endif
         }
     }
+#if IN_GCC
+    else if (ident == Id::GNU_no_moduleinfo)
+    {
+        if (args && args->dim > 0)
+             error(Loc(), "takes no parameters");
+
+        sc->module->nomoduleinfo = true;
+        goto Lnodecl;
+    }
+#endif
     else if (global.params.ignoreUnsupportedPragmas)
     {
         if (global.params.verbose)

--- a/gcc/d/dfrontend/idgen.c
+++ b/gcc/d/dfrontend/idgen.c
@@ -270,6 +270,11 @@ Msgtable msgtable[] =
     { "startaddress" },
     { "mangle" },
 
+#ifdef IN_GCC
+    // GDC-specific pragmas.
+    { "GNU_no_moduleinfo" },
+#endif
+
     // For special functions
     { "tohash", "toHash" },
     { "tostring", "toString" },

--- a/gcc/d/dfrontend/module.c
+++ b/gcc/d/dfrontend/module.c
@@ -58,6 +58,7 @@ Module::Module(const char *filename, Identifier *ident, int doDocComment, int do
     members = NULL;
     isDocFile = 0;
     needmoduleinfo = 0;
+    nomoduleinfo = 0;
     selfimports = 0;
     insearch = 0;
     decldefs = NULL;

--- a/gcc/d/dfrontend/module.h
+++ b/gcc/d/dfrontend/module.h
@@ -82,6 +82,7 @@ public:
     unsigned numlines;  // number of lines in source file
     int isDocFile;      // if it is a documentation input file, not D source
     int needmoduleinfo;
+    int nomoduleinfo;   // don't emit moduleinfo
 
     int selfimports;            // 0: don't know, 1: does not, 2: does
     int selfImports();          // returns !=0 if module imports itself

--- a/gcc/testsuite/gdc.test/compilable/gdc.d
+++ b/gcc/testsuite/gdc.test/compilable/gdc.d
@@ -17,3 +17,71 @@ void flatten()
 {
 }
 
+/* Tests for __builtin_volatile_load/store. ASM needs to be verified manually  */
+
+import gcc.builtins;
+
+enum xptr = cast(int*)0xDEADBEEF;
+enum xptr2 = cast(int*)0x42;
+
+// Verify that every load is emitted
+void testVolatile1()
+{
+    while(true)
+    {
+        auto x = __builtin_volatile_load(xptr);
+    }
+}
+
+// Verify that every load is emitted
+void testVolatile2()
+{
+    auto x = __builtin_volatile_load(xptr);
+    x = __builtin_volatile_load(xptr);
+    x = __builtin_volatile_load(xptr);
+}
+
+// Verify that every load is emitted
+void testVolatile3()
+{
+    __builtin_volatile_load(xptr);
+    __builtin_volatile_load(xptr);
+    __builtin_volatile_load(xptr);
+}
+
+// ensure ordering of volatile accesses
+void testVolatile4()
+{
+    auto x = __builtin_volatile_load(xptr);
+    x = __builtin_volatile_load(xptr2);
+    x = __builtin_volatile_load(xptr);
+    x = __builtin_volatile_load(xptr2);
+    x = __builtin_volatile_load(xptr);
+}
+
+// Verify that every store is emitted
+void testVolatile5()
+{
+    while(true)
+    {
+        __builtin_volatile_store(xptr, 0);
+    }
+}
+
+// Verify that every store is emitted
+void testVolatile6()
+{
+    __builtin_volatile_store(xptr, 0);
+    __builtin_volatile_store(xptr, 0);
+    __builtin_volatile_store(xptr, 0);
+}
+
+// ensure ordering of volatile accesses
+void testVolatile7()
+{
+    __builtin_volatile_store(xptr, 0);
+    __builtin_volatile_store(xptr2, 0);
+    __builtin_volatile_store(xptr, 0);
+    __builtin_volatile_store(xptr2, 0);
+    __builtin_volatile_store(xptr, 0);
+}

--- a/gcc/testsuite/gdc.test/runnable/gdc.d
+++ b/gcc/testsuite/gdc.test/runnable/gdc.d
@@ -719,6 +719,58 @@ void test142()
 
 /******************************************/
 
+// Tests for __builtin_volatile_load / __builtin_volatile_store
+import gcc.builtins;
+
+void testVolatile1()
+{
+    int local;
+    __builtin_volatile_store(&local, 42);
+    assert(local == 42);
+}
+
+void testVolatile2()
+{
+    int local = 42;
+    assert(__builtin_volatile_load(&local) == 42);
+    local = 0;
+    assert(__builtin_volatile_load(&local) == 0);
+}
+
+struct NonPOD
+{
+    int x;
+    ~this()
+    {
+        x++;
+    }
+}
+
+struct POD
+{
+    int x, y, z;
+    double x1, y1, z1;
+}
+
+void testVolatile3()
+{
+    assert(!__traits(compiles, __builtin_volatile_load(cast(NonPOD*)0xDEADBEEF)));
+    assert(!__traits(compiles, __builtin_volatile_load(cast(POD*)0xDEADBEEF)));
+    assert(__traits(compiles, __builtin_volatile_load(cast(ubyte*)0xDEADBEEF)));
+    assert(__traits(compiles, __builtin_volatile_load(cast(ushort*)0xDEADBEEF)));
+    assert(__traits(compiles, __builtin_volatile_load(cast(uint*)0xDEADBEEF)));
+    assert(__traits(compiles, __builtin_volatile_load(cast(ulong*)0xDEADBEEF)));
+
+    assert(!__traits(compiles, __builtin_volatile_store(cast(NonPOD*)0xDEADBEEF, NonPOD.init)));
+    assert(!__traits(compiles, __builtin_volatile_store(cast(POD*)0xDEADBEEF, POD.init)));
+    assert(__traits(compiles, __builtin_volatile_store(cast(ubyte*)0xDEADBEEF, ubyte.init)));
+    assert(__traits(compiles, __builtin_volatile_store(cast(ushort*)0xDEADBEEF, ushort.init)));
+    assert(__traits(compiles, __builtin_volatile_store(cast(uint*)0xDEADBEEF, uint.init)));
+    assert(__traits(compiles, __builtin_volatile_store(cast(ulong*)0xDEADBEEF, ulong.init)));
+}
+
+/******************************************/
+
 void main()
 {
     test2();
@@ -738,6 +790,9 @@ void main()
     test131();
     test133();
     test141();
+    testVolatile1();
+    testVolatile2();
+    testVolatile3();
 
     printf("Success!\n");
 }


### PR DESCRIPTION
Currently limited to isIntegral types. PODs could work as well, but the current implementation doesn't work with aggregate types (I guess the declarations/members have to be marked as volatile as well? It's quite a mystery to me when GCC uses what flag. For example TYPE_VOLATILE doesn't do anything without TREE_THIS_VOLATILE on the INDIRECT_REF).

Also loading a complete aggregate with such a builtin is probably almost always a performance problem (because of volatile guarantees you always have to load the complete struct, even if only one field is accessed. So it's better to expose a 'flat' API)
