### PR TITLE
Change `const __sync_op_and` to `enum __sync_op_and`

### DIFF
--- a/libphobos/libdruntime/gcc/atomics.d
+++ b/libphobos/libdruntime/gcc/atomics.d
@@ -28,7 +28,7 @@ import gcc.builtins;
  */
 private template __sync_op_and(string op1, string op2)
 {
-    const __sync_op_and = `
+    enum __sync_op_and = `
 T __sync_` ~ op1 ~ `_and_` ~ op2 ~ `(T)(const ref shared T ptr, T value)
 {
     static if (T.sizeof == byte.sizeof)


### PR DESCRIPTION
See http://forum.dlang.org/post/kolzqasjupljvqzivtjf@forum.dlang.org

> 1. In the data segment there is some source code as ascii text 
>    from a template in gcc/atomics.d . This is in the actual data 
>    segment and not in debug info segments and goes into the data 
>    segment of the executable. I do not see any code using this data. 
>    Why is this in the executable and is it possible to remove it?
