### PR TITLE
cruntime_*: fix a typo

### DIFF
--- a/gcc/d/patches/patch-versym-os-5.x
+++ b/gcc/d/patches/patch-versym-os-5.x
@@ -260,7 +260,7 @@ These official OS versions are not implemented:
 +	if (OPTION_GLIBC)					\
 +	  {							\
 +	    builtin_define ("GNU_GLibc");			\
-+	    builtin_define ("CRuntime_GLibc");			\
++	    builtin_define ("CRuntime_Glibc");			\
 +	  }							\
 +	else if (OPTION_UCLIBC)					\
 +	  {							\


### PR DESCRIPTION
DMD uses a lower 'l' here.

---

Oops.
