### PR TITLE
Support @attribute("weak"), @attribute("alias")

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,6 +1,9 @@
 2015-04-05  Johannes Pfau  <johannespfau@gmail.com>
 
 	* d-lang.cc(d_handle_section_attribute): New function.
+	* d-builtins.cc(handle_alias_attribute): Move to d-lang.cc to
+	support attribute(alias) in user code.
+	* d-lang.cc(d_handle_alias_attribute): Ditto.
 
 2015-03-21  Johannes Pfau  <johannespfau@gmail.com>
 

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -4,6 +4,7 @@
 	* d-builtins.cc(handle_alias_attribute): Move to d-lang.cc to
 	support attribute(alias) in user code.
 	* d-lang.cc(d_handle_alias_attribute): Ditto.
+	* d-lang.cc(d_handle_weak_attribute): New function.
 
 2015-03-21  Johannes Pfau  <johannespfau@gmail.com>
 

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -5,6 +5,8 @@
 	support attribute(alias) in user code.
 	* d-lang.cc(d_handle_alias_attribute): Ditto.
 	* d-lang.cc(d_handle_weak_attribute): New function.
+	* d-decls.cc(FuncDeclaration::toSymbol): Do not set
+	DECL_DECLARED_INLINE_P prematurely.
 
 2015-03-21  Johannes Pfau  <johannespfau@gmail.com>
 

--- a/gcc/d/d-builtins.cc
+++ b/gcc/d/d-builtins.cc
@@ -56,7 +56,6 @@ static tree handle_type_generic_attribute (tree *, tree, tree, int, bool *);
 static tree handle_transaction_pure_attribute (tree *, tree, tree, int, bool *);
 static tree handle_returns_twice_attribute (tree *, tree, tree, int, bool *);
 static tree handle_fnspec_attribute (tree *, tree, tree, int, bool *);
-static tree handle_alias_attribute (tree *, tree, tree, int, bool *);
 static tree handle_weakref_attribute (tree *, tree, tree, int, bool *);
 static tree ignore_attribute (tree *, tree, tree, int, bool *);
 
@@ -1040,8 +1039,6 @@ const attribute_spec d_builtins_attribute_table[] =
      source code and signals that it may be overridden by machine tables.  */
   { "*tm regparm",            0, 0, false, true, true,
 			      ignore_attribute, false },
-  { "alias",                  1, 1, true,  false, false,
-			      handle_alias_attribute, false },
   { "weakref",                0, 1, true,  false, false,
 			      handle_weakref_attribute, false },
   { NULL,                     0, 0, false, false, false, NULL, false }
@@ -1333,29 +1330,6 @@ handle_fnspec_attribute (tree *node ATTRIBUTE_UNUSED, tree ARG_UNUSED (name),
   gcc_assert (args
 	      && TREE_CODE (TREE_VALUE (args)) == STRING_CST
 	      && !TREE_CHAIN (args));
-  return NULL_TREE;
-}
-
-/* Handle an "alias" or "ifunc" attribute; arguments as in
-   struct attribute_spec.handler.  */
-
-static tree
-handle_alias_attribute (tree *node, tree ARG_UNUSED (name),
-			tree args, int ARG_UNUSED (flags),
-			bool *no_add_attrs ATTRIBUTE_UNUSED)
-{
-  gcc_assert (TREE_CODE (*node) == FUNCTION_DECL);
-  gcc_assert (!DECL_INITIAL (*node));
-  gcc_assert (!decl_function_context (*node));
-
-  tree id = TREE_VALUE (args);
-  gcc_assert (TREE_CODE (id) == STRING_CST);
-
-  id = get_identifier (TREE_STRING_POINTER (id));
-  /* This counts as a use of the object pointed to.  */
-  TREE_USED (id) = 1;
-  DECL_INITIAL (*node) = error_mark_node;
-
   return NULL_TREE;
 }
 

--- a/gcc/d/d-decls.cc
+++ b/gcc/d/d-decls.cc
@@ -393,12 +393,6 @@ FuncDeclaration::toSymbol()
 	  DECL_DECLARED_INLINE_P (fndecl) = 1;
 	  DECL_NO_INLINE_WARNING_P (fndecl) = 1;
 	}
-      // Don't know what to do with this.
-      else if (flag_inline_functions)
-	{
-	  DECL_DECLARED_INLINE_P (fndecl) = 1;
-	  DECL_NO_INLINE_WARNING_P (fndecl) = 1;
-	}
 
       if (naked)
 	{

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -43,6 +43,7 @@ static tree d_handle_flatten_attribute(tree *, tree, tree, int, bool *);
 static tree d_handle_target_attribute(tree *, tree, tree, int, bool *);
 static tree d_handle_noclone_attribute(tree *, tree, tree, int, bool *);
 static tree d_handle_section_attribute(tree *, tree, tree, int, bool *);
+static tree d_handle_alias_attribute (tree *, tree, tree, int, bool *);
 
 static const char *iprefix_dir = NULL;
 static const char *imultilib_dir = NULL;
@@ -63,6 +64,8 @@ static const attribute_spec d_attribute_table[] =
 				d_handle_noclone_attribute, false },
     { "section",                1, 1, true,  false, false,
 				d_handle_section_attribute, false },
+    { "alias",                  1, 1, true,  false, false,
+				d_handle_alias_attribute, false },
     { NULL,                     0, 0, false, false, false, NULL, false }
 };
 
@@ -1815,6 +1818,65 @@ d_handle_section_attribute (tree *node, tree ARG_UNUSED (name), tree args,
     }
 
   return NULL_TREE;
+}
+
+/* Handle an "alias" attribute; arguments as in
+   struct attribute_spec.handler.  */
+
+static tree
+d_handle_alias_attribute (tree *node, tree ARG_UNUSED (name),
+			  tree args, int ARG_UNUSED (flags),
+			  bool *no_add_attrs ATTRIBUTE_UNUSED)
+{
+  tree decl = *node;
+
+  if (TREE_CODE (decl) != FUNCTION_DECL
+      && TREE_CODE (decl) != VAR_DECL)
+    {
+      warning (OPT_Wattributes, "%qE attribute ignored", name);
+      *no_add_attrs = true;
+      return NULL_TREE;
+    }
+  else if ((TREE_CODE (decl) == FUNCTION_DECL && DECL_INITIAL (decl))
+      || (TREE_CODE (decl) != FUNCTION_DECL
+	  && TREE_PUBLIC (decl) && !DECL_EXTERNAL (decl))
+      /* A static variable declaration is always a tentative definition,
+	 but the alias is a non-tentative definition which overrides.  */
+      || (TREE_CODE (decl) != FUNCTION_DECL
+	  && ! TREE_PUBLIC (decl) && DECL_INITIAL (decl)))
+    {
+      error ("%q+D defined both normally and as %qE attribute", decl, name);
+      *no_add_attrs = true;
+      return NULL_TREE;
+    }
+  else if (decl_function_context (decl))
+    {
+      error ("%q+D alias functions must be global", name);
+      *no_add_attrs = true;
+      return NULL_TREE;
+    }
+  else
+    {
+      tree id;
+
+      id = TREE_VALUE (args);
+      if (TREE_CODE (id) != STRING_CST)
+	{
+	  error ("attribute %qE argument not a string", name);
+	  *no_add_attrs = true;
+	  return NULL_TREE;
+	}
+      id = get_identifier (TREE_STRING_POINTER (id));
+      /* This counts as a use of the object pointed to.  */
+      TREE_USED (id) = 1;
+
+      if (TREE_CODE (decl) == FUNCTION_DECL)
+	DECL_INITIAL (decl) = error_mark_node;
+      else
+	TREE_STATIC (decl) = 1;
+
+      return NULL_TREE;
+    }
 }
 
 struct lang_hooks lang_hooks = LANG_HOOKS_INITIALIZER;


### PR DESCRIPTION
@ibuclaw How should I replace the asserts in `d_handle_alias_attribute`? Simply ignorethe attribute like GCC does or report an error?
