### PR TITLE
Bug 27 - Undefined interface functions when inheriting from two sources.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,16 @@
+2015-04-07  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-objfile.cc(output_declaration_p): Remove check for semanticRun.
+	(FuncDeclaration::toObjFile): Name bool parameter force_p, allow it to
+	override the initial output_declaration_p check.  Force run all
+	semantic passes for symbols that it routine is generating code for.
+	(d_finish_function): Don't mark TREE_STATIC on functions that are
+	really DECL_EXTERN.
+	(finish_thunk): Force thunks referencing external methods to be
+	expanded to gimple.
+	* d-decls.cc(FuncDeclaration::toThunkSymbol): Call toObjFile on all
+	thunk target functions.
+
 2015-04-05  Johannes Pfau  <johannespfau@gmail.com>
 
 	* d-lang.cc(d_handle_section_attribute): New function.

--- a/gcc/d/d-decls.cc
+++ b/gcc/d/d-decls.cc
@@ -461,6 +461,7 @@ FuncDeclaration::toThunkSymbol (int offset)
   Thunk *thunk;
 
   toSymbol();
+  toObjFile(true);
 
   /* If the thunk is to be static (that is, it is being emitted in this
      module, there can only be one FUNCTION_DECL for it.   Thus, there

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -1096,10 +1096,6 @@ output_declaration_p (Dsymbol *dsym)
 
   if (fd != NULL)
     {
-      // If have already started emitting, continue doing so.
-      if (fd->semanticRun >= PASSobj)
-	return true;
-
       if (fd->isNested())
 	{
 	  // Typically, an error occurred whilst compiling
@@ -1146,7 +1142,7 @@ output_declaration_p (Dsymbol *dsym)
 // down to assembler language output.
 
 void
-FuncDeclaration::toObjFile(bool)
+FuncDeclaration::toObjFile(bool force_p)
 {
   // Already generated the function.
   if (semanticRun >= PASSobj)
@@ -1168,8 +1164,15 @@ FuncDeclaration::toObjFile(bool)
       return;
     }
 
-  if (!output_declaration_p(this))
+  if (!force_p && !output_declaration_p(this))
     return;
+
+  // Ensure all semantic passes have ran.
+  if (semanticRun < PASSsemantic3)
+    {
+      functionSemantic3();
+      Module::runDeferredSemantic3();
+    }
 
   if (global.errors)
     return;
@@ -1876,22 +1879,24 @@ d_finish_function (FuncDeclaration *fd)
 
   gcc_assert (TREE_CODE (decl) == FUNCTION_DECL);
 
-  if (DECL_SAVED_TREE (decl) != NULL_TREE)
+  if (output_declaration_p (fd))
     {
-      TREE_STATIC (decl) = 1;
-      DECL_EXTERNAL (decl) = 0;
+      if (DECL_SAVED_TREE (decl) != NULL_TREE)
+	{
+	  TREE_STATIC (decl) = 1;
+	  DECL_EXTERNAL (decl) = 0;
+	}
+
+      if (!targetm.have_ctors_dtors)
+	{
+	  if (DECL_STATIC_CONSTRUCTOR (decl))
+	    static_ctor_list.safe_push (fd);
+	  if (DECL_STATIC_DESTRUCTOR (decl))
+	    static_dtor_list.safe_push (fd);
+	}
     }
 
   d_add_global_declaration (decl);
-
-  if (!targetm.have_ctors_dtors)
-    {
-      if (DECL_STATIC_CONSTRUCTOR (decl))
-	static_ctor_list.safe_push (fd);
-      if (DECL_STATIC_DESTRUCTOR (decl))
-	static_dtor_list.safe_push (fd);
-    }
-
   cgraph_node::finalize_function (decl, true);
 }
 
@@ -2140,11 +2145,17 @@ finish_thunk (tree thunk_decl, tree target_decl, int offset)
   if (DECL_ONE_ONLY (target_decl))
     thunk_node->add_to_same_comdat_group (funcn);
 
-  if (!targetm.asm_out.can_output_mi_thunk (thunk_decl, fixed_offset,
-					    virtual_value, alias))
+  /* Target assemble_mi_thunk doesn't work across section boundaries
+     on many targets, instead force thunk to be expanded in gimple.  */
+  if (DECL_EXTERNAL (target_decl))
     {
-      /* if varargs... */
-      sorry ("backend for this target machine does not support thunks");
+      if (!stdarg_p (TREE_TYPE (thunk_decl)))
+	{
+	  /* Put generic thunk into COMDAT.  */
+	  d_comdat_linkage (thunk_decl);
+	  thunk_node->create_edge (funcn, NULL, 0, CGRAPH_FREQ_BASE);
+	  thunk_node->expand_thunk (false, true);
+	}
     }
 }
 


### PR DESCRIPTION
Finally fix bug 27.

http://bugzilla.gdcproject.org/show_bug.cgi?id=27

@jpf91 - You also wanted to try and implement cross-module inlining.  This should at least be a first step in making that possible.  As of 2.067, semantic3 is ran on all functions that are passed to canInline, so the following might be possible.

```
if (global.params.useInline)
{
    if (canInline (this, this->needThis(), 0, 0))
        this->toObjFile(true/*force_p*/);
}
```
