### PR TITLE
Implement -fno-rtti

### DIFF
--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -360,6 +360,8 @@ convert_expr (tree exp, Type *etype, Type *totype)
 	  }
 
 	// The offset can only be determined at runtime, do dynamic cast
+	if (global.params.noTypeinfo)
+	  error (global.params.noTypeinfo, "Can't use dynamic cast");
 	tree args[2];
 	args[0] = exp;
 	args[1] = build_address(cdto->toSymbol()->Stree);

--- a/gcc/d/d-elem.cc
+++ b/gcc/d/d-elem.cc
@@ -2348,6 +2348,12 @@ ArrayLiteralExp::toElem (IRState *irs)
   if (tb->ty == Tsarray)
     return d_convert (type->toCtype(), ctor);
 
+  if (global.params.noTypeinfo)
+    {
+      error (global.params.noTypeinfo, "Can't use array literal");
+      return error_mark_node;
+    }
+
   args[0] = build_typeinfo (etype->arrayOf());
   args[1] = build_integer_cst (elements->dim, size_type_node);
 

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -176,6 +176,7 @@ d_init_options(unsigned int, cl_decoded_option *decoded_options)
   global.params.useDeprecated = 1;
   global.params.betterC = false;
   global.params.allInst = false;
+  global.params.noTypeinfo = NULL;
 
   global.params.linkswitches = new Strings();
   global.params.libfiles = new Strings();
@@ -472,6 +473,10 @@ d_handle_option (size_t scode, const char *arg, int value,
 
     case OPT_femit_moduleinfo:
       global.params.betterC = !value;
+      break;
+
+    case OPT_frtti:
+      global.params.noTypeinfo = value ? NULL : "%s: TypeInfo disabled using -fno-rtti switch.";
       break;
 
     case OPT_fignore_unknown_pragmas:

--- a/gcc/d/d-todt.cc
+++ b/gcc/d/d-todt.cc
@@ -894,7 +894,7 @@ ClassDeclaration::toDt2(dt_t **pdt, ClassDeclaration *cd)
 	      tree dt = build_address(cd2->toSymbol()->Stree);
 	      if (offset < (size_t) b->offset)
 		dt_zeropad(pdt, b->offset - offset);
-	      dt_cons(pdt, build_offset(dt, size_int(csymoffset)));
+	      dt_cons(pdt, global.params.noTypeinfo ? null_pointer_node : build_offset(dt, size_int(csymoffset)));
 	      break;
 	    }
 	}

--- a/gcc/d/d-typinf.cc
+++ b/gcc/d/d-typinf.cc
@@ -88,6 +88,7 @@ Type::getInternalTypeInfo (Scope *sc)
 void
 Type::genTypeInfo(Scope *sc)
 {
+  gcc_assert (!global.params.noTypeinfo);
   if (!Type::dtypeinfo)
     {
       error(Loc(), "TypeInfo not found. object.d may be incorrectly installed or corrupt");

--- a/gcc/d/dfrontend/declaration.c
+++ b/gcc/d/dfrontend/declaration.c
@@ -2048,16 +2048,24 @@ Expression *VarDeclaration::callScopeDtor(Scope *sc)
         {
             if (type->toBasetype()->ty == Tsarray)
             {
-                // Typeinfo.destroy(cast(void*)&v);
-                Expression *ea = new SymOffExp(loc, this, 0, 0);
-                ea = new CastExp(loc, ea, Type::tvoid->pointerTo());
-                Expressions *args = new Expressions();
-                args->push(ea);
+                if (global.params.noTypeinfo && !(sc->flags & SCOPEctfe))
+                {
+                    error(global.params.noTypeinfo, "Can't build array destructor");
+                    e = new ErrorExp();
+                }
+                else
+                {
+                    // Typeinfo.destroy(cast(void*)&v);
+                    Expression *ea = new SymOffExp(loc, this, 0, 0);
+                    ea = new CastExp(loc, ea, Type::tvoid->pointerTo());
+                    Expressions *args = new Expressions();
+                    args->push(ea);
 
-                Expression *et = type->getTypeInfo(sc);
-                et = new DotIdExp(loc, et, Id::destroy);
+                    Expression *et = type->getTypeInfo(sc);
+                    et = new DotIdExp(loc, et, Id::destroy);
 
-                e = new CallExp(loc, et, args);
+                    e = new CallExp(loc, et, args);
+                }
             }
             else
             {
@@ -2117,6 +2125,18 @@ void ObjectNotFound(Identifier *id)
     fatal();
 }
 
+/******************************************
+ */
+
+void TypeInfoAvailable()
+{
+    if (global.params.noTypeinfo)
+    {
+        Type::error(Loc(), global.params.noTypeinfo, "Can't build TypeInfo declaration");
+        fatal();
+    }
+}
+
 /******************************** SymbolDeclaration ********************************/
 
 SymbolDeclaration::SymbolDeclaration(Loc loc, StructDeclaration *dsym)
@@ -2151,6 +2171,7 @@ void ClassInfoDeclaration::semantic(Scope *sc)
 TypeInfoDeclaration::TypeInfoDeclaration(Type *tinfo, int internal)
     : VarDeclaration(Loc(), Type::dtypeinfo->type, tinfo->getTypeInfoIdent(internal), NULL)
 {
+    TypeInfoAvailable();
     this->tinfo = tinfo;
     storage_class = STCstatic | STCgshared;
     protection = PROTpublic;
@@ -2188,6 +2209,7 @@ char *TypeInfoDeclaration::toChars()
 TypeInfoConstDeclaration::TypeInfoConstDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    TypeInfoAvailable();
     if (!Type::typeinfoconst)
     {
         ObjectNotFound(Id::TypeInfo_Const);
@@ -2205,6 +2227,7 @@ TypeInfoConstDeclaration *TypeInfoConstDeclaration::create(Type *tinfo)
 TypeInfoInvariantDeclaration::TypeInfoInvariantDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    TypeInfoAvailable();
     if (!Type::typeinfoinvariant)
     {
         ObjectNotFound(Id::TypeInfo_Invariant);
@@ -2222,6 +2245,7 @@ TypeInfoInvariantDeclaration *TypeInfoInvariantDeclaration::create(Type *tinfo)
 TypeInfoSharedDeclaration::TypeInfoSharedDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    TypeInfoAvailable();
     if (!Type::typeinfoshared)
     {
         ObjectNotFound(Id::TypeInfo_Shared);
@@ -2239,6 +2263,7 @@ TypeInfoSharedDeclaration *TypeInfoSharedDeclaration::create(Type *tinfo)
 TypeInfoWildDeclaration::TypeInfoWildDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    TypeInfoAvailable();
     if (!Type::typeinfowild)
     {
         ObjectNotFound(Id::TypeInfo_Wild);
@@ -2256,6 +2281,7 @@ TypeInfoWildDeclaration *TypeInfoWildDeclaration::create(Type *tinfo)
 TypeInfoStructDeclaration::TypeInfoStructDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    TypeInfoAvailable();
     if (!Type::typeinfostruct)
     {
         ObjectNotFound(Id::TypeInfo_Struct);
@@ -2273,6 +2299,7 @@ TypeInfoStructDeclaration *TypeInfoStructDeclaration::create(Type *tinfo)
 TypeInfoClassDeclaration::TypeInfoClassDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    TypeInfoAvailable();
     if (!Type::typeinfoclass)
     {
         ObjectNotFound(Id::TypeInfo_Class);
@@ -2290,6 +2317,7 @@ TypeInfoClassDeclaration *TypeInfoClassDeclaration::create(Type *tinfo)
 TypeInfoInterfaceDeclaration::TypeInfoInterfaceDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    TypeInfoAvailable();
     if (!Type::typeinfointerface)
     {
         ObjectNotFound(Id::TypeInfo_Interface);
@@ -2307,6 +2335,7 @@ TypeInfoInterfaceDeclaration *TypeInfoInterfaceDeclaration::create(Type *tinfo)
 TypeInfoPointerDeclaration::TypeInfoPointerDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    TypeInfoAvailable();
     if (!Type::typeinfopointer)
     {
         ObjectNotFound(Id::TypeInfo_Pointer);
@@ -2324,6 +2353,7 @@ TypeInfoPointerDeclaration *TypeInfoPointerDeclaration::create(Type *tinfo)
 TypeInfoArrayDeclaration::TypeInfoArrayDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    TypeInfoAvailable();
     if (!Type::typeinfoarray)
     {
         ObjectNotFound(Id::TypeInfo_Array);
@@ -2341,6 +2371,7 @@ TypeInfoArrayDeclaration *TypeInfoArrayDeclaration::create(Type *tinfo)
 TypeInfoStaticArrayDeclaration::TypeInfoStaticArrayDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    TypeInfoAvailable();
     if (!Type::typeinfostaticarray)
     {
         ObjectNotFound(Id::TypeInfo_StaticArray);
@@ -2358,6 +2389,7 @@ TypeInfoStaticArrayDeclaration *TypeInfoStaticArrayDeclaration::create(Type *tin
 TypeInfoAssociativeArrayDeclaration::TypeInfoAssociativeArrayDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    TypeInfoAvailable();
     if (!Type::typeinfoassociativearray)
     {
         ObjectNotFound(Id::TypeInfo_AssociativeArray);
@@ -2375,6 +2407,7 @@ TypeInfoAssociativeArrayDeclaration *TypeInfoAssociativeArrayDeclaration::create
 TypeInfoVectorDeclaration::TypeInfoVectorDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    TypeInfoAvailable();
     if (!Type::typeinfovector)
     {
         ObjectNotFound(Id::TypeInfo_Vector);
@@ -2392,6 +2425,7 @@ TypeInfoVectorDeclaration *TypeInfoVectorDeclaration::create(Type *tinfo)
 TypeInfoEnumDeclaration::TypeInfoEnumDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    TypeInfoAvailable();
     if (!Type::typeinfoenum)
     {
         ObjectNotFound(Id::TypeInfo_Enum);
@@ -2409,6 +2443,7 @@ TypeInfoEnumDeclaration *TypeInfoEnumDeclaration::create(Type *tinfo)
 TypeInfoFunctionDeclaration::TypeInfoFunctionDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    TypeInfoAvailable();
     if (!Type::typeinfofunction)
     {
         ObjectNotFound(Id::TypeInfo_Function);
@@ -2426,6 +2461,7 @@ TypeInfoFunctionDeclaration *TypeInfoFunctionDeclaration::create(Type *tinfo)
 TypeInfoDelegateDeclaration::TypeInfoDelegateDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    TypeInfoAvailable();
     if (!Type::typeinfodelegate)
     {
         ObjectNotFound(Id::TypeInfo_Delegate);
@@ -2443,6 +2479,7 @@ TypeInfoDelegateDeclaration *TypeInfoDelegateDeclaration::create(Type *tinfo)
 TypeInfoTupleDeclaration::TypeInfoTupleDeclaration(Type *tinfo)
     : TypeInfoDeclaration(tinfo, 0)
 {
+    TypeInfoAvailable();
     if (!Type::typeinfotypelist)
     {
         ObjectNotFound(Id::TypeInfo_Tuple);

--- a/gcc/d/dfrontend/func.c
+++ b/gcc/d/dfrontend/func.c
@@ -1324,6 +1324,12 @@ void FuncDeclaration::semantic3(Scope *sc)
             if (f->linkage == LINKd)
             {
                 // Declare _arguments[]
+                if (global.params.noTypeinfo && !(sc->flags & SCOPEctfe))
+                {
+                    error(global.params.noTypeinfo, "Can't use runtime variadic arguments");
+                    return;
+                }
+
                 v_arguments = new VarDeclaration(Loc(), Type::typeinfotypelist->type, Id::_arguments_typeinfo, NULL);
                 v_arguments->storage_class |= STCtemp | STCparameter;
                 v_arguments->semantic(sc2);
@@ -2109,7 +2115,15 @@ void FuncDeclaration::semantic3(Scope *sc)
                         if (isStatic())
                         {
                             // The monitor is in the ClassInfo
-                            vsync = new DotIdExp(loc, new DsymbolExp(loc, cd), Id::classinfo);
+                            if (global.params.noTypeinfo && !(sc->flags & SCOPEctfe))
+                            {
+                                error(global.params.noTypeinfo, "Can't use synchronized");
+                                vsync = new ErrorExp();
+                            }
+                            else
+                            {
+                                vsync = new DotIdExp(loc, new DsymbolExp(loc, cd), Id::classinfo);
+                            }
                         }
                         else
                         {

--- a/gcc/d/dfrontend/mars.h
+++ b/gcc/d/dfrontend/mars.h
@@ -201,6 +201,8 @@ struct Param
     const char *resfile;
     const char *exefile;
     const char *mapfile;
+    // Language features which can be disabled
+    const char* noTypeinfo;   // != null => disable Typeinfo
 };
 
 struct Compiler

--- a/gcc/d/dfrontend/mtype.c
+++ b/gcc/d/dfrontend/mtype.c
@@ -3836,6 +3836,12 @@ Expression *TypeArray::dotExp(Scope *sc, Expression *e, Identifier *ident, int f
 
         assert(size);
 
+        if (global.params.noTypeinfo && !(sc->flags & SCOPEctfe))
+        {
+            error(e->loc, global.params.noTypeinfo, "Can't use reverse");
+            return new ErrorExp();
+        }
+
         static FuncDeclaration *adReverse_fd = NULL;
         if (!adReverse_fd) {
             Parameters* args = new Parameters;
@@ -3858,6 +3864,12 @@ Expression *TypeArray::dotExp(Scope *sc, Expression *e, Identifier *ident, int f
         static FuncDeclaration *fd = NULL;
         Expression *ec;
         Expressions *arguments;
+
+        if (global.params.noTypeinfo && !(sc->flags & SCOPEctfe))
+        {
+            error(e->loc, global.params.noTypeinfo, "Can't use sort");
+            goto Lerror;
+        }
 
         if (!fd) {
             Parameters* args = new Parameters;
@@ -4667,6 +4679,12 @@ Type *TypeAArray::semantic(Loc loc, Scope *sc)
     //printf("TypeAArray::semantic() %s index->ty = %d\n", toChars(), index->ty);
     if (deco)
         return this;
+
+    if (global.params.noTypeinfo && !(sc->flags & SCOPEctfe))
+    {
+        error(loc, global.params.noTypeinfo, "Can't use AAs");
+        return Type::terror;
+    }
 
     this->loc = loc;
     this->sc = sc;
@@ -8252,6 +8270,12 @@ L1:
 
         if (ident == Id::classinfo)
         {
+            if (global.params.noTypeinfo && !(sc->flags & SCOPEctfe))
+            {
+                error(e->loc, global.params.noTypeinfo, "Can't use classinfo");
+                return new ErrorExp();
+            }
+
             assert(Type::typeinfoclass);
             Type *t = Type::typeinfoclass->type;
             if (e->op == TOKtype || e->op == TOKdottype)

--- a/gcc/d/gdc.texi
+++ b/gcc/d/gdc.texi
@@ -178,6 +178,10 @@ Don't recognize built-in functions that do not begin with
 @cindex @option{-fno-emit-moduleinfo}
 Turns off generation of module information and related functions.
 
+@item -fno-rtti
+@cindex @option{-fno-rtti}
+Turns off generation of runtime type information.
+
 @item -fd-verbose
 @cindex @option{-fd-verbose}
 Print information about D language processing to stdout.

--- a/gcc/d/lang.opt
+++ b/gcc/d/lang.opt
@@ -142,6 +142,9 @@ femit-moduleinfo
 D
 Generate ModuleInfo struct for output module
 
+frtti
+D
+
 fonly=
 D Joined RejectNegative
 Process all modules specified on the command line, but only generate code for the module specified by the argument


### PR DESCRIPTION
Ready for review. I'll have to check the changes in `d-todt.cc` again, I'm not sure how TypeInfo is used there. The changes in `d-objfile.cc` are 90% indentation changes. The frontend part needs to be pulled into dmd first. This pull request is mostly for early testing & feedback.

Easier to read diff by ignoring whitespace changes: https://github.com/D-Programming-GDC/GDC/pull/100/files?w=1

Minimal object.d / runtime:

``` d
module object;

class Object
{
}
```

Usage: `/opt/gdc/bin/gdc -nophoboslib -fno-rtti -fno-emit-moduleinfo -fno-invariants test.d`
