### PR TITLE
fmake-deps option: avoid duplicates in generated dependency list, make this list complete

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,10 @@
+2015-07-20  Sebastien Alaiwan <sebastien.alaiwan@gmail.com>
+
+	* d-lang.cc(is_system_module): Extract function.
+	(write_one_dep): Extract function.
+	(deps_write): Eliminate duplicated dependencies, include
+	indirect and private dependencies.
+
 2015-07-19  Sebastien Alaiwan <sebastien.alaiwan@gmail.com>
 
 	* d-lang.cc(d_parse_file): Set ref flag on the module and make deps


### PR DESCRIPTION
Only direct imports were taken into account when generating dependency list.
This fixes the exploration of imported modules to generate a complete list.
