### PR TITLE
Add OSX fiber_switchContext for x86 and x86_64

### DIFF
--- a/libphobos/libdruntime/core/thread.d
+++ b/libphobos/libdruntime/core/thread.d
@@ -3240,6 +3240,21 @@ private
             version = AlignFiberStackTo16Byte;
             version = AsmExternal;
         }
+        else version (OSX)
+        {
+            version(X86)
+            {
+                version = AsmX86_Posix;
+                version = AlignFiberStackTo16Byte;
+                version = AsmExternal;
+            }
+            else version(X86_64)
+            {
+                version = AsmX86_64_Posix;
+                version = AlignFiberStackTo16Byte;
+                version = AsmExternal;
+            }
+        }
     }
     else version( PPC )
     {

--- a/libphobos/libdruntime/core/threadasm.S
+++ b/libphobos/libdruntime/core/threadasm.S
@@ -495,3 +495,61 @@ _fiber_switchContext:
     // 'return' to complete switch
     ret;
 #endif
+/************************************************************************************
+ * i386- and x86_64-apple-darwin (OS X) ASM BITS
+ ************************************************************************************/
+#if defined(__i386__) && defined(__APPLE__)
+.globl _fiber_switchContext
+_fiber_switchContext:
+	// save current stack state
+	push %ebp
+	mov  %esp, %ebp
+	push %edi
+	push %esi
+	push %ebx
+	push %eax
+
+	// store oldp again with more accurate address
+	mov 8(%ebp), %eax
+	mov %esp, (%eax)
+	// load newp to begin context switch
+	mov 12(%ebp), %esp
+
+	// load saved state from new stack
+	pop %eax
+	pop %ebx
+	pop %esi
+	pop %edi
+	pop %ebp
+
+	// 'return' to complete switch
+	ret
+#endif
+#if defined(__x86_64__) && defined(__APPLE__)
+.globl _fiber_switchContext
+_fiber_switchContext:
+	// Save current stack state.save current stack state
+	push %rbp
+	mov  %rsp, %rbp
+	push %rbx
+	push %r12
+	push %r13
+	push %r14
+	push %r15
+
+	// store oldp again with more accurate address
+	mov %rsp, (%rdi)
+	// load newp to begin context switch
+	mov %rsi, %rsp
+
+	// load saved state from new stack
+	pop %r15
+	pop %r14
+	pop %r13
+	pop %r12
+	pop %rbx
+	pop %rbp
+
+	// 'return' to complete switch
+	ret
+#endif


### PR DESCRIPTION
Implements OS X Fiber context switching in threadasm.S.  Used same assembly as dmd style inline asm for AsmX86_Posix and AsmX86_64_Posix thread.d.

A side note: interesting that the sequence for X86 saves register eax.  I don't think it needs to, all calling conventions I am familiar with eax is not preserved.

Passes druntime unitttests.
