### PR TITLE
ARM: fix FPSCR bits and resetIeeeFlags

### DIFF
--- a/libphobos/src/std/math.d
+++ b/libphobos/src/std/math.d
@@ -3712,11 +3712,11 @@ private:
     {
         enum : int
         {
-            INEXACT_MASK   = 0x00001000,
-            UNDERFLOW_MASK = 0x00000800,
-            OVERFLOW_MASK  = 0x00000400,
-            DIVBYZERO_MASK = 0x00000200,
-            INVALID_MASK   = 0x00000100
+            INEXACT_MASK   = 0x10,
+            UNDERFLOW_MASK = 0x08,
+            OVERFLOW_MASK  = 0x04,
+            DIVBYZERO_MASK = 0x02,
+            INVALID_MASK   = 0x01
         }
     }
     else version(SPARC)
@@ -3824,7 +3824,8 @@ private:
             }
             else version (ARM)
             {
-                uint old = getIeeeFlags();
+                uint old = void;
+                asm { "vmrs %0, FPSCR" : "=r" (old); }
                 old &= ~0b11111; // http://infocenter.arm.com/help/topic/com.arm.doc.ddi0408i/Chdfifdc.html
                 asm {"vmsr FPSCR, %0;" : : "r" (old);} 
             }
@@ -3942,8 +3943,8 @@ struct FloatingPointControl
         enum : RoundingMode
         {
             roundToNearest = 0x000000,
-            roundDown      = 0x400000,
-            roundUp        = 0x800000,
+            roundDown      = 0x800000,
+            roundUp        = 0x400000,
             roundToZero    = 0xC00000
         }
     }


### PR DESCRIPTION
ARM FPSCR bit corrections comes from druntime commit D-Programming-Language/phobos@f640df12e4397d2dfa20ef2f60fb39bd47552aef

resetIeeeFlags was clearing all bits in fpscr (e.g. rounding mode lost), now only clears cumulative exception bits.

Note: I haven't finished building all of phobos on ARM, only compiled with hard float and looked at assembly.  Similar assembly was tested on hardware using LDC.

Also, I did not know in GCC inline asm how to let compiler pick a temporary register to clobber, so I explicitly used r0.

From objdump of math.o:

```
00002b9c <_D3std4math9IeeeFlags14resetIeeeFlagsFZv>:
    2b9c:   eef10a10    vmrs    r0, fpscr
    2ba0:   e3c0001f    bic r0, r0, #31
    2ba4:   eee10a10    vmsr    fpscr, r0
    2ba8:   e12fff1e    bx  lr
```
