### PR TITLE
Implement core.atomic using gcc __atomic builtins, deprecating gcc.atomics

### DIFF
--- a/libphobos/libdruntime/gcc/atomics.d
+++ b/libphobos/libdruntime/gcc/atomics.d
@@ -19,7 +19,7 @@
 /* This module is intended to provide some basic support for lock-free
    concurrent programming via the GCC builtins if the platform supports it.  */
 
-module gcc.atomics;
+deprecated module gcc.atomics;
 
 import gcc.builtins;
 


### PR DESCRIPTION
Mapping `enum MemoryOrder` to C++11's `memory_order` in libstdc++.
