### PR TITLE
Fix crash when generating dependency file

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2015-07-19  Sebastien Alaiwan <sebastien.alaiwan@gmail.com>
+
+	* d-lang.cc(d_parse_file): Set ref flag on the module and make deps
+	file handle.
+
 2015-07-11  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-codegen.cc(convert_for_assignment): Remove handling of zero

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -1079,6 +1079,7 @@ d_parse_file()
 	{
 	  File deps (global.params.moduleDepsFile);
 	  deps.setbuffer ((void *) ob->data, ob->offset);
+	  deps.ref = 1;
 	  writeFile(Loc(), &deps);
 	}
       else
@@ -1098,6 +1099,7 @@ d_parse_file()
 	{
 	  File deps (global.params.makeDepsFile);
 	  deps.setbuffer ((void *) ob->data, ob->offset);
+	  deps.ref = 1;
 	  writeFile(Loc(), &deps);
 	}
       else


### PR DESCRIPTION
The crash happens on rare occasions, but the bug can always be seen using valgrind.
Basically, the internal memory block of the OutBuffer was freed two times.
