### PR TITLE
Avoid usage of hash_set, not available in gcc-4.9

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,7 @@
+2015-07-24  Sebastien Alaiwan  <sebastien.alaiwan@gmail.com>
+
+	* (deps_write): Use StringTable instead of hash_set of string pointers.
+
 2015-07-23  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-attribs.h: Adjust includes.


### PR DESCRIPTION
Use gdc-provided StringTable instead of a hash_set<const char*>.
This should solve the compatibility issue with gcc-4.9 and below.
This also avoids relying on string pointer values to eliminate duplicates.
