### PR TITLE
Convert IRState::doArraySet to free function

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,6 +1,14 @@
+2015-07-26  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-irstate.cc(IRState::doArraySet): Remove function.
+	* d-codegen.cc(build_array_set): New function.
+	* d-elem.cc(AssignExp::toElem): Use build_array_set.
+	(StructLiteralExp::toElem): Likewise.
+
 2015-07-24  Sebastien Alaiwan  <sebastien.alaiwan@gmail.com>
 
-	* (deps_write): Use StringTable instead of hash_set of string pointers.
+	* d-lang.cc(deps_write): Use StringTable instead of hash_set of string
+	pointers.
 
 2015-07-23  Iain Buclaw  <ibuclaw@gdcproject.org>
 

--- a/gcc/d/d-codegen.h
+++ b/gcc/d/d-codegen.h
@@ -124,6 +124,7 @@ extern tree build_array_index (tree ptr, tree index);
 extern tree build_offset_op (tree_code op, tree ptr, tree idx);
 extern tree build_offset (tree ptr_node, tree byte_offset);
 extern tree build_memref (tree type, tree ptr, tree byte_offset);
+extern tree build_array_set(tree ptr, tree length, tree value);
 
 // Function calls
 extern tree d_build_call (FuncDeclaration *fd, tree object, Expressions *args);

--- a/gcc/d/d-elem.cc
+++ b/gcc/d/d-elem.cc
@@ -907,7 +907,7 @@ AssignExp::toElem(IRState *irs)
 					 d_array_ptr(t1), integer_zero_node, size);
 	    }
 	  else
-	    result = irs->doArraySet(d_array_ptr(t1), t2, d_array_length(t1));
+	    result = build_array_set(d_array_ptr(t1), d_array_length(t1), t2);
 
 	  return compound_expr(result, t1);
 	}
@@ -2460,7 +2460,7 @@ StructLiteralExp::toElem(IRState *irs)
 
 	      tree ptr_tree = build_nop(build_ctype(etype->pointerTo()),
 					build_address(exp_tree));
-	      tree set_exp = irs->doArraySet(ptr_tree, exp->toElem(irs), size);
+	      tree set_exp = build_array_set(ptr_tree, size, exp->toElem(irs));
 	      exp_tree = compound_expr(set_exp, exp_tree);
 	    }
 	}

--- a/gcc/d/d-irstate.h
+++ b/gcc/d/d-irstate.h
@@ -182,9 +182,6 @@ struct IRState
   void continueLoop (Identifier *ident);
   void exitLoop (Identifier *ident);
 
-  // ** Array initialiser loop expression.
-  tree doArraySet (tree ptr, tree value, tree count);
-
   // ** Goto/Label statement evaluation
   void doJump (Statement *stmt, tree t_label);
   void pushLabel (LabelDsymbol *l);


### PR DESCRIPTION
The last part of `IRState` that should have been moved to codegen routines, but depended too heavily on `IRState` routines.
