### PR TITLE
Simplify binding_level handling routines.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -5,6 +5,21 @@
 	* d-elem.cc(AssignExp::toElem): Use build_array_set.
 	(StructLiteralExp::toElem): Likewise.
 
+	* d-codegen.cc(build_array_set): Don't set this_block, update call to
+	pop_binding_level.
+	* d-irstate.cc(IRState::endFunction): Update assert.
+	(IRState::startScope): Move IRState::startBindings here, clean-up.
+	(IRState::endScope): Move IRState::endBindings here, clean-up.
+	(IRState::startBindings): Remove function.
+	(IRState::endBindings): Likewise.
+	(IRState::currentScope): Likewise.
+	(IRState::scopes_): Remove.
+	* d-lang.cc(pop_binding_level): Update signature, clean-up.
+	(d_pushdecl): Don't set names_end.
+	(binding_level::names_end): Remove.
+	(binding_level::this_block): Remove.
+	(FuncDeclaration::toObjFile): Clean-up.
+
 2015-07-24  Sebastien Alaiwan  <sebastien.alaiwan@gmail.com>
 
 	* d-lang.cc(deps_write): Use StringTable instead of hash_set of string

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -1849,9 +1849,7 @@ tree
 build_array_set(tree ptr, tree length, tree value)
 {
   tree stmt_list = alloc_stmt_list();
-  tree block = make_node(BLOCK);
   push_binding_level();
-  current_binding_level->this_block = block;
 
   // Build temporary locals for length and ptr, and maybe value.
   tree t = build_local_temp(size_type_node);
@@ -1893,7 +1891,7 @@ build_array_set(tree ptr, tree length, tree value)
   append_to_statement_list_force(loop_body, &stmt_list);
 
   // Wrap up expression.
-  block = pop_binding_level(1, 0);
+  tree block = pop_binding_level(false);
 
   return build3(BIND_EXPR, void_type_node,
 		BLOCK_VARS (block), stmt_list, block);

--- a/gcc/d/d-irstate.h
+++ b/gcc/d/d-irstate.h
@@ -153,15 +153,6 @@ struct IRState
   void startScope();
   void endScope();
 
-  unsigned *currentScope()
-  {
-    gcc_assert (!this->scopes_.is_empty());
-    return this->scopes_.last();
-  }
-
-  void startBindings();
-  void endBindings();
-
   // Update current source file location to LOC.
   void doLineNote (const Loc& loc)
   { set_input_location (loc); }
@@ -208,7 +199,6 @@ struct IRState
 
  protected:
   auto_vec<tree> statementList_;
-  auto_vec<unsigned *> scopes_;
   auto_vec<Flow *> loops_;
   auto_vec<Label *> labels_;
 };

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -49,6 +49,7 @@
 #include "gimplify.h"
 #include "debug.h"
 #include "hash-set.h"
+#include "function.h"
 
 #include "d-lang.h"
 #include "d-codegen.h"
@@ -1363,71 +1364,30 @@ push_binding_level()
 }
 
 tree
-pop_binding_level (int keep, int routinebody)
+pop_binding_level(bool functionbody)
 {
   binding_level *level = current_binding_level;
-  tree block, decls;
-
   current_binding_level = level->level_chain;
-  decls = level->names;
 
-  if (level->this_block)
-    block = level->this_block;
-  else if (keep || routinebody)
-    block = make_node (BLOCK);
-  else
-    block = NULL_TREE;
+  tree block = make_node(BLOCK);
+  BLOCK_VARS (block) = level->names;
+  BLOCK_SUBBLOCKS (block) = level->blocks;
 
-  if (block)
-    {
-      BLOCK_VARS (block) = routinebody ? NULL_TREE : decls;
-      BLOCK_SUBBLOCKS (block) = level->blocks;
-    }
-  /* In each subblock, record that this is its superior. */
+  // In each subblock, record that this is its superior.
   for (tree t = level->blocks; t; t = BLOCK_CHAIN (t))
     BLOCK_SUPERCONTEXT (t) = block;
 
-  /* Dispose of the block that we just made inside some higher level. */
-  if (routinebody)
-    DECL_INITIAL (current_function_decl) = block;
-  else if (block)
+  // Dispose of the block that we just made inside some higher level.
+  if (functionbody)
     {
-      // Original logic was: If this block was created by this poplevel
-      // call and not and earlier set_block, insert it into the parent's
-      // list of blocks.  Blocks created with set_block have to be
-      // inserted with insert_block.
-      if (!level->this_block)
-	current_binding_level->blocks = chainon (current_binding_level->blocks, block);
+      DECL_INITIAL (current_function_decl) = block;
+      BLOCK_SUPERCONTEXT (block) = current_function_decl;
     }
-  /* If we did not make a block for the level just exited, any blocks made for inner
-     levels (since they cannot be recorded as subblocks in that level) must be
-     carried forward so they will later become subblocks of something else. */
-  else if (level->blocks)
-    current_binding_level->blocks = chainon (current_binding_level->blocks, level->blocks);
+  else
+    current_binding_level->blocks
+      = block_chainon(current_binding_level->blocks, block);
 
-  if (block)
-    {
-      TREE_USED (block) = 1;
-      tree vars = copy_list (BLOCK_VARS (block));
-
-      /* Warnings for unused variables.  */
-      for (tree t = nreverse (vars); t != NULL_TREE; t = TREE_CHAIN (t))
-	{
-	  if (VAR_P (t)
-	      && (!TREE_USED (t) /*|| !DECL_READ_P (t)*/) // %% TODO
-	      && !TREE_NO_WARNING (t)
-	      && DECL_NAME (t)
-	      && !DECL_ARTIFICIAL (t))
-	    {
-	      if (!TREE_USED (t))
-		warning_at (DECL_SOURCE_LOCATION (t),
-			    OPT_Wunused_variable, "unused variable %q+D", t);
-	      else if (DECL_CONTEXT (t) == current_function_decl)
-		warning_at (DECL_SOURCE_LOCATION (t),
-			    OPT_Wunused_but_set_variable, "variable %qD set but not used", t);
-	    }
-	}
-    }
+  TREE_USED (block) = 1;
   return block;
 }
 
@@ -1460,11 +1420,9 @@ d_pushdecl (tree decl)
   if (DECL_CONTEXT (decl) == NULL_TREE)
     DECL_CONTEXT (decl) = current_function_decl;
 
-  // Put decls on list in reverse order. We will reverse them later if necessary.
+  // Put decls on list in reverse order.
   TREE_CHAIN (decl) = current_binding_level->names;
   current_binding_level->names = decl;
-  if (!TREE_CHAIN (decl))
-    current_binding_level->names_end = decl;
 
   return decl;
 }

--- a/gcc/d/d-lang.h
+++ b/gcc/d/d-lang.h
@@ -87,18 +87,9 @@ struct GTY(()) binding_level
   /* A chain of declarations. These are in the reverse of the order supplied. */
   tree names;
 
-  /* A pointer to the end of the names chain. Only needed to facilitate
-     a quick test if a decl is in the list by checking if its TREE_CHAIN
-     is not NULL or it is names_end (in pushdecl_nocheck()). */
-  tree names_end;
-
   /* For each level (except the global one), a chain of BLOCK nodes for
      all the levels that were entered and exited one level down. */
   tree blocks;
-
-  /* The BLOCK node for this level, if one has been preallocated.
-     If NULL_TREE, the BLOCK is allocated (if needed) when the level is popped. */
-  tree this_block;
 
   /* The binding level this one is contained in. */
   binding_level *level_chain;
@@ -175,7 +166,7 @@ extern void add_import_paths(const char *iprefix, const char *imultilib, bool st
 /* In d-lang.cc */
 extern tree d_pushdecl (tree);
 extern void push_binding_level();
-extern tree pop_binding_level (int, int);
+extern tree pop_binding_level(bool functionbody);
 
 extern void init_global_binding_level();
 extern void set_decl_binding_chain (tree decl_chain);
@@ -186,8 +177,6 @@ extern tree d_signed_type (tree);
 extern void d_init_exceptions();
 
 extern void d_keep (tree t);
-
-extern void set_block (tree);
 
 
 /* In d-builtins.cc */


### PR DESCRIPTION
A much needed simplification for dead code.

Also removes unused parameter/variable warnings, as this shouldn't really be done in the glue.
