### PR TITLE
Move IRState into language-specific struct function

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,16 @@
+2015-07-27  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-codegen.cc(current_irstate): Remove.
+	(d_build_call): Check cfun before dereferencing.
+	* d-codegen.h(current_irstate): Redefine as macro.
+	* d-irstate.cc(IRState::IRState): Remove.
+	(IRState::startFunction): Initialize language-specific cfun field.
+	(IRState::endFunction): Free language-specific cfun field.
+	* d-lang.cc(d_parse_file): Don't initialize current_irstate.
+	* d-lang.h(language_function): Add irs field.
+	* d-objfile.cc(Dsymbol::toObjFile): Check cfun.
+	(FuncDeclaration::toObjFile): Adjust start and end calls.
+
 2015-07-26  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-irstate.cc(IRState::doArraySet): Remove function.

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -37,6 +37,7 @@
 #include "stringpool.h"
 #include "stor-layout.h"
 #include "attribs.h"
+#include "function.h"
 
 #include "d-lang.h"
 #include "d-objfile.h"
@@ -46,7 +47,6 @@
 
 
 Module *current_module_decl;
-IRState *current_irstate;
 
 
 // Return the DECL_CONTEXT for symbol DSYM.
@@ -2167,7 +2167,7 @@ d_build_call (FuncDeclaration *fd, tree object, Expressions *args)
 tree
 d_build_call (TypeFunction *tf, tree callable, tree object, Expressions *arguments)
 {
-  IRState *irs = current_irstate;
+  IRState *irs = cfun ? current_irstate : NULL;
   tree ctype = TREE_TYPE (callable);
   tree callee = callable;
   tree saved_args = NULL_TREE;

--- a/gcc/d/d-codegen.h
+++ b/gcc/d/d-codegen.h
@@ -265,7 +265,7 @@ extern bool call_by_alias_p (FuncDeclaration *caller, FuncDeclaration *callee);
 
 // Globals.
 extern Module *current_module_decl;
-extern IRState *current_irstate;
+#define current_irstate (cfun->language->irs)
 
 #endif
 

--- a/gcc/d/d-irstate.h
+++ b/gcc/d/d-irstate.h
@@ -89,10 +89,6 @@ struct Flow
 struct IRState
 {
  public:
-  IRState *parent;
-
-  IRState();
-
   // ** Functions
   FuncDeclaration *func;
   Module *mod;
@@ -102,7 +98,7 @@ struct IRState
 
   auto_vec<FuncDeclaration *> deferred;
 
-  IRState *startFunction (FuncDeclaration *decl);
+  static IRState *startFunction (FuncDeclaration *decl);
   void endFunction();
 
   // Variables that are in scope that will need destruction later.

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -854,8 +854,6 @@ d_parse_file()
 	d_nametype (Type::basic[ty]);
     }
 
-  current_irstate = new IRState();
-
   // Create Modules
   Modules modules;
   modules.reserve (num_in_fnames);

--- a/gcc/d/d-lang.h
+++ b/gcc/d/d-lang.h
@@ -20,33 +20,34 @@
 #ifndef GCC_DCMPLR_DC_LANG_H
 #define GCC_DCMPLR_DC_LANG_H
 
+// Forward type declarations to avoid including unnecessary headers.
+class Declaration;
+class Type;
+struct IRState;
+
 /* Nothing is added to tree_identifier; */
 struct GTY(()) lang_identifier
 {
   struct tree_identifier common;
 };
 
-/* This is required to be defined, but we do not use it. */
+/* Global state pertinent to the current function. */
 struct GTY(()) language_function
 {
-  int unused;
+  IRState * GTY((skip)) irs;
 };
 
 /* The D front end types have not been integrated into the GCC garbage
    collection system.  Handle this by using the "skip" attribute. */
-class Declaration;
-typedef Declaration *DeclarationGTYP;
 struct GTY(()) lang_decl
 {
-  DeclarationGTYP GTY((skip)) d_decl;
+  Declaration * GTY((skip)) d_decl;
 };
 
 /* The lang_type field is not set for every GCC type. */
-class Type;
-typedef Type *TypeGTYP;
 struct GTY(()) lang_type
 {
-  TypeGTYP GTY((skip)) d_type;
+  Type * GTY((skip)) d_type;
 };
 
 /* Another required, but unused declaration.  This could be simplified, since

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -106,15 +106,12 @@ Dsymbol::toObjFile(bool)
       if (imp->isstatic)
 	return;
 
-      IRState *irs = current_irstate;
-      Module *mod = current_module_decl;
-      tree context;
-
       // Get the context of this import, this should never be null.
-      if (irs->func != NULL)
-	context = irs->func->toSymbol()->Stree;
+      tree context;
+      if (cfun != NULL)
+	context = current_irstate->func->toSymbol()->Stree;
       else
-	context = mod->toImport()->Stree;
+	context = current_module_decl->toImport()->Stree;
 
       if (imp->ident == NULL)
 	{
@@ -1206,10 +1203,6 @@ FuncDeclaration::toObjFile(bool force_p)
   if (global.params.verbose)
     fprintf (global.stdmsg, "function  %s\n", this->toPrettyChars());
 
-  IRState *irs = current_irstate->startFunction (this);
-  // Default chain value is 'null' unless parent found.
-  irs->sthis = null_pointer_node;
-
   tree old_current_function_decl = current_function_decl;
   function *old_cfun = cfun;
   current_function_decl = fndecl;
@@ -1225,6 +1218,8 @@ FuncDeclaration::toObjFile(bool force_p)
 
   allocate_struct_function (fndecl, false);
   set_function_end_locus (endloc);
+
+  IRState *irs = IRState::startFunction (this);
 
   tree parm_decl = NULL_TREE;
   tree param_list = NULL_TREE;
@@ -1428,10 +1423,10 @@ FuncDeclaration::toObjFile(bool force_p)
 	}
     }
 
+  irs->endFunction();
+
   current_function_decl = old_current_function_decl;
   set_cfun (old_cfun);
-
-  irs->endFunction();
 }
 
 //


### PR DESCRIPTION
This is the kickstarter for removing `IRState` from the completely from the glue.  Once all fields have been transitioned out of `IRState` and into `language_function`, all methods will be moved into either `IRVisitor` or as codegen routines.

After that, should be possible to remove `current_irstate` and just pass `NULL` to all `toElem` calls.

@jpf91 - can you see any reason why we shouldn't use `language_function`?
