### PR TITLE
Do not depend on libbacktrace if phobos is not enabled

### DIFF
--- a/gcc/d/config-lang.in
+++ b/gcc/d/config-lang.in
@@ -26,7 +26,11 @@ language="d"
 
 compilers="cc1d\$(exeext)"
 
-target_libs="target-libphobos target-zlib target-libbacktrace"
+if eval test x\${enable_libphobos} "=" xno ; then
+    target_libs=""
+else
+    target_libs="target-libphobos target-zlib target-libbacktrace"
+fi
 
 gtfiles="\$(srcdir)/d/d-builtins.cc \$(srcdir)/d/d-lang.cc \$(srcdir)/d/d-lang.h"
 


### PR DESCRIPTION
Certain multilib configurations (AVR, GCC ARM Embedded toolchain) don't build when we depend on `libbacktrace` as `libbacktrace` sometimes fails to compile. (BTW: This also happens for MinGW targets but I always patched `libbacktrace` to make it build). Passing `--disable-libbacktrace` is also not possible in those cases as some multilib configurations need `libbacktrace` and don't build with `--disable-libbacktrace`. The best solution is to simply do not add an dependency here and let GCC do it's magic to determine whether to build `libbacktrace` or not.

ping @ibuclaw 

I'm also wondering whether we should remove the dependency on `libbacktrace` for phobos builds. Seems like these are interpreted as 'hard' dependencies, but we can build without `libbacktrace` just fine. This might require users to explicitly use `--enable-libbacktrace` though which could be a problem.
