### PR TITLE
Use builtin trap() to halt execution, rather than abort()

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2015-08-10  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-elem.cc(HaltExp::toElem): Use __builtin_trap to halt execution,
+	rather than the library abort() call.
+
 2015-08-07  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-codegen.cc(build_closure): Update signature, update all callers.

--- a/gcc/d/d-elem.cc
+++ b/gcc/d/d-elem.cc
@@ -1891,8 +1891,7 @@ FuncExp::toElem (IRState *)
 elem *
 HaltExp::toElem (IRState *)
 {
-  // Needs improvement.  Avoid library calls if possible..
-  return d_build_call_nary (builtin_decl_explicit (BUILT_IN_ABORT), 0);
+  return d_build_call_nary (builtin_decl_explicit (BUILT_IN_TRAP), 0);
 }
 
 elem *

--- a/libphobos/libdruntime/gcc/deh.d
+++ b/libphobos/libdruntime/gcc/deh.d
@@ -24,9 +24,6 @@ import gcc.unwind.pe;
 import gcc.builtins;
 import gcc.config;
 
-import core.memory;
-import core.stdc.stdlib;
-
 extern(C)
 {
   int _d_isbaseof(ClassInfo, ClassInfo);
@@ -125,7 +122,7 @@ private void
 __gdc_terminate()
 {
   // Replaces std::terminate and terminating with a specific handler
-  abort();
+  __builtin_trap();
 }
 
 // This is called by the unwinder.
@@ -408,7 +405,7 @@ else
 	  return _URC_CONTINUE_UNWIND;
 
 	default:
-	  abort();
+	  __builtin_trap();
 	}
       actions |= state & _US_FORCE_UNWIND;
 

--- a/libphobos/libdruntime/gcc/unwind/generic.d
+++ b/libphobos/libdruntime/gcc/unwind/generic.d
@@ -22,12 +22,11 @@
 module gcc.unwind.generic;
 
 private import gcc.builtins;
-private import core.stdc.stdlib; // for abort
 
 /* This is derived from the C++ ABI for IA-64.  Where we diverge
    for cross-architecture compatibility are noted with "@@@".  */
 
-extern (C):
+extern(C):
 
 /* Level 1: Base ABI  */
 
@@ -35,9 +34,9 @@ extern (C):
    inefficient for 32-bit and smaller machines.  */
 alias _Unwind_Word = __builtin_unwind_uint;
 alias _Unwind_Sword = __builtin_unwind_int;
-version (IA64)
+version(IA64)
 {
-  version (HPUX)
+  version(HPUX)
     alias _Unwind_Ptr = __builtin_machine_uint;
   else
     alias _Unwind_Ptr = __builtin_pointer_uint;
@@ -110,55 +109,55 @@ enum
 struct _Unwind_Context;
 
 /* Raise an exception, passing along the given exception object.  */
-_Unwind_Reason_Code _Unwind_RaiseException (_Unwind_Exception *);
+_Unwind_Reason_Code _Unwind_RaiseException(_Unwind_Exception *);
 
 /* Raise an exception for forced unwinding.  */
 
 extern(C) alias _Unwind_Stop_Fn
-    = _Unwind_Reason_Code function (int, _Unwind_Action,
-				    _Unwind_Exception_Class,
-				    _Unwind_Exception *,
-				    _Unwind_Context *, void *);
+    = _Unwind_Reason_Code function(int, _Unwind_Action,
+				   _Unwind_Exception_Class,
+				   _Unwind_Exception *,
+				   _Unwind_Context *, void *);
 
-_Unwind_Reason_Code _Unwind_ForcedUnwind (_Unwind_Exception *, _Unwind_Stop_Fn, void *);
+_Unwind_Reason_Code _Unwind_ForcedUnwind(_Unwind_Exception *, _Unwind_Stop_Fn, void *);
 
 /* Helper to invoke the exception_cleanup routine.  */
-void _Unwind_DeleteException (_Unwind_Exception *);
+void _Unwind_DeleteException(_Unwind_Exception *);
 
 /* Resume propagation of an existing exception.  This is used after
    e.g. executing cleanup code, and not to implement rethrowing.  */
-void _Unwind_Resume (_Unwind_Exception *);
+void _Unwind_Resume(_Unwind_Exception *);
 
 /* @@@ Resume propagation of an FORCE_UNWIND exception, or to rethrow
    a normal exception that was handled.  */
-_Unwind_Reason_Code _Unwind_Resume_or_Rethrow (_Unwind_Exception *);
+_Unwind_Reason_Code _Unwind_Resume_or_Rethrow(_Unwind_Exception *);
 
 /* @@@ Use unwind data to perform a stack backtrace.  The trace callback
    is called for every stack frame in the call chain, but no cleanup
    actions are performed.  */
 extern(C) alias _Unwind_Trace_Fn
-    = _Unwind_Reason_Code function (_Unwind_Context *, void *);
+    = _Unwind_Reason_Code function(_Unwind_Context *, void *);
 
-_Unwind_Reason_Code _Unwind_Backtrace (_Unwind_Trace_Fn, void *);
+_Unwind_Reason_Code _Unwind_Backtrace(_Unwind_Trace_Fn, void *);
 
 /* These functions are used for communicating information about the unwind
    context (i.e. the unwind descriptors and the user register state) between
    the unwind library and the personality routine and landing pad.  Only
    selected registers may be manipulated.  */
 
-_Unwind_Word _Unwind_GetGR (_Unwind_Context *, int);
-void _Unwind_SetGR (_Unwind_Context *, int, _Unwind_Word);
+_Unwind_Word _Unwind_GetGR(_Unwind_Context *, int);
+void _Unwind_SetGR(_Unwind_Context *, int, _Unwind_Word);
 
-_Unwind_Ptr _Unwind_GetIP (_Unwind_Context *);
-_Unwind_Ptr _Unwind_GetIPInfo (_Unwind_Context *, int *);
-void _Unwind_SetIP (_Unwind_Context *, _Unwind_Ptr);
+_Unwind_Ptr _Unwind_GetIP(_Unwind_Context *);
+_Unwind_Ptr _Unwind_GetIPInfo(_Unwind_Context *, int *);
+void _Unwind_SetIP(_Unwind_Context *, _Unwind_Ptr);
 
 /* @@@ Retrieve the CFA of the given context.  */
-_Unwind_Word _Unwind_GetCFA (_Unwind_Context *);
+_Unwind_Word _Unwind_GetCFA(_Unwind_Context *);
 
-void *_Unwind_GetLanguageSpecificData (_Unwind_Context *);
+void *_Unwind_GetLanguageSpecificData(_Unwind_Context *);
 
-_Unwind_Ptr _Unwind_GetRegionStart (_Unwind_Context *);
+_Unwind_Ptr _Unwind_GetRegionStart(_Unwind_Context *);
 
 
 /* The personality routine is the function in the C++ (or other language)
@@ -176,55 +175,55 @@ _Unwind_Ptr _Unwind_GetRegionStart (_Unwind_Context *);
    lack of code to handle the different data format.  */
 
 extern(C) alias _Unwind_Personality_Fn
-    = _Unwind_Reason_Code function (int, _Unwind_Action,
-				    _Unwind_Exception_Class,
-				    _Unwind_Exception *,
-				    _Unwind_Context *);
+    = _Unwind_Reason_Code function(int, _Unwind_Action,
+				   _Unwind_Exception_Class,
+				   _Unwind_Exception *,
+				   _Unwind_Context *);
 
 /* @@@ The following alternate entry points are for setjmp/longjmp
    based unwinding.  */
 
 struct SjLj_Function_Context;
-extern void _Unwind_SjLj_Register (SjLj_Function_Context *);
-extern void _Unwind_SjLj_Unregister (SjLj_Function_Context *);
+extern void _Unwind_SjLj_Register(SjLj_Function_Context *);
+extern void _Unwind_SjLj_Unregister(SjLj_Function_Context *);
 
-_Unwind_Reason_Code _Unwind_SjLj_RaiseException (_Unwind_Exception *);
-_Unwind_Reason_Code _Unwind_SjLj_ForcedUnwind (_Unwind_Exception *, _Unwind_Stop_Fn, void *);
-void _Unwind_SjLj_Resume (_Unwind_Exception *);
-_Unwind_Reason_Code _Unwind_SjLj_Resume_or_Rethrow (_Unwind_Exception *);
+_Unwind_Reason_Code _Unwind_SjLj_RaiseException(_Unwind_Exception *);
+_Unwind_Reason_Code _Unwind_SjLj_ForcedUnwind(_Unwind_Exception *, _Unwind_Stop_Fn, void *);
+void _Unwind_SjLj_Resume(_Unwind_Exception *);
+_Unwind_Reason_Code _Unwind_SjLj_Resume_or_Rethrow(_Unwind_Exception *);
 
 /* @@@ The following provide access to the base addresses for text
    and data-relative addressing in the LDSA.  In order to stay link
    compatible with the standard ABI for IA-64, we inline these.  */
 
-version (IA64)
+version(IA64)
 {
   _Unwind_Ptr
-  _Unwind_GetDataRelBase (_Unwind_Context *_C)
+  _Unwind_GetDataRelBase(_Unwind_Context *_C)
   {
     /* The GP is stored in R1.  */
-    return _Unwind_GetGR (_C, 1);
+    return _Unwind_GetGR(_C, 1);
   }
 
   _Unwind_Ptr
-  _Unwind_GetTextRelBase (_Unwind_Context *)
+  _Unwind_GetTextRelBase(_Unwind_Context *)
   {
-    abort ();
+    __builtin_trap();
     return 0;
   }
 
   /* @@@ Retrieve the Backing Store Pointer of the given context.  */
-  _Unwind_Word _Unwind_GetBSP (_Unwind_Context *);
+  _Unwind_Word _Unwind_GetBSP(_Unwind_Context *);
 }
 else
 {
-  _Unwind_Ptr _Unwind_GetDataRelBase (_Unwind_Context *);
-  _Unwind_Ptr _Unwind_GetTextRelBase (_Unwind_Context *);
+  _Unwind_Ptr _Unwind_GetDataRelBase(_Unwind_Context *);
+  _Unwind_Ptr _Unwind_GetTextRelBase(_Unwind_Context *);
 }
 
 /* @@@ Given an address, return the entry point of the function that
    contains it.  */
-extern void * _Unwind_FindEnclosingFunction (void *pc);
+extern void * _Unwind_FindEnclosingFunction(void *pc);
 
 
 /* leb128 type numbers have a potentially unlimited size.
@@ -247,6 +246,6 @@ else static if (long.sizeof >= (void*).sizeof)
 }
 else
 {
-  static assert (0, "What type shall we use for _sleb128_t?");
+  static assert(0, "What type shall we use for _sleb128_t?");
 }
 

--- a/libphobos/libdruntime/gcc/unwind/pe.d
+++ b/libphobos/libdruntime/gcc/unwind/pe.d
@@ -21,7 +21,7 @@
 module gcc.unwind.pe;
 
 import gcc.unwind;
-private import core.stdc.stdlib : abort;
+import gcc.builtins;
 
 /* Pointer encodings, from dwarf2.h.  */
 enum
@@ -48,13 +48,13 @@ enum
   DW_EH_PE_indirect = 0x80
 }
 
-version (NO_SIZE_OF_ENCODED_VALUE) {}
+version(NO_SIZE_OF_ENCODED_VALUE) {}
 else
 {
   /* Given an encoding, return the number of bytes the format occupies.
      This is only defined for fixed-size encodings, and so does not
      include leb128.  */
-  uint size_of_encoded_value (ubyte encoding)
+  uint size_of_encoded_value(ubyte encoding)
   {
       if (encoding == DW_EH_PE_omit)
 	return 0;
@@ -74,7 +74,7 @@ else
   }
 }
 
-version (NO_BASE_OF_ENCODED_VALUE) {}
+version(NO_BASE_OF_ENCODED_VALUE) {}
 else
 {
   /* Given an encoding and an _Unwind_Context, return the base to which
@@ -83,7 +83,7 @@ else
      not available.  */
 
   _Unwind_Ptr
-  base_of_encoded_value (ubyte encoding, _Unwind_Context *context)
+  base_of_encoded_value(ubyte encoding, _Unwind_Context *context)
   {
     if (encoding == DW_EH_PE_omit)
       return cast(_Unwind_Ptr) 0;
@@ -96,13 +96,13 @@ else
 	return cast(_Unwind_Ptr) 0;
 
       case DW_EH_PE_textrel:
-	return _Unwind_GetTextRelBase (context);
+	return _Unwind_GetTextRelBase(context);
       case DW_EH_PE_datarel:
-	return _Unwind_GetDataRelBase (context);
+	return _Unwind_GetDataRelBase(context);
       case DW_EH_PE_funcrel:
-	return _Unwind_GetRegionStart (context);
+	return _Unwind_GetRegionStart(context);
       }
-    assert (0);
+    assert(0);
   }
 }
 
@@ -112,7 +112,7 @@ else
    pointers should not be leb128 encoded on that target.  */
 
 ubyte *
-read_uleb128 (ubyte *p, _uleb128_t *val)
+read_uleb128(ubyte *p, _uleb128_t *val)
 {
   uint shift = 0;
   ubyte a_byte;
@@ -134,7 +134,7 @@ read_uleb128 (ubyte *p, _uleb128_t *val)
 /* Similar, but read a signed leb128 value.  */
 
 ubyte *
-read_sleb128 (ubyte *p, _sleb128_t *val)
+read_sleb128(ubyte *p, _sleb128_t *val)
 {
   uint shift = 0;
   ubyte a_byte;
@@ -162,8 +162,8 @@ read_sleb128 (ubyte *p, _sleb128_t *val)
    by base_of_encoded_value for this encoding in the appropriate context.  */
 
 ubyte *
-read_encoded_value_with_base (ubyte encoding, _Unwind_Ptr base,
-                              ubyte *p, _Unwind_Ptr *val)
+read_encoded_value_with_base(ubyte encoding, _Unwind_Ptr base,
+                             ubyte *p, _Unwind_Ptr *val)
 {
   union unaligned
     {
@@ -199,7 +199,7 @@ read_encoded_value_with_base (ubyte encoding, _Unwind_Ptr base,
         case DW_EH_PE_uleb128:
           {
             _uleb128_t tmp;
-            p = read_uleb128 (p, &tmp);
+            p = read_uleb128(p, &tmp);
             result = cast(_Unwind_Internal_Ptr) tmp;
           }
           break;
@@ -207,7 +207,7 @@ read_encoded_value_with_base (ubyte encoding, _Unwind_Ptr base,
         case DW_EH_PE_sleb128:
           {
             _sleb128_t tmp;
-            p = read_sleb128 (p, &tmp);
+            p = read_sleb128(p, &tmp);
             result = cast(_Unwind_Internal_Ptr) tmp;
           }
           break;
@@ -239,7 +239,7 @@ read_encoded_value_with_base (ubyte encoding, _Unwind_Ptr base,
           break;
 
         default:
-          abort ();
+          __builtin_trap();
         }
 
       if (result != 0)
@@ -262,11 +262,11 @@ else
      rather than providing it directly.  */
 
   ubyte *
-  read_encoded_value (_Unwind_Context *context, ubyte encoding,
-		      ubyte *p, _Unwind_Ptr *val)
+  read_encoded_value(_Unwind_Context *context, ubyte encoding,
+		     ubyte *p, _Unwind_Ptr *val)
   {
-    return read_encoded_value_with_base (encoding,
-		  base_of_encoded_value (encoding, context),
+    return read_encoded_value_with_base(encoding,
+		  base_of_encoded_value(encoding, context),
 		  p, val);
   }
 }


### PR DESCRIPTION
This will, eg: emit `.value 0x0b0f` on x86, or `.inst 0xe7f000f0` on ARM.

This should reduce the size of Druntime/Phobos ever so slightly, as there will be no more dependencies on libc abort().

|  | libgdruntime | libgphobos | helloworld |
| --- | --- | --- | --- |
| **Before** | 5849kb | 54.69mb | 8569kb |
| **After** | 5839kb | 54.63mb | 8560kb |

So, is a subtle improvement.
