### PR TITLE
Only call class invariant if one provably exists in any base classes

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,10 @@
+2015-08-12  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	(needsInvariant): New function.
+	(AssertExp::toElem): Check if there are any invariants found in the
+	class object's vtable, and only call the invariant if the classinfo
+	doesn't match at runtime.
+
 2015-08-10  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-elem.cc(HaltExp::toElem): Use __builtin_trap to halt execution,


### PR DESCRIPTION
This is an interesting optimization that turns:

```
if (this != 0B)
  {
    _D9invariant12_d_invariantFC6ObjectZv (this);
  }
```

Into:

```
  if (this != 0B)
    {
      if (**(struct TypeInfo_Class * * *) this == (struct TypeInfo_Class *) &MyClass.__Class)
        {
          (void) 0;
        }
      else
        {
          _D9invariant12_d_invariantFC6ObjectZv (this);
        }
    }
```

If the given `MyClass` object has no invariants found in it's vtable.

In some contrived benchmarks, I found this to achieve 2% better runtime results in non-release builds vs. turning off invariants altogether with `-fno-invariants` (with `-O2`, I should try non-optimized builds too).

Just waiting to here back if there are any thoughts in the community on this, but I can't think of a problem on my end.
