### PR TITLE
Set ENUM_IS_SCOPED on enumeral types

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2015-08-17  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* types.cc(TypeVisitor::visit(TypeEnum)): Set ENUM_IS_SCOPED on all
+	enumeral types.
+
 2015-08-10  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-elem.cc(HaltExp::toElem): Use __builtin_trap to halt execution,

--- a/gcc/d/types.cc
+++ b/gcc/d/types.cc
@@ -196,6 +196,7 @@ public:
       }
 
     t->ctype = make_node(ENUMERAL_TYPE);
+    ENUM_IS_SCOPED (t->ctype) = 1;
     TYPE_LANG_SPECIFIC (t->ctype) = build_d_type_lang_specific(t);
     d_keep(t->ctype);
 


### PR DESCRIPTION
As in D, all named enums are considered "scoped".  Needed for better debugging experience.
