### PR TITLE
Don't set flag_evaluation_order by default

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -2,6 +2,8 @@
 
 	* types.cc(TypeVisitor::visit(TypeEnum)): Set ENUM_IS_SCOPED on all
 	enumeral types.
+	* d-lang.cc(d_init_options_struct): Remove setting
+	flag_evaluation_order.
 
 2015-08-10  Iain Buclaw  <ibuclaw@gdcproject.org>
 

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -199,9 +199,6 @@ d_init_options_struct(gcc_options *opts)
   // Keep in synch with existing -fbounds-check flag.
   opts->x_flag_bounds_check = global.params.useArrayBounds;
 
-  // Honour left to right code evaluation.
-  opts->x_flag_evaluation_order = 1;
-
   // D says that signed overflow is precisely defined.
   opts->x_flag_wrapv = 1;
 }


### PR DESCRIPTION
Fixes http://bugzilla.gdcproject.org/show_bug.cgi?id=185

Until it is agreed whether or not we should honour LTR, this should probably be unset for the moment.
