### PR TITLE
Replace uses of $(target_alias) with $(target_noncanonical).

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2015-08-19  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* Make-lang.in: Replace uses of $(target_alias) with
+	$(target_noncanonical).
+
 2015-08-17  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* types.cc(TypeVisitor::visit(TypeEnum)): Set ENUM_IS_SCOPED on all

--- a/gcc/d/Make-lang.in
+++ b/gcc/d/Make-lang.in
@@ -22,7 +22,7 @@
 # Installation name.
 
 D_INSTALL_NAME = $(shell echo gdc|sed '$(program_transform_name)')
-D_TARGET_INSTALL_NAME = $(target_alias)-$(shell echo gdc|sed '$(program_transform_name)')
+D_TARGET_INSTALL_NAME = $(target_noncanonical)-$(shell echo gdc|sed '$(program_transform_name)')
 
 # Name of phobos library
 D_LIBPHOBOS = -DLIBPHOBOS=\"gphobos2\"


### PR DESCRIPTION
I noticed that there was a failing command in `make install` for gdc because `target_alias` was not defined.  I reckon this is because I was calling it with `make -C gcc`, however it seems that `target_noncanonical` has been the correct way to get this information for over ten years now.  Might as well catch-up.
