### PR TITLE
Bug 198: Handle anonymous aggregates in type layout and component referencing.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,22 @@
+2015-10-03  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-codegen.cc(build_two_field_type): Use DECL_FIELD_CONTEXT to access
+	field context decl.
+	(build_frame_type): Likewise.
+	(lookup_anon_field): New function.
+	(component_ref): Use it.
+	(fixup_anonymous_offset): New function.
+	(layout_aggregate_members): New function.
+	(layout_aggregate_type): Move generation of fields into
+	layout_aggregate_members.
+	(insert_aggregate_field): Update signature, update all callers.
+	(finish_aggregate_type): Likewise.
+	* d-todt.cc(dt_container2): Use DECL_FIELD_CONTEXT to access field
+	context decl.
+	* types.cc(TypeVisitor::visit(TypeStruct)): Likewise.
+	(TypeVisitor::visit(TypeClass)): Likewise.
+	* d-tree.h(ANON_AGGR_TYPE_P): New type macro.
+
 2015-08-25  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-builtins.cc(maybe_set_builtin_1): Remove va_list handling.

--- a/gcc/d/d-codegen.h
+++ b/gcc/d/d-codegen.h
@@ -214,8 +214,8 @@ extern tree build_typeinfo (Type *t);
 
 // Record layout
 extern void layout_aggregate_type(AggregateDeclaration *decl, tree type, AggregateDeclaration *base);
-extern void insert_aggregate_field(AggregateDeclaration *decl, tree type, tree field, size_t offset);
-extern void finish_aggregate_type(AggregateDeclaration *decl, tree type, UserAttributeDeclaration *declattrs);
+extern void insert_aggregate_field(Loc loc, tree type, tree field, size_t offset);
+extern void finish_aggregate_type(unsigned structsize, unsigned alignsize, tree type, UserAttributeDeclaration *declattrs);
 
 // Type management for D frontend types.
 // Returns TRUE if T1 and T2 are mutably the same type.

--- a/gcc/d/d-elem.cc
+++ b/gcc/d/d-elem.cc
@@ -1694,55 +1694,55 @@ DelegateExp::toElem (IRState *)
 }
 
 elem *
-DotVarExp::toElem (IRState *)
+DotVarExp::toElem(IRState *)
 {
-  FuncDeclaration *func_decl;
-  VarDeclaration *var_decl;
-  Type *obj_basetype = e1->type->toBasetype();
+  Type *tb = e1->type->toBasetype();
 
-  switch (obj_basetype->ty)
+  switch (tb->ty)
     {
     case Tpointer:
-      if (obj_basetype->nextOf()->toBasetype()->ty != Tstruct)
+      if (tb->nextOf()->toBasetype()->ty != Tstruct)
 	break;
       // drop through
 
     case Tstruct:
     case Tclass:
-      func_decl = var->isFuncDeclaration();
-      var_decl = var->isVarDeclaration();
-      if (func_decl)
+    {
+      FuncDeclaration *fd = var->isFuncDeclaration();
+      VarDeclaration *vd = var->isVarDeclaration();
+      if (fd != NULL)
       {
 	// if Tstruct, objInstanceMethod will use the address of e1
-	if (func_decl->isThis())
-	  return get_object_method (e1->toElem(NULL), e1, func_decl, type);
+	if (fd->isThis())
+	  return get_object_method(e1->toElem(NULL), e1, fd, type);
 	else
 	  {
 	    // Static method; ignore the object instance
-	    return build_address (func_decl->toSymbol()->Stree);
+	    return build_address(fd->toSymbol()->Stree);
     	  }
       }
-      else if (var_decl)
+      else if (vd)
 	{
-	  if (!var_decl->isField())
-	    return get_decl_tree (var_decl);
+	  if (!vd->isField())
+	    return get_decl_tree(vd);
 	  else
 	    {
 	      tree this_tree = e1->toElem(NULL);
-	      if (obj_basetype->ty != Tstruct)
-		this_tree = build_deref (this_tree);
-	      return component_ref (this_tree, var_decl->toSymbol()->Stree);
+	      if (tb->ty != Tstruct)
+		this_tree = build_deref(this_tree);
+	      return component_ref(this_tree, vd->toSymbol()->Stree);
 	    }
 	}
       else
-	error ("%s is not a field, but a %s", var->toChars(), var->kind());
+	error("%s is not a field, but a %s", var->toChars(), var->kind());
       break;
+    }
 
     default:
       break;
     }
 
-  error ("Don't know how to handle %s", toChars());
+  error("Don't know how to handle %s", toChars());
   return error_mark_node;
 }
 

--- a/gcc/d/d-todt.cc
+++ b/gcc/d/d-todt.cc
@@ -109,7 +109,7 @@ dt_container2(dt_t *dt)
 	  tree field = build_decl(UNKNOWN_LOCATION, FIELD_DECL, NULL_TREE, TREE_TYPE(value));
 	  tree size = TYPE_SIZE_UNIT(TREE_TYPE(value));
 
-	  DECL_CONTEXT(field) = aggtype;
+	  DECL_FIELD_CONTEXT(field) = aggtype;
 	  DECL_FIELD_OFFSET(field) = offset;
 	  DECL_FIELD_BIT_OFFSET(field) = bitsize_zero_node;
 	  SET_DECL_OFFSET_ALIGN(field, TYPE_ALIGN(TREE_TYPE(value)));

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -174,7 +174,11 @@ lang_tree_node
 
 // True if the type is an imaginary float type.
 #define D_TYPE_IMAGINARY_FLOAT(NODE) \
-  (TYPE_LANG_FLAG_1 (TREE_CHECK ((NODE), REAL_TYPE)))
+  (TYPE_LANG_FLAG_0 (TREE_CHECK ((NODE), REAL_TYPE)))
+
+// True if the type is an anonymous record or union.
+#define ANON_AGGR_TYPE_P(NODE) \
+  (TYPE_LANG_FLAG_1 (RECORD_OR_UNION_CHECK (NODE)))
 
 // True if the symbol should be made "link one only".  This is used to
 // defer calling make_decl_one_only() before the decl has been prepared.

--- a/gcc/d/dfrontend/attrib.c
+++ b/gcc/d/dfrontend/attrib.c
@@ -685,6 +685,9 @@ AnonDeclaration::AnonDeclaration(Loc loc, bool isunion, Dsymbols *decl)
     this->alignment = 0;
     this->isunion = isunion;
     this->sem = 0;
+    this->anonoffset = 0;
+    this->anonstructsize = 0;
+    this->anonalignsize = 0;
 }
 
 Dsymbol *AnonDeclaration::syntaxCopy(Dsymbol *s)
@@ -760,8 +763,8 @@ void AnonDeclaration::setFieldOffset(AggregateDeclaration *ad, unsigned *poffset
                 offset = 0;
         }
 
-        unsigned anonstructsize = ad->structsize;
-        unsigned anonalignsize  = ad->alignsize;
+        anonstructsize = ad->structsize;
+        anonalignsize  = ad->alignsize;
         ad->structsize = savestructsize;
         ad->alignsize  = savealignsize;
 
@@ -775,7 +778,7 @@ void AnonDeclaration::setFieldOffset(AggregateDeclaration *ad, unsigned *poffset
         /* Given the anon 'member's size and alignment,
          * go ahead and place it.
          */
-        unsigned anonoffset = AggregateDeclaration::placeField(
+        anonoffset = AggregateDeclaration::placeField(
                 poffset,
                 anonstructsize, anonalignsize, alignment,
                 &ad->structsize, &ad->alignsize,

--- a/gcc/d/dfrontend/attrib.h
+++ b/gcc/d/dfrontend/attrib.h
@@ -132,6 +132,9 @@ public:
     bool isunion;
     structalign_t alignment;
     int sem;                    // 1 if successful semantic()
+    unsigned anonoffset;        // offset of the first member
+    unsigned anonstructsize;    // size of anonymous struct
+    unsigned anonalignsize;     // size of anonymous struct for alignment purposes
 
     AnonDeclaration(Loc loc, bool isunion, Dsymbols *decl);
     Dsymbol *syntaxCopy(Dsymbol *s);
@@ -139,6 +142,7 @@ public:
     void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     const char *kind();
+    AnonDeclaration *isAnonDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/gcc/d/dfrontend/dsymbol.h
+++ b/gcc/d/dfrontend/dsymbol.h
@@ -274,6 +274,7 @@ public:
     virtual DeleteDeclaration *isDeleteDeclaration() { return NULL; }
     virtual SymbolDeclaration *isSymbolDeclaration() { return NULL; }
     virtual AttribDeclaration *isAttribDeclaration() { return NULL; }
+    virtual AnonDeclaration *isAnonDeclaration() { return NULL; }
     virtual OverloadSet *isOverloadSet() { return NULL; }
     virtual void accept(Visitor *v) { v->visit(this); }
 };

--- a/gcc/d/types.cc
+++ b/gcc/d/types.cc
@@ -261,14 +261,17 @@ public:
 
     // Must set up the overall size, etc. before determining the context or
     // laying out fields as those types may make references to this type.
-    TYPE_SIZE (t->ctype) = bitsize_int(t->sym->structsize * BITS_PER_UNIT);
-    TYPE_SIZE_UNIT (t->ctype) = size_int(t->sym->structsize);
-    TYPE_ALIGN (t->ctype) = t->sym->alignsize * BITS_PER_UNIT;
-    TYPE_PACKED (t->ctype) = (t->sym->alignsize == 1);
+    unsigned structsize = t->sym->structsize;
+    unsigned alignsize = t->sym->alignsize;
+
+    TYPE_SIZE (t->ctype) = bitsize_int(structsize * BITS_PER_UNIT);
+    TYPE_SIZE_UNIT (t->ctype) = size_int(structsize);
+    TYPE_ALIGN (t->ctype) = alignsize * BITS_PER_UNIT;
+    TYPE_PACKED (t->ctype) = (alignsize == 1);
     compute_record_mode(t->ctype);
 
     layout_aggregate_type(t->sym, t->ctype, t->sym);
-    finish_aggregate_type(t->sym, t->ctype, t->sym->userAttribDecl);
+    finish_aggregate_type(structsize, alignsize, t->ctype, t->sym->userAttribDecl);
 
     TYPE_CONTEXT (t->ctype) = d_decl_context(t->sym);
     build_type_decl(t->ctype, t->sym);
@@ -411,7 +414,7 @@ public:
     t->ctype = make_node(RECORD_TYPE);
     tree ptr = build_decl(BUILTINS_LOCATION, FIELD_DECL,
 			  get_identifier("ptr"), ptr_type_node);
-    DECL_CONTEXT (ptr) = t->ctype;
+    DECL_FIELD_CONTEXT (ptr) = t->ctype;
     TYPE_FIELDS (t->ctype) = ptr;
     TYPE_NAME (t->ctype) = get_identifier(t->toChars());
     TYPE_TRANSPARENT_AGGR (t->ctype) = 1;
@@ -463,7 +466,7 @@ public:
 
     // Add the fields of each base class
     layout_aggregate_type(t->sym, basetype, t->sym);
-    finish_aggregate_type(t->sym, basetype, t->sym->userAttribDecl);
+    finish_aggregate_type(t->sym->structsize, t->sym->alignsize, basetype, t->sym->userAttribDecl);
 
     // Type is final, there are no derivations.
     if (t->sym->storage_class & STCfinal)

--- a/gcc/testsuite/gdc.test/runnable/gdc.d
+++ b/gcc/testsuite/gdc.test/runnable/gdc.d
@@ -810,6 +810,50 @@ auto test194(ref bool overflow)
 
 /******************************************/
 
+// Bug 198
+
+struct S198
+{
+    union
+    {
+        float[3] v;
+        struct
+        {
+            float x;
+            float y;
+            float z;
+        }
+    }
+
+    this(float x_, float y_, float z_)
+    {
+        x = x_;
+        y = y_;
+        z = z_;
+    }
+
+    ref S198 opOpAssign(string op)(S198 operand)
+    if (op == "+")
+    {
+        x += operand.x;
+        y += operand.y;
+        z += operand.z;
+        return this;
+    }
+}
+
+auto test198()
+{
+    S198 sum = S198(0, 0, 0);
+
+    foreach(size_t v; 0 .. 3)
+        sum += S198(1, 2, 3);
+
+    assert(sum.v == [3, 6, 9]);
+}
+
+/******************************************/
+
 void main()
 {
     test2();
@@ -831,6 +875,7 @@ void main()
     test133();
     test141();
     test179();
+    test198();
 
     printf("Success!\n");
 }


### PR DESCRIPTION
Should fix long standing bugs related to DCE and SRA passes, because a flat
variable list confuses certain constraints, such as a union member with a
non-zero offset, or even stranger, two struct members with the same offset.

```
* d-codegen.cc(build_two_field_type): Use DECL_FIELD_CONTEXT to access
field context decl.
(build_frame_type): Likewise.
(lookup_anon_field): New function.
(component_ref): Use it.
(fixup_anonymous_offset): New function.
(layout_aggregate_members): New function.
(layout_aggregate_type): Move generation of fields into
layout_aggregate_members.
(insert_aggregate_field): Update signature, update all callers.
(finish_aggregate_type): Likewise.
* d-todt.cc(dt_container2): Use DECL_FIELD_CONTEXT to access field
context decl.
* types.cc(TypeVisitor::visit(TypeStruct)): Likewise.
(TypeVisitor::visit(TypeClass)): Likewise.
* d-tree.h(ANON_AGGR_TYPE_P): New type macro.
```
