### PR TITLE
Handle tuple fields when laying out aggregate, and struct literals with anonymous records.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,12 @@
+2015-10-06  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-codegen.cc(build_struct_literal): New function.
+	(layout_aggregate_members): Handle variables that are really tuples.
+	* d-elem.cc(StructLiteralExp::toElem): Handle slicing void arrays.
+	Use build_struct_literal to handle anonymous records.
+	* d-lang.h(d_unknown_type_node): Rename to unknown_type_node, update
+	in all files.
+
 2015-10-03  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-codegen.cc(build_two_field_type): Use DECL_FIELD_CONTEXT to access

--- a/gcc/d/d-builtins.cc
+++ b/gcc/d/d-builtins.cc
@@ -840,7 +840,7 @@ d_init_builtins()
   D_TYPE_IMAGINARY_FLOAT (ireal_type_node) = 1;
 
   /* Used for ModuleInfo, ClassInfo, and Interface decls.  */
-  d_unknown_type_node = make_node(RECORD_TYPE);
+  unknown_type_node = make_node(RECORD_TYPE);
 
   {
     /* Make sure we get a unique function type, so we can give

--- a/gcc/d/d-codegen.h
+++ b/gcc/d/d-codegen.h
@@ -83,6 +83,7 @@ extern tree d_mark_read (tree exp);
 extern tree build_address (tree exp);
 
 extern tree build_struct_memcmp (tree_code code, StructDeclaration *sd, tree arg0, tree arg1);
+extern tree build_struct_literal(tree type, tree init);
 
 // Routines to handle variables that are references.
 extern type_kind declaration_type_kind(Declaration *decl);

--- a/gcc/d/d-decls.cc
+++ b/gcc/d/d-decls.cc
@@ -555,7 +555,7 @@ ClassDeclaration::toSymbol()
       csym = toSymbolX ("__Class", 0, 0, "Z");
 
       tree decl = build_decl (BUILTINS_LOCATION, VAR_DECL,
-			      get_identifier (csym->prettyIdent), d_unknown_type_node);
+			      get_identifier (csym->prettyIdent), unknown_type_node);
       SET_DECL_ASSEMBLER_NAME (decl, get_identifier (csym->Sident));
       csym->Stree = decl;
       d_keep (decl);
@@ -581,7 +581,7 @@ InterfaceDeclaration::toSymbol()
       csym = toSymbolX ("__Interface", 0, 0, "Z");
 
       tree decl = build_decl (BUILTINS_LOCATION, VAR_DECL,
-			      get_identifier (csym->prettyIdent), d_unknown_type_node);
+			      get_identifier (csym->prettyIdent), unknown_type_node);
       SET_DECL_ASSEMBLER_NAME (decl, get_identifier (csym->Sident));
       csym->Stree = decl;
       d_keep (decl);
@@ -606,7 +606,7 @@ Module::toSymbol()
       csym = toSymbolX ("__ModuleInfo", 0, 0, "Z");
 
       tree decl = build_decl (BUILTINS_LOCATION, VAR_DECL,
-			      get_identifier (csym->prettyIdent), d_unknown_type_node);
+			      get_identifier (csym->prettyIdent), unknown_type_node);
       SET_DECL_ASSEMBLER_NAME (decl, get_identifier (csym->Sident));
       csym->Stree = decl;
       d_keep (decl);
@@ -659,7 +659,7 @@ ClassReferenceExp::toSymbol()
       value->sym = new Symbol();
 
       // Build reference symbol.
-      tree decl = build_decl (UNKNOWN_LOCATION, VAR_DECL, NULL_TREE, d_unknown_type_node);
+      tree decl = build_decl (UNKNOWN_LOCATION, VAR_DECL, NULL_TREE, unknown_type_node);
       char *ident;
 
       ASM_FORMAT_PRIVATE_NAME (ident, "*", DECL_UID (decl));

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -1826,7 +1826,7 @@ d_finish_symbol (Symbol *sym)
       if (DECL_INITIAL (decl) == NULL_TREE)
 	{
 	  tree sinit = dtvector_to_tree (sym->Sdt);
-	  if (TREE_TYPE (decl) == d_unknown_type_node)
+	  if (TREE_TYPE (decl) == unknown_type_node)
 	    {
 	      TREE_TYPE (decl) = TREE_TYPE (sinit);
 	      TYPE_NAME (TREE_TYPE (decl)) = get_identifier (sym->Sident);

--- a/gcc/d/d-todt.cc
+++ b/gcc/d/d-todt.cc
@@ -47,7 +47,7 @@ dt_t **
 dt_cons(dt_t **pdt, tree val)
 {
   if (*pdt == NULL_TREE)
-    *pdt = build_constructor(d_unknown_type_node, NULL);
+    *pdt = build_constructor(unknown_type_node, NULL);
 
   CONSTRUCTOR_APPEND_ELT(CONSTRUCTOR_ELTS(*pdt), 0, val);
   return pdt;

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -244,6 +244,6 @@ extern GTY(()) tree d_global_trees[DTI_MAX];
 #define ifloat_type_node		d_global_trees[DTI_IFLOAT_TYPE]
 #define idouble_type_node		d_global_trees[DTI_IDOUBLE_TYPE]
 #define ireal_type_node			d_global_trees[DTI_IREAL_TYPE]
-#define d_unknown_type_node		d_global_trees[DTI_UNKNOWN_TYPE]
+#define unknown_type_node		d_global_trees[DTI_UNKNOWN_TYPE]
 
 #endif

--- a/gcc/d/dfrontend/mtype.c
+++ b/gcc/d/dfrontend/mtype.c
@@ -7881,7 +7881,7 @@ Expression *TypeStruct::defaultInitLiteral(Loc loc)
             error(loc, "circular reference to '%s'", vd->toPrettyChars());
             return new ErrorExp();
         }
-        if (vd->offset < offset)
+        if (vd->offset < offset || vd->type->size() == 0)
             e = NULL;
         else if (vd->init)
         {

--- a/gcc/d/dfrontend/struct.c
+++ b/gcc/d/dfrontend/struct.c
@@ -1132,7 +1132,11 @@ bool StructDeclaration::fill(Loc loc, Expressions *elements, bool ctorinit)
         if (elements && vx)
         {
             Expression *e;
-            if (vx->init)
+            if (vx->type->size() == 0)
+            {
+                e = NULL;
+            }
+            else if (vx->init)
             {
                 assert(!vx->init->isVoidInitializer());
                 e = vx->getConstInitializer(false);

--- a/gcc/testsuite/gdc.test/runnable/gdc.d
+++ b/gcc/testsuite/gdc.test/runnable/gdc.d
@@ -812,7 +812,7 @@ auto test194(ref bool overflow)
 
 // Bug 198
 
-struct S198
+struct S198a
 {
     union
     {
@@ -832,7 +832,7 @@ struct S198
         z = z_;
     }
 
-    ref S198 opOpAssign(string op)(S198 operand)
+    ref S198a opOpAssign(string op)(S198a operand)
     if (op == "+")
     {
         x += operand.x;
@@ -842,12 +842,40 @@ struct S198
     }
 }
 
+struct S198b
+{
+    @property get()
+    {
+        union Buf
+        {
+            void[0] result;
+        }
+        const Buf buf = { };
+        return buf.result;
+    }
+}
+
+struct S198c
+{
+    @property get()
+    {
+        union Buf
+        {
+            TypeInfo info;
+            void[0] result;
+        }
+        const Buf buf = { };
+        return buf.result;
+    }
+}
+
+
 auto test198()
 {
-    S198 sum = S198(0, 0, 0);
+    S198a sum = S198a(0, 0, 0);
 
     foreach(size_t v; 0 .. 3)
-        sum += S198(1, 2, 3);
+        sum += S198a(1, 2, 3);
 
     assert(sum.v == [3, 6, 9]);
 }


### PR DESCRIPTION
Second part of fixing bug 198, and part-way towards 183 too.

```
* d-codegen.cc(build_struct_literal): New function.
(layout_aggregate_members): Handle variables that are really tuples.
* d-elem.cc(StructLiteralExp::toElem): Handle slicing void arrays.
Use build_struct_literal to handle anonymous records.
* d-lang.h(d_unknown_type_node): Rename to unknown_type_node, update
in all files.
```
