### PR TITLE
Bug 196: Fix unexpected token in assembly output

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,9 @@
+2015-10-07  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-decls.cc(StructLiteralExp::toSymbol): Use letter prefix for
+	anonymous name.  Don't set TREE_READONLY.
+	(ClassReferenceExp::toSymbol): Likewise.
+
 2015-10-06  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-codegen.cc(build_struct_literal): New function.

--- a/gcc/d/d-decls.cc
+++ b/gcc/d/d-decls.cc
@@ -631,21 +631,20 @@ StructLiteralExp::toSymbol()
 
       // Build reference symbol.
       tree ctype = build_ctype(type);
-      tree decl = build_decl (UNKNOWN_LOCATION, VAR_DECL, NULL_TREE, ctype);
-      get_unique_name (decl, "*");
-      set_decl_location (decl, loc);
+      tree decl = build_decl(UNKNOWN_LOCATION, VAR_DECL, NULL_TREE, ctype);
+      get_unique_name(decl, "S");
+      set_decl_location(decl, loc);
 
       TREE_PUBLIC (decl) = 0;
       TREE_STATIC (decl) = 1;
-      TREE_READONLY (decl) = 1;
       TREE_USED (decl) = 1;
       DECL_ARTIFICIAL (decl) = 1;
 
       sym->Stree = decl;
       this->sinit = sym;
 
-      toDt (&sym->Sdt);
-      d_finish_symbol (sym);
+      toDt(&sym->Sdt);
+      d_finish_symbol(sym);
     }
 
   return sym;
@@ -659,24 +658,23 @@ ClassReferenceExp::toSymbol()
       value->sym = new Symbol();
 
       // Build reference symbol.
-      tree decl = build_decl (UNKNOWN_LOCATION, VAR_DECL, NULL_TREE, unknown_type_node);
+      tree decl = build_decl(UNKNOWN_LOCATION, VAR_DECL, NULL_TREE, unknown_type_node);
       char *ident;
 
-      ASM_FORMAT_PRIVATE_NAME (ident, "*", DECL_UID (decl));
-      DECL_NAME (decl) = get_identifier (ident);
-      set_decl_location (decl, loc);
+      ASM_FORMAT_PRIVATE_NAME (ident, "C", DECL_UID (decl));
+      DECL_NAME (decl) = get_identifier(ident);
+      set_decl_location(decl, loc);
 
       TREE_PUBLIC (decl) = 0;
       TREE_STATIC (decl) = 1;
-      TREE_READONLY (decl) = 1;
       TREE_USED (decl) = 1;
       DECL_ARTIFICIAL (decl) = 1;
 
       value->sym->Stree = decl;
       value->sym->Sident = ident;
 
-      toInstanceDt (&value->sym->Sdt);
-      d_finish_symbol (value->sym);
+      toInstanceDt(&value->sym->Sdt);
+      d_finish_symbol(value->sym);
 
       value->sinit = value->sym;
     }

--- a/gcc/testsuite/gdc.test/runnable/gdc.d
+++ b/gcc/testsuite/gdc.test/runnable/gdc.d
@@ -810,6 +810,29 @@ auto test194(ref bool overflow)
 
 /******************************************/
 
+// Bug 196
+
+class C196
+{
+    int a;
+}
+
+struct S196
+{
+    int a;
+}
+
+void test196()
+{
+    __gshared c = new C196();
+    __gshared s = new S196(0);
+    c.a = 1;
+    s.a = 1;
+}
+
+
+/******************************************/
+
 // Bug 198
 
 struct S198a
@@ -903,6 +926,7 @@ void main()
     test133();
     test141();
     test179();
+    test196();
     test198();
 
     printf("Success!\n");


### PR DESCRIPTION
http://bugzilla.gdcproject.org/show_bug.cgi?id=196

```
* d-decls.cc(StructLiteralExp::toSymbol): Use letter prefix for
anonymous name.
(ClassReferenceExp::toSymbol): Likewise.  Don't set TREE_READONLY.
```
