### PR TITLE
Fix ice-invalid when initializing struct with an array

### DIFF
--- a/gcc/d/dfrontend/init.c
+++ b/gcc/d/dfrontend/init.c
@@ -480,6 +480,12 @@ Initializer *ArrayInitializer::semantic(Scope *sc, Type *t, NeedInterpret needIn
                 e = toAssocArrayLiteral();
             else
                 e = toExpression();
+            if (!e)
+            {
+                error(loc, "cannot use array to initialize %s", t->toChars());
+                goto Lerr;
+            }
+
             ExpInitializer *ei = new ExpInitializer(e->loc, e);
             return ei->semantic(sc, t, needInterpret);
         }


### PR DESCRIPTION
The following patch fixes a crash on the following invalid code:

struct S
{
}

S g =
[
  { 1[] }
];
