### PR TITLE
Fix bug where non-trivially copyable arrays were being copied in the wrong direction

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2016-02-03  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-elem.cc (AssignExp::toElem): Pass parameters for arraycopy and
+	arrayassign in the correct order.
+
 2016-01-31  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* longdouble.h (longdouble): Use one contiguous array for the

--- a/gcc/d/d-elem.cc
+++ b/gcc/d/d-elem.cc
@@ -938,13 +938,13 @@ AssignExp::toElem(IRState *)
 	    }
 	  else if (postblit && op != TOKblit)
 	    {
-	      // Generate _d_arrayassign() or _d_arrayctor()
+	      // Generate _d_arrayassign(ti, from, to) or _d_arrayctor(ti, from, to)
 	      tree args[3];
 	      LibCall libcall;
 
 	      args[0] = build_typeinfo(etype);
-	      args[1] = maybe_make_temp(d_array_convert(e1));
-	      args[2] = d_array_convert(e2);
+	      args[1] = maybe_make_temp(d_array_convert(e2));
+	      args[2] = d_array_convert(e1);
 	      libcall = (op == TOKconstruct) ? LIBCALL_ARRAYCTOR : LIBCALL_ARRAYASSIGN;
 
 	      return build_libcall(libcall, 3, args, build_ctype(type));
@@ -1031,14 +1031,14 @@ AssignExp::toElem(IRState *)
       
       if (postblit && op != TOKblit)
 	{
-	  // Generate _d_arrayassign() or _d_arrayctor()
+	  // Generate _d_arrayassign(ti, from, to) or _d_arrayctor(ti, from, to)
 	  tree t1 = e1->toElem(NULL);
 	  tree args[3];
 	  LibCall libcall;
 
 	  args[0] = build_typeinfo(etype);
-	  args[1] = d_array_convert(e1);
-	  args[2] = d_array_convert(e2);
+	  args[1] = d_array_convert(e2);
+	  args[2] = d_array_convert(e1);
 	  libcall = (op == TOKconstruct) ? LIBCALL_ARRAYCTOR : LIBCALL_ARRAYASSIGN;
 
 	  tree result = build_libcall(libcall, 3, args);


### PR DESCRIPTION
This has always been a bug, but never discovered!

See https://github.com/D-Programming-GDC/GDC/commit/887ebcc1456aa519a4038f6ac4399789284d5cb8
