### PR TITLE
Adjust flags for druntime and phobos unittest builds

### DIFF
--- a/libphobos/libdruntime/Makefile.am
+++ b/libphobos/libdruntime/Makefile.am
@@ -38,7 +38,7 @@ SUFFIXES = .d
 	$(CC) -o $@ $(OUR_CFLAGS) $(CFLAGS) -c $<
 
 %.t.o : %.d
-	$(GDC) -o $@ $(DFLAGSX) -fno-invariants $(D_EXTRA_DFLAGS) $(MULTIFLAGS) -c $<
+	$(GDC) -o $@ $(DFLAGSX) $(D_EXTRA_DFLAGS) $(MULTIFLAGS) -c $<
 
 %.t.o : %.o
 	cp $< $@

--- a/libphobos/libdruntime/Makefile.in
+++ b/libphobos/libdruntime/Makefile.in
@@ -455,7 +455,7 @@ all-local: libgdruntime.a
 	$(CC) -o $@ $(OUR_CFLAGS) $(CFLAGS) -c $<
 
 %.t.o : %.d
-	$(GDC) -o $@ $(DFLAGSX) -fno-invariants $(D_EXTRA_DFLAGS) $(MULTIFLAGS) -c $<
+	$(GDC) -o $@ $(DFLAGSX) $(D_EXTRA_DFLAGS) $(MULTIFLAGS) -c $<
 
 %.t.o : %.o
 	cp $< $@

--- a/libphobos/src/Makefile.am
+++ b/libphobos/src/Makefile.am
@@ -122,7 +122,7 @@ libgphobos2_t.a : $(ALL_PHOBOS_OBJS:.o=.t.o)
 	$(RANLIB) $@
 
 unittest: libgphobos2.a libgphobos2_t.a unittest.o
-	$(GDC) -o $@ $(CFLAGS) unittest.o -L./ -L../libdruntime -lgphobos2_t -lgdruntime $(LIBS) $(DL_LIBS)
+	$(GDC) -o $@ $(CFLAGS) unittest.o -nophoboslib -L./ -L../libdruntime -lgphobos2_t -lgdruntime $(LIBS) $(DL_LIBS)
 
 #--------------------------------------#
 # Install, doc, etc targets

--- a/libphobos/src/Makefile.in
+++ b/libphobos/src/Makefile.in
@@ -471,7 +471,7 @@ libgphobos2_t.a : $(ALL_PHOBOS_OBJS:.o=.t.o)
 	$(RANLIB) $@
 
 unittest: libgphobos2.a libgphobos2_t.a unittest.o
-	$(GDC) -o $@ $(CFLAGS) unittest.o -L./ -L../libdruntime -lgphobos2_t -lgdruntime $(LIBS) $(DL_LIBS)
+	$(GDC) -o $@ $(CFLAGS) unittest.o -nophoboslib -L./ -L../libdruntime -lgphobos2_t -lgdruntime $(LIBS) $(DL_LIBS)
 
 #--------------------------------------#
 # Install, doc, etc targets


### PR DESCRIPTION
Whatever was broken that needed -fno-invariants seems long since fixed.

I noticed when building phobos unittest, it was try to link in libgphobos2 as well as libgphobos2_t, so to avoid any hiding errors, removed it.
