### PR TITLE
Add two new codegen routines for building condition expressions

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,13 @@
+2016-02-18  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-codegen.cc (build_condition): New function.  Update all callers
+	that generate a COND_EXPR that returns a value to use it.
+	(build_vcondition): New function.  Update all callers that generate a
+	void COND_EXPR to use it.
+	* toir.cc (IRVisitor::visit(DoStatement)): Build a COND_EXPR instead
+	of an EXIT_EXPR to break from the loop.
+	(IRVisitor::visit(ForStatement)): Likewise.
+
 2016-02-14  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-elem.cc: Remove redundant IRState parameter from all lowering

--- a/gcc/d/d-codegen.h
+++ b/gcc/d/d-codegen.h
@@ -261,6 +261,8 @@ extern tree build_vinit(tree dst, tree src);
 extern tree build_nop(tree t, tree e);
 extern tree build_vconvert(tree t, tree e);
 extern tree build_boolop(tree_code code, tree arg0, tree arg1);
+extern tree build_condition(tree type, tree arg0, tree arg1, tree arg2);
+extern tree build_vcondition(tree arg0, tree arg1, tree arg2);
 
 extern tree compound_expr(tree arg0, tree arg1);
 extern tree vcompound_expr(tree arg0, tree arg1);

--- a/gcc/d/toir.cc
+++ b/gcc/d/toir.cc
@@ -206,7 +206,7 @@ public:
 
     // Wrap up our constructed if condition into a COND_EXPR.
     set_input_location(s->loc);
-    tree cond = build3(COND_EXPR, void_type_node, ifcond, ifbody, elsebody);
+    tree cond = build_vcondition(ifcond, ifbody, elsebody);
     add_stmt(cond);
 
     // Finish the if-then scope.
@@ -248,8 +248,9 @@ public:
     set_input_location(s->condition->loc);
     tree exitcond = convert_for_condition(s->condition->toElemDtor(),
 					  s->condition->type);
-    add_stmt(build1(EXIT_EXPR, void_type_node,
-		    build1(TRUTH_NOT_EXPR, TREE_TYPE (exitcond), exitcond)));
+    add_stmt(build_vcondition(exitcond, void_node,
+			      build1(GOTO_EXPR, void_type_node, lbreak)));
+    TREE_USED (lbreak) = 1;
 
     tree body = this->end_scope();
     set_input_location(s->loc);
@@ -273,8 +274,9 @@ public:
 	set_input_location(s->condition->loc);
 	tree exitcond = convert_for_condition(s->condition->toElemDtor(),
 					      s->condition->type);
-	add_stmt(build1(EXIT_EXPR, void_type_node,
-			build1(TRUTH_NOT_EXPR, TREE_TYPE (exitcond), exitcond)));
+	add_stmt(build_vcondition(exitcond, void_node,
+				  build1(GOTO_EXPR, void_type_node, lbreak)));
+	TREE_USED (lbreak) = 1;
       }
 
     if (s->body)
@@ -478,8 +480,7 @@ public:
 		tree ifcase = build2(EQ_EXPR, build_ctype(condtype), condition,
 				     cs->exp->toElemDtor());
 		tree ifbody = fold_build1(GOTO_EXPR, void_type_node, caselabel);
-		tree cond = build3(COND_EXPR, void_type_node,
-				   ifcase, ifbody, void_node);
+		tree cond = build_vcondition(ifcase, ifbody, void_node);
 		TREE_USED (caselabel) = 1;
 		D_LABEL_VARIABLE_CASE (caselabel) = 1;
 		add_stmt(cond);


### PR DESCRIPTION
Refactors the way conditional break statements are generated.

Before: exit_expr(condition);
After:  cond_expr(condition, goto Lbreak, void);
