### PR TITLE
Always accept requests for integral types up to 128bits.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -14,6 +14,12 @@
 	* d-lang.cc (parse_int): Remove function.
 	(d_handle_option): Use integral_argument to parse numbers.
 
+	* d-codegen.cc (lower_struct_comparison): Built custom type if
+	lang_hooks.types.type_for_mode returns nothing.
+	* d-lang.cc (d_type_for_mode): Always support cent/ucent modes.
+	(d_type_for_size): Add support for cent/ucent precision types.
+	(d_signed_or_unsigned_type): Always support cent/ucent precisions.
+
 2016-02-18  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-codegen.cc (build_condition): New function.  Update all callers

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -1888,11 +1888,11 @@ lower_struct_comparison(tree_code code, StructDeclaration *sd, tree t1, tree t2)
   // Let backend take care of union comparisons.
   if (sd->isUnionDeclaration())
     {
-      tmemcmp = d_build_call_nary (builtin_decl_explicit (BUILT_IN_MEMCMP), 3,
-				   build_address (t1), build_address (t2),
-				   size_int (sd->structsize));
+      tmemcmp = d_build_call_nary(builtin_decl_explicit(BUILT_IN_MEMCMP), 3,
+				  build_address(t1), build_address(t2),
+				  size_int(sd->structsize));
 
-      return build_boolop (code, tmemcmp, integer_zero_node);
+      return build_boolop(code, tmemcmp, integer_zero_node);
     }
 
   for (size_t i = 0; i < sd->fields.dim; i++)
@@ -1900,8 +1900,8 @@ lower_struct_comparison(tree_code code, StructDeclaration *sd, tree t1, tree t2)
       VarDeclaration *vd = sd->fields[i];
       tree sfield = vd->toSymbol()->Stree;
 
-      tree t1ref = component_ref (t1, sfield);
-      tree t2ref = component_ref (t2, sfield);
+      tree t1ref = component_ref(t1, sfield);
+      tree t2ref = component_ref(t2, sfield);
       tree tcmp;
 
       if (vd->type->ty == Tstruct)
@@ -1913,18 +1913,21 @@ lower_struct_comparison(tree_code code, StructDeclaration *sd, tree t1, tree t2)
       else
 	{
 	  tree stype = build_ctype(vd->type);
-	  machine_mode mode = int_mode_for_mode (TYPE_MODE (stype));
+	  machine_mode mode = int_mode_for_mode(TYPE_MODE (stype));
 
 	  if (vd->type->isintegral())
 	    {
 	      // Integer comparison, no special handling required.
-	      tcmp = build_boolop (code, t1ref, t2ref);
+	      tcmp = build_boolop(code, t1ref, t2ref);
 	    }
 	  else if (mode != BLKmode)
 	    {
 	      // Compare field bits as their corresponding integer type.
 	      //   *((T*) &t1) == *((T*) &t2)
-	      tree tmode = lang_hooks.types.type_for_mode (mode, 1);
+	      tree tmode = lang_hooks.types.type_for_mode(mode, 1);
+
+	      if (tmode == NULL_TREE)
+		tmode = make_unsigned_type(GET_MODE_BITSIZE (mode));
 
 	      t1ref = build_vconvert(tmode, t1ref);
 	      t2ref = build_vconvert(tmode, t2ref);

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -1237,10 +1237,8 @@ d_type_for_mode(machine_mode mode, int unsignedp)
   if (mode == DImode)
     return unsignedp ? ulong_type_node : long_type_node;
 
-#if HOST_BITS_PER_WIDE_INT >= 64
   if (mode == TYPE_MODE(cent_type_node))
     return unsignedp ? ucent_type_node : cent_type_node;
-#endif
 
   if (mode == TYPE_MODE(float_type_node))
     return float_type_node;
@@ -1300,6 +1298,9 @@ d_type_for_size(unsigned bits, int unsignedp)
   if (bits <= TYPE_PRECISION(long_type_node))
     return unsignedp ? ulong_type_node : long_type_node;
 
+  if (bits <= TYPE_PRECISION(cent_type_node))
+    return unsignedp ? ucent_type_node : cent_type_node;
+
   return 0;
 }
 
@@ -1310,16 +1311,18 @@ d_signed_or_unsigned_type(int unsignedp, tree type)
       || TYPE_UNSIGNED(type) == (unsigned) unsignedp)
     return type;
 
-#if HOST_BITS_PER_WIDE_INT >= 64
   if (TYPE_PRECISION(type) == TYPE_PRECISION(cent_type_node))
     return unsignedp ? ucent_type_node : cent_type_node;
-#endif
+
   if (TYPE_PRECISION(type) == TYPE_PRECISION(long_type_node))
     return unsignedp ? ulong_type_node : long_type_node;
+
   if (TYPE_PRECISION(type) == TYPE_PRECISION(int_type_node))
     return unsignedp ? uint_type_node : int_type_node;
+
   if (TYPE_PRECISION(type) == TYPE_PRECISION(short_type_node))
     return unsignedp ? ushort_type_node : short_type_node;
+
   if (TYPE_PRECISION(type) == TYPE_PRECISION(byte_type_node))
     return unsignedp ? ubyte_type_node : byte_type_node;
 


### PR DESCRIPTION
This could come from either the middle-end or in some codegen routines, such as `lower_struct_comparison`
