### PR TITLE
Add special handling for artificial symbol for struct literals

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -25,6 +25,11 @@
 	(expand_intrinsic_vaarg): Likewise.
 	* d-lang.cc (d_type_promotes_to): Likewise.
 
+	* d-elem.cc (AddrExp::toElem): Take address of the static const symbol
+	for the struct literal,  not the const constructor.
+	(CallExp::toElem): Don't pass generated static struct literal symbol
+	as the object parameter for DotVar call expressions.
+
 2016-02-18  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-codegen.cc (build_condition): New function.  Update all callers


### PR DESCRIPTION
These are things that were fixed during 2.066 (or maybe earlier), but a testcase that caught it was added first in 2.067.
