### PR TITLE
Bug 202: Undefined reference to libcurl functions

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -12,6 +12,9 @@
 	(d_finish_function): Don't send DECL_ABSTRACT_P functions to backend.
 	(d_finish_compilation): Mark all symbols as needed.
 
+	* d-objfile.cc: Remove redundant bool parameter from all lowering
+	routines for symbols, update all callers.
+
 2016-02-22  Eugene Wissner <belka@caraus.de>
 
 	* d-lang.cc (d_init): Remove short_double parameter from

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,17 @@
+2016-03-03  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-objfile.cc (gcc_attribute_p): New function.
+	(output_declaration_p): Inline into FuncDeclaration::ObjFile.
+	(unnest_function): Likewise.
+	(FuncDeclaration::toObjFile): Remove named parameter, update all
+	callers to ignore it.
+	(d_comdat_group): Use DECL_ASSEMBLER_NAME for the comdat group.
+	(d_comdat_linkage): Catch duplicate instantiations of templates, put
+	them in the same comdat group.
+	(setup_symbol_storage): Mark templates not to be written as abstract.
+	(d_finish_function): Don't send DECL_ABSTRACT_P functions to backend.
+	(d_finish_compilation): Mark all symbols as needed.
+
 2016-02-22  Eugene Wissner <belka@caraus.de>
 
 	* d-lang.cc (d_init): Remove short_double parameter from

--- a/gcc/d/d-decls.cc
+++ b/gcc/d/d-decls.cc
@@ -472,7 +472,7 @@ FuncDeclaration::toThunkSymbol (int offset)
   Thunk *thunk;
 
   toSymbol();
-  toObjFile(false);
+  toObjFile();
 
   /* If the thunk is to be static (that is, it is being emitted in this
      module, there can only be one FUNCTION_DECL for it.   Thus, there

--- a/gcc/d/d-decls.cc
+++ b/gcc/d/d-decls.cc
@@ -472,7 +472,7 @@ FuncDeclaration::toThunkSymbol (int offset)
   Thunk *thunk;
 
   toSymbol();
-  toObjFile(true);
+  toObjFile(false);
 
   /* If the thunk is to be static (that is, it is being emitted in this
      module, there can only be one FUNCTION_DECL for it.   Thus, there

--- a/gcc/d/d-elem.cc
+++ b/gcc/d/d-elem.cc
@@ -1854,7 +1854,7 @@ DeclarationExp::toElem()
     }
 
   push_stmt_list();
-  declaration->toObjFile (0);
+  declaration->toObjFile();
   tree t = pop_stmt_list();
 
   /* Construction of an array for typesafe-variadic function arguments

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -106,7 +106,7 @@ gcc_attribute_p(Dsymbol *dsym)
 }
 
 void
-Dsymbol::toObjFile(bool)
+Dsymbol::toObjFile()
 {
   // Emit the imported symbol to debug.
   Import *imp = this->isImport();
@@ -178,13 +178,13 @@ Dsymbol::toObjFile(bool)
 	{
 	  Declaration *d = ((DsymbolExp *) o)->s->isDeclaration();
 	  if (d)
-	    d->toObjFile(false);
+	    d->toObjFile();
 	}
     }
 }
 
 void
-AttribDeclaration::toObjFile(bool)
+AttribDeclaration::toObjFile()
 {
   Dsymbols *d = include (NULL, NULL);
 
@@ -194,12 +194,12 @@ AttribDeclaration::toObjFile(bool)
   for (size_t i = 0; i < d->dim; i++)
     {
       Dsymbol *s = (*d)[i];
-      s->toObjFile(false);
+      s->toObjFile();
     }
 }
 
 void
-PragmaDeclaration::toObjFile(bool)
+PragmaDeclaration::toObjFile()
 {
   if (!global.params.ignoreUnsupportedPragmas)
     {
@@ -209,11 +209,11 @@ PragmaDeclaration::toObjFile(bool)
 	 warning (loc, "pragma(startaddress) not implemented");
     }
 
-  AttribDeclaration::toObjFile(false);
+  AttribDeclaration::toObjFile();
 }
 
 void
-Nspace::toObjFile(bool)
+Nspace::toObjFile()
 {
   if (isError(this) || !members)
     return;
@@ -221,12 +221,12 @@ Nspace::toObjFile(bool)
   for (size_t i = 0; i < members->dim; i++)
     {
       Dsymbol *s = (*members)[i];
-      s->toObjFile(false);
+      s->toObjFile();
     }
 }
 
 void
-StructDeclaration::toObjFile(bool)
+StructDeclaration::toObjFile()
 {
   if (type->ty == Terror)
     {
@@ -259,22 +259,22 @@ StructDeclaration::toObjFile(bool)
       Dsymbol *member = (*members)[i];
       // There might be static ctors in the members, and they cannot
       // be put in separate object files.
-      member->toObjFile(false);
+      member->toObjFile();
     }
 
   // Put out xopEquals, xopCmp and xopHash
   if (xeq && xeq != xerreq)
-    xeq->toObjFile(false);
+    xeq->toObjFile();
 
   if (xcmp && xcmp != xerrcmp)
-    xcmp->toObjFile(false);
+    xcmp->toObjFile();
 
   if (xhash)
-    xhash->toObjFile(false);
+    xhash->toObjFile();
 }
 
 void
-ClassDeclaration::toObjFile(bool)
+ClassDeclaration::toObjFile()
 {
   if (type->ty == Terror)
     {
@@ -289,7 +289,7 @@ ClassDeclaration::toObjFile(bool)
   for (size_t i = 0; i < members->dim; i++)
     {
       Dsymbol *member = (*members)[i];
-      member->toObjFile(false);
+      member->toObjFile();
     }
 
   // Generate C symbols
@@ -629,7 +629,7 @@ ClassDeclaration::baseVtblOffset (BaseClass *bc)
 }
 
 void
-InterfaceDeclaration::toObjFile(bool)
+InterfaceDeclaration::toObjFile()
 {
   if (type->ty == Terror)
     {
@@ -644,7 +644,7 @@ InterfaceDeclaration::toObjFile(bool)
   for (size_t i = 0; i < members->dim; i++)
     {
       Dsymbol *member = (*members)[i];
-      member->toObjFile(false);
+      member->toObjFile();
     }
 
   // Generate C symbols
@@ -652,7 +652,7 @@ InterfaceDeclaration::toObjFile(bool)
 
   // Put out the TypeInfo
   type->genTypeInfo(NULL);
-  type->vtinfo->toObjFile(false);
+  type->vtinfo->toObjFile();
 
   /* Put out the ClassInfo.
    * The layout is:
@@ -762,7 +762,7 @@ InterfaceDeclaration::toObjFile(bool)
 }
 
 void
-EnumDeclaration::toObjFile(bool)
+EnumDeclaration::toObjFile()
 {
   if (semanticRun >= PASSobj)
     return;
@@ -792,7 +792,7 @@ EnumDeclaration::toObjFile(bool)
 }
 
 void
-VarDeclaration::toObjFile(bool)
+VarDeclaration::toObjFile()
 {
   if (type->ty == Terror)
     {
@@ -802,7 +802,7 @@ VarDeclaration::toObjFile(bool)
 
   if (aliassym)
     {
-      toAlias()->toObjFile(false);
+      toAlias()->toObjFile();
       return;
     }
 
@@ -894,7 +894,7 @@ VarDeclaration::toObjFile(bool)
 }
 
 void
-TemplateInstance::toObjFile(bool)
+TemplateInstance::toObjFile()
 {
   if (isError (this)|| !members)
     return;
@@ -905,12 +905,12 @@ TemplateInstance::toObjFile(bool)
   for (size_t i = 0; i < members->dim; i++)
     {
       Dsymbol *s = (*members)[i];
-      s->toObjFile(false);
+      s->toObjFile();
     }
 }
 
 void
-TemplateMixin::toObjFile(bool)
+TemplateMixin::toObjFile()
 {
   if (isError (this)|| !members)
     return;
@@ -918,12 +918,12 @@ TemplateMixin::toObjFile(bool)
   for (size_t i = 0; i < members->dim; i++)
     {
       Dsymbol *s = (*members)[i];
-      s->toObjFile(false);
+      s->toObjFile();
     }
 }
 
 void
-TypeInfoDeclaration::toObjFile(bool)
+TypeInfoDeclaration::toObjFile()
 {
   Symbol *s = toSymbol();
   toDt (&s->Sdt);
@@ -1081,7 +1081,7 @@ Module::genmoduleinfo()
 // down to assembler language output.
 
 void
-FuncDeclaration::toObjFile(bool)
+FuncDeclaration::toObjFile()
 {
   // Already generated the function.
   if (this->semanticRun >= PASSobj)
@@ -1162,7 +1162,7 @@ FuncDeclaration::toObjFile(bool)
   // first so we need to arrange for toObjFile to be called earlier.
   FuncDeclaration *fdp = this->toParent2()->isFuncDeclaration();
   if (fdp && fdp->semanticRun < PASSobj)
-    fdp->toObjFile(false);
+    fdp->toObjFile();
 
   if (global.params.verbose)
     fprintf (global.stdmsg, "function  %s\n", this->toPrettyChars());
@@ -1375,7 +1375,7 @@ FuncDeclaration::toObjFile(bool)
   for (size_t i = 0; i < cfun->language->deferred_fns.length(); ++i)
     {
       FuncDeclaration *fd = cfun->language->deferred_fns[i];
-      fd->toObjFile(false);
+      fd->toObjFile();
     }
 
   if (UnitTestDeclaration *ud = this->isUnitTestDeclaration())
@@ -1383,7 +1383,7 @@ FuncDeclaration::toObjFile(bool)
       for (size_t i = 0; i < ud->deferredNested.dim; ++i)
 	{
 	  FuncDeclaration *fd = ud->deferredNested[i];
-	  fd->toObjFile(false);
+	  fd->toObjFile();
 	}
     }
 
@@ -1408,7 +1408,7 @@ Module::genobjfile(bool)
       for (size_t i = 0; i < members->dim; i++)
 	{
 	  Dsymbol *dsym = (*members)[i];
-	  dsym->toObjFile(false);
+	  dsym->toObjFile();
 	}
     }
 
@@ -2193,7 +2193,7 @@ build_simple_function (const char *name, tree expr, bool static_ctor)
   // %% Maybe remove the identifier
   WrappedExp *body = new WrappedExp (mod->loc, expr, Type::tvoid);
   func->fbody = new ExpStatement (mod->loc, body);
-  func->toObjFile(false);
+  func->toObjFile();
 
   return func;
 }
@@ -2284,7 +2284,7 @@ build_emutls_function (vec<VarDeclaration *> tlsVars)
     }
   func->fbody = new CompoundStatement (mod->loc, body);
   func->semantic3 (mod->scope);
-  func->toObjFile (false);
+  func->toObjFile();
 
   return func->toSymbol();
 }

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -62,7 +62,6 @@ static Symbol *build_emutls_function (vec<VarDeclaration *> tlsVars);
 static Symbol *build_ctor_function (const char *, vec<FuncDeclaration *>, vec<VarDeclaration *>);
 static Symbol *build_dtor_function (const char *, vec<FuncDeclaration *>);
 static Symbol *build_unittest_function (const char *, vec<FuncDeclaration *>);
-static bool output_declaration_p (Dsymbol *dsym);
 
 // Module info.  Assuming only one module per run of the compiler.
 ModuleInfo *current_module_info;
@@ -89,6 +88,22 @@ Symbol::Symbol()
   this->frameInfo = NULL;
 }
 
+// Returns true if DSYM is from the gcc.attribute module.
+
+static bool
+gcc_attribute_p(Dsymbol *dsym)
+{
+  ModuleDeclaration *md = dsym->getModule()->md;
+
+  if (md && md->packages && md->packages->dim == 1)
+    {
+      if (!strcmp((*md->packages)[0]->string, "gcc")
+	  && !strcmp(md->id->string, "attribute"))
+	return true;
+    }
+
+  return false;
+}
 
 void
 Dsymbol::toObjFile(bool)
@@ -224,7 +239,8 @@ StructDeclaration::toObjFile(bool)
   if (isAnonymous() || !members)
     return;
 
-  if (!output_declaration_p (this))
+  // Don't emit any symbols from gcc.attribute module.
+  if (gcc_attribute_p(this))
     return;
 
   // Generate TypeInfo
@@ -1061,122 +1077,56 @@ Module::genmoduleinfo()
   build_moduleinfo (msym);
 }
 
-// For nested functions in particular, unnest DECL in the cgraph,
-// as all static chain passing is handled by the front-end.
-
-static void
-unnest_function(tree decl)
-{
-  struct cgraph_node *node = cgraph_node::get_create(decl);
-
-  if (node->origin)
-    node->unnest();
-}
-
-// Returns true if we want to compile the declaration DSYM.
-
-static bool
-output_declaration_p (Dsymbol *dsym)
-{
-  // If errors occurred compiling it.
-  if (dsym->isDeclaration())
-    {
-      Type *t = ((Declaration *) dsym)->type;
-
-      if (t->ty == Terror)
-	return false;
-
-      if (t->ty == Tfunction)
-	{
-	  TypeFunction *tf = (TypeFunction *) t;
-	  if (tf->next == NULL || tf->next->ty == Terror)
-	    return false;
-	}
-    }
-
-  // Don't emit any symbols from gcc.attribute module.
-  ModuleDeclaration *md = dsym->getModule()->md;
-  if (md && md->packages && md->packages->dim == 1)
-    {
-      if (!strcmp ((*md->packages)[0]->string, "gcc")
-	  && !strcmp (md->id->string, "attribute"))
-	return false;
-    }
-
-  FuncDeclaration *fd = dsym->isFuncDeclaration();
-
-  if (fd != NULL)
-    {
-      if (fd->isNested())
-	{
-	  // Typically, an error occurred whilst compiling
-	  if (fd->fbody && !fd->vthis)
-	    {
-	      gcc_assert (global.errors);
-	      return false;
-	    }
-
-	  FuncDeclaration *fdp = fd->toParent2()->isFuncDeclaration();
-	  if (fdp && fdp->semanticRun < PASSobj)
-	    {
-	      // Parent failed to compile, but errors were gagged.
-	      if (fdp->semantic3Errors)
-		return false;
-
-	      if (UnitTestDeclaration *udp = fdp->isUnitTestDeclaration())
-		{
-		  udp->deferredNested.push(fd);
-		  return false;
-		}
-	    }
-	}
-
-      for (FuncDeclaration *fdp = fd; fdp != NULL;)
-	{
-      	  if (!fdp->isInstantiated() && fdp->inNonRoot())
-    	    return false;
-
-      	  if (!fdp->isNested())
-	    break;
-
-	  fdp = fdp->toParent2()->isFuncDeclaration();
-	}
-    }
-
-  if (!flag_emit_templates)
-    return !D_DECL_IS_TEMPLATE (dsym->toSymbol()->Stree);
-
-  return true;
-}
-
 // Finish up a function declaration and compile it all the way
 // down to assembler language output.
 
 void
-FuncDeclaration::toObjFile(bool force_p)
+FuncDeclaration::toObjFile(bool)
 {
   // Already generated the function.
-  if (semanticRun >= PASSobj)
+  if (this->semanticRun >= PASSobj)
+    return;
+
+  // Don't emit any symbols from gcc.attribute module.
+  if (gcc_attribute_p(this))
     return;
 
   // Not emitting unittest functions.
   if (!global.params.useUnitTests && this->isUnitTestDeclaration())
     return;
 
-  tree fndecl = toSymbol()->Stree;
-
-  // Do this even if we are not emitting the body.
-  // Such as when when -fno-emit-templates is in effect.
-  unnest_function(fndecl);
-
-  if (!fbody)
+  // Check if any errors occurred when running semantic.
+  if (this->type->ty == Tfunction)
     {
-      rest_of_decl_compilation (fndecl, 1, 0);
-      return;
+      TypeFunction *tf = (TypeFunction *) this->type;
+      if (tf->next == NULL || tf->next->ty == Terror)
+	return;
     }
 
-  if (!force_p && !output_declaration_p(this))
-    return;
+  if (this->isNested())
+    {
+      // Typically, an error occurred whilst compiling
+      if (this->fbody && !this->vthis)
+	{
+	  gcc_assert(global.errors);
+	  return;
+	}
+
+      FuncDeclaration *fdp = this->toParent2()->isFuncDeclaration();
+      if (fdp && fdp->semanticRun < PASSobj)
+	{
+	  // Parent failed to compile, but errors were gagged.
+	  if (fdp->semantic3Errors)
+	    return;
+
+	  // Defer until outer unittest has been emitted.
+	  if (UnitTestDeclaration *udp = fdp->isUnitTestDeclaration())
+	    {
+	      udp->deferredNested.push(this);
+	      return;
+	    }
+	}
+    }
 
   // Ensure all semantic passes have ran.
   if (semanticRun < PASSsemantic3)
@@ -1187,6 +1137,21 @@ FuncDeclaration::toObjFile(bool force_p)
 
   if (global.errors)
     return;
+
+  tree fndecl = toSymbol()->Stree;
+
+  // For nested functions in particular, unnest fndecl in the cgraph, as
+  // all static chain passing is handled by the front-end.  Do this even
+  // if we are not emitting the body.
+  struct cgraph_node *node = cgraph_node::get_create(fndecl);
+  if (node->origin)
+    node->unnest();
+
+  if (!fbody)
+    {
+      rest_of_decl_compilation (fndecl, 1, 0);
+      return;
+    }
 
   // Start generating code for this function.
   gcc_assert(this->semanticRun == PASSsemantic3done);
@@ -1650,20 +1615,20 @@ get_unique_name (tree decl, const char *prefix)
 // Return the COMDAT group into which DECL should be placed.
 
 static tree
-d_comdat_group (tree decl)
+d_comdat_group(tree decl)
 {
   // If already part of a comdat group, use that.
   if (DECL_COMDAT_GROUP (decl))
     return DECL_COMDAT_GROUP (decl);
 
-  return decl;
+  return DECL_ASSEMBLER_NAME (decl);
 }
 
 // Set DECL up to have the closest approximation of "initialized common"
 // linkage available.
 
 void
-d_comdat_linkage (tree decl)
+d_comdat_linkage(tree decl)
 {
   // Weak definitions have to be public.
   if (!TREE_PUBLIC (decl))
@@ -1675,12 +1640,12 @@ d_comdat_linkage (tree decl)
 
   // The following makes assumptions about the behavior of make_decl_one_only.
   if (SUPPORTS_ONE_ONLY)
-    make_decl_one_only (decl, d_comdat_group (decl));
+    make_decl_one_only(decl, d_comdat_group(decl));
   else if (SUPPORTS_WEAK)
     {
       tree decl_init = DECL_INITIAL (decl);
       DECL_INITIAL (decl) = integer_zero_node;
-      make_decl_one_only (decl, d_comdat_group (decl));
+      make_decl_one_only(decl, d_comdat_group(decl));
       DECL_INITIAL (decl) = decl_init;
     }
   else if (TREE_CODE (decl) == FUNCTION_DECL
@@ -1695,13 +1660,32 @@ d_comdat_linkage (tree decl)
     DECL_COMMON (decl) = 1;
 
   DECL_COMDAT (decl) = 1;
+
+  symtab_node *node = symtab_node::get(decl);
+  if (!node->same_comdat_group)
+    {
+      // Identical symbols go in the same comdat group.
+      static hash_map<tree, symtab_node *> comdat_list(251);
+      bool existed;
+
+      symtab_node **entry = &comdat_list.get_or_insert(node->get_comdat_group(),
+						       &existed);
+      if (!existed)
+	*entry = node;
+      else
+	{
+	  node->add_to_same_comdat_group(*entry);
+	  // Note that this function is now never emitted.
+	  DECL_ABSTRACT_P (decl) = 1;
+	}
+    }
 }
 
 // Set a DECL's STATIC and EXTERN based on the decl's storage class
 // and if it is to be emitted in this module.
 
 void
-setup_symbol_storage (Dsymbol *dsym, tree decl, bool public_p)
+setup_symbol_storage(Dsymbol *dsym, tree decl, bool public_p)
 {
   Declaration *rd = dsym->isDeclaration();
 
@@ -1709,7 +1693,7 @@ setup_symbol_storage (Dsymbol *dsym, tree decl, bool public_p)
       || (VAR_P (decl) && (rd && rd->isDataseg()))
       || (TREE_CODE (decl) == FUNCTION_DECL))
     {
-      bool local_p = output_module_p (dsym->getModule());
+      bool local_p = output_module_p(dsym->getModule());
       Dsymbol *sym = dsym->toParent();
 
       while (sym)
@@ -1719,8 +1703,8 @@ setup_symbol_storage (Dsymbol *dsym, tree decl, bool public_p)
 	    {
 	      D_DECL_ONE_ONLY (decl) = 1;
 	      D_DECL_IS_TEMPLATE (decl) = 1;
-	      local_p = flag_emit_templates
-		&& output_module_p (ti->instantiatingModule);
+	      DECL_ABSTRACT_P (decl) = !flag_emit_templates;
+	      local_p = output_module_p(ti->instantiatingModule);
 	      break;
 	    }
 	  sym = sym->toParent();
@@ -1741,10 +1725,7 @@ setup_symbol_storage (Dsymbol *dsym, tree decl, bool public_p)
 
       // Tell backend this is a thread local decl.
       if (vd && vd->isDataseg() && vd->isThreadlocal())
-	set_decl_tls_model (decl, decl_default_tls_model (decl));
-
-      if (rd && rd->storage_class & STCcomdat)
-	D_DECL_ONE_ONLY (decl) = 1;
+	set_decl_tls_model(decl, decl_default_tls_model(decl));
 
       // Do this by default, but allow private templates to override
       if (public_p || !fd || !fd->isNested())
@@ -1757,7 +1738,7 @@ setup_symbol_storage (Dsymbol *dsym, tree decl, bool public_p)
 	TREE_PROTECTED (decl) = 1;
 
       if (D_DECL_ONE_ONLY (decl))
-	d_comdat_linkage (decl);
+	d_comdat_linkage(decl);
     }
   else
     {
@@ -1769,10 +1750,10 @@ setup_symbol_storage (Dsymbol *dsym, tree decl, bool public_p)
   if (rd && rd->userAttribDecl)
     {
       Expressions *attrs = rd->userAttribDecl->getAttributes();
-      decl_attributes (&decl, build_attributes (attrs), 0);
+      decl_attributes(&decl, build_attributes(attrs), 0);
     }
   else if (DECL_ATTRIBUTES (decl) != NULL)
-    decl_attributes (&decl, DECL_ATTRIBUTES (decl), 0);
+    decl_attributes(&decl, DECL_ATTRIBUTES (decl), 0);
 }
 
 // Mark DECL, which is a VAR_DECL or FUNCTION_DECL as a symbol that
@@ -1885,71 +1866,80 @@ d_finish_symbol (Symbol *sym)
 }
 
 void
-d_finish_function (FuncDeclaration *fd)
+d_finish_function(FuncDeclaration *fd)
 {
   Symbol *s = fd->toSymbol();
   tree decl = s->Stree;
 
-  gcc_assert (TREE_CODE (decl) == FUNCTION_DECL);
+  gcc_assert(TREE_CODE (decl) == FUNCTION_DECL);
 
-  if (output_declaration_p (fd))
+  // If function is not needed, don't send it to backend.
+  if (DECL_ABSTRACT_P (decl))
+    return;
+
+  // If we generated the function, but it's really extern.
+  // Such as external inlinable functions or thunk aliases.
+  bool extern_p = false;
+  for (FuncDeclaration *fdp = fd; fdp != NULL;)
     {
-      if (DECL_SAVED_TREE (decl) != NULL_TREE)
+      if (!fdp->isInstantiated() && fdp->inNonRoot())
 	{
-	  TREE_STATIC (decl) = 1;
-	  DECL_EXTERNAL (decl) = 0;
+	  extern_p = true;
+	  break;
 	}
 
-      if (!targetm.have_ctors_dtors)
-	{
-	  if (DECL_STATIC_CONSTRUCTOR (decl))
-	    static_ctor_list.safe_push (fd);
-	  if (DECL_STATIC_DESTRUCTOR (decl))
-	    static_dtor_list.safe_push (fd);
-	}
+      if (!fdp->isNested())
+	break;
+
+      fdp = fdp->toParent2()->isFuncDeclaration();
     }
 
-  d_add_global_declaration (decl);
-  cgraph_node::finalize_function (decl, true);
+  if (extern_p)
+    {
+      TREE_STATIC (decl) = 0;
+      DECL_EXTERNAL (decl) = 1;
+    }
+  else if (DECL_SAVED_TREE (decl) != NULL_TREE)
+    {
+      TREE_STATIC (decl) = 1;
+      DECL_EXTERNAL (decl) = 0;
+    }
+
+  if (!targetm.have_ctors_dtors)
+    {
+      if (DECL_STATIC_CONSTRUCTOR (decl))
+	static_ctor_list.safe_push(fd);
+      if (DECL_STATIC_DESTRUCTOR (decl))
+	static_dtor_list.safe_push(fd);
+    }
+
+  d_add_global_declaration(decl);
+  cgraph_node::finalize_function(decl, true);
 }
 
 // Wrapup all global declarations and start the final compilation.
 
 void
-d_finish_compilation (tree *vec, int len)
+d_finish_compilation(tree *vec, int len)
 {
   // Complete all generated thunks.
   symtab->process_same_body_aliases();
-
-  StringTable *table = new StringTable;
-  table->_init();
 
   // Process all file scopes in this compilation, and the external_scope,
   // through wrapup_global_declarations.
   for (int i = 0; i < len; i++)
     {
       tree decl = vec[i];
+      wrapup_global_declarations(&decl, 1);
 
-      // Determine if a global var/function is needed.
-      int needed = wrapup_global_declarations (&decl, 1);
-
+      // We want the static symbol to be written.
       if ((VAR_P (decl) && TREE_STATIC (decl))
 	  || TREE_CODE (decl) == FUNCTION_DECL)
-	{
-	  // Don't emit, assembler name already in symbol table.
-	  tree name = DECL_ASSEMBLER_NAME (decl);
-	  if (!table->insert (IDENTIFIER_POINTER (name), IDENTIFIER_LENGTH (name)))
-	    needed = 0;
-	  else
-	    needed = 1;
-
-	  if (needed)
-	    mark_needed (decl);
-	}
+	mark_needed(decl);
       else if (TREE_CODE (decl) == TYPE_DECL)
 	{
 	  bool toplevel = !DECL_CONTEXT (decl);
-	  rest_of_decl_compilation (decl, toplevel, 0);
+	  rest_of_decl_compilation(decl, toplevel, 0);
 	}
     }
 }
@@ -2103,7 +2093,7 @@ finish_thunk (tree thunk_decl, tree target_decl, int offset)
       && targetm_common.have_named_sections)
     {
       tree fn = target_decl;
-      struct symtab_node *symbol = symtab_node::get (target_decl);
+      symtab_node *symbol = symtab_node::get (target_decl);
 
       if (symbol != NULL && symbol->alias)
 	{

--- a/gcc/d/d-todt.cc
+++ b/gcc/d/d-todt.cc
@@ -534,7 +534,7 @@ FuncExp::toDt (dt_t **pdt)
     }
 
   tree dt = build_address (fd->toSymbol()->Stree);
-  fd->toObjFile (0);
+  fd->toObjFile();
 
   return dt_cons (pdt, dt);
 }

--- a/gcc/d/d-typinf.cc
+++ b/gcc/d/d-typinf.cc
@@ -133,7 +133,7 @@ Type::genTypeInfo(Scope *sc)
 		}
 	    }
 	  else
-	    t->vtinfo->toObjFile(0);
+	    t->vtinfo->toObjFile();
 	}
     }
   // Types aren't merged, but we can share the vtinfo's

--- a/gcc/d/dfrontend/aggregate.h
+++ b/gcc/d/dfrontend/aggregate.h
@@ -179,7 +179,7 @@ public:
     bool fill(Loc loc, Expressions *elements, bool ctorinit);
     bool isPOD();
 
-    void toObjFile(bool multiobj);                       // compile to .obj file
+    void toObjFile();                       // compile to .obj file
     void toDt(dt_t **pdt);
 
     StructDeclaration *isStructDeclaration() { return this; }
@@ -302,7 +302,7 @@ public:
     void addLocalClass(ClassDeclarations *);
 
     // Back end
-    void toObjFile(bool multiobj);                       // compile to .obj file
+    void toObjFile();                       // compile to .obj file
     unsigned baseVtblOffset(BaseClass *bc);
     Symbol *toSymbol();
     Symbol *toVtblSymbol();
@@ -328,7 +328,7 @@ public:
     bool isCPPinterface();
     bool isCOMinterface();
 
-    void toObjFile(bool multiobj);                       // compile to .obj file
+    void toObjFile();                       // compile to .obj file
     Symbol *toSymbol();
 
     InterfaceDeclaration *isInterfaceDeclaration() { return this; }

--- a/gcc/d/dfrontend/attrib.h
+++ b/gcc/d/dfrontend/attrib.h
@@ -57,7 +57,7 @@ public:
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     AttribDeclaration *isAttribDeclaration() { return this; }
 
-    void toObjFile(bool multiobj);                       // compile to .obj file
+    void toObjFile();                       // compile to .obj file
     void accept(Visitor *v) { v->visit(this); }
 };
 
@@ -157,7 +157,7 @@ public:
     void setScope(Scope *sc);
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     const char *kind();
-    void toObjFile(bool multiobj);                       // compile to .obj file
+    void toObjFile();                       // compile to .obj file
     void accept(Visitor *v) { v->visit(this); }
 };
 

--- a/gcc/d/dfrontend/declaration.h
+++ b/gcc/d/dfrontend/declaration.h
@@ -291,7 +291,7 @@ public:
     void checkNestedReference(Scope *sc, Loc loc);
     Dsymbol *toAlias();
     Symbol *toSymbol();
-    void toObjFile(bool multiobj);                       // compile to .obj file
+    void toObjFile();                       // compile to .obj file
     // Eliminate need for dynamic_cast
     VarDeclaration *isVarDeclaration() { return (VarDeclaration *)this; }
     void accept(Visitor *v) { v->visit(this); }
@@ -340,7 +340,7 @@ public:
     char *toChars();
 
     Symbol *toSymbol();
-    void toObjFile(bool multiobj);                       // compile to .obj file
+    void toObjFile();                       // compile to .obj file
     virtual void toDt(dt_t **pdt);
 
     TypeInfoDeclaration *isTypeInfoDeclaration() { return this; }
@@ -698,7 +698,7 @@ public:
 
     Symbol *toSymbol();
     Symbol *toThunkSymbol(int offset);  // thunk version
-    void toObjFile(bool multiobj);                       // compile to .obj file
+    void toObjFile();                       // compile to .obj file
 
     FuncDeclaration *isFuncDeclaration() { return this; }
 

--- a/gcc/d/dfrontend/dsymbol.h
+++ b/gcc/d/dfrontend/dsymbol.h
@@ -226,7 +226,7 @@ public:
 
     // Backend
     virtual Symbol *toSymbol();                 // to backend symbol
-    virtual void toObjFile(bool multiobj);                       // compile to .obj file
+    virtual void toObjFile();                       // compile to .obj file
 
     Symbol *toImport();                         // to backend import symbol
     static Symbol *toImport(Symbol *s);         // to backend import symbol

--- a/gcc/d/dfrontend/enum.h
+++ b/gcc/d/dfrontend/enum.h
@@ -68,7 +68,7 @@ public:
 
     EnumDeclaration *isEnumDeclaration() { return this; }
 
-    void toObjFile(bool multiobj);                       // compile to .obj file
+    void toObjFile();                       // compile to .obj file
 
     Symbol *sinit;
     Symbol *toInitializer();

--- a/gcc/d/dfrontend/nspace.h
+++ b/gcc/d/dfrontend/nspace.h
@@ -32,7 +32,7 @@ class Nspace : public ScopeDsymbol
     void setFieldOffset(AggregateDeclaration *ad, unsigned *poffset, bool isunion);
     const char *kind();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
-    void toObjFile(bool multiobj);
+    void toObjFile();
     Nspace *isNspace() { return this; }
 };
 

--- a/gcc/d/dfrontend/staticassert.c
+++ b/gcc/d/dfrontend/staticassert.c
@@ -121,7 +121,7 @@ bool StaticAssert::oneMember(Dsymbol **ps, Identifier *ident)
     return true;
 }
 
-void StaticAssert::toObjFile(bool multiobj)
+void StaticAssert::toObjFile()
 {
 }
 

--- a/gcc/d/dfrontend/staticassert.h
+++ b/gcc/d/dfrontend/staticassert.h
@@ -34,7 +34,7 @@ public:
     void semantic(Scope *sc);
     void semantic2(Scope *sc);
     bool oneMember(Dsymbol **ps, Identifier *ident);
-    void toObjFile(bool multiobj);
+    void toObjFile();
     const char *kind();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
     void accept(Visitor *v) { v->visit(this); }

--- a/gcc/d/dfrontend/template.h
+++ b/gcc/d/dfrontend/template.h
@@ -356,7 +356,7 @@ public:
     hash_t hashCode();
 
     bool needsCodegen();
-    void toObjFile(bool multiobj);                       // compile to .obj file
+    void toObjFile();                       // compile to .obj file
 
     // Internal
     bool findTempDecl(Scope *sc, WithScopeSymbol **pwithsym);
@@ -394,7 +394,7 @@ public:
     char *toChars();
     void toCBuffer(OutBuffer *buf, HdrGenState *hgs);
 
-    void toObjFile(bool multiobj);                       // compile to .obj file
+    void toObjFile();                       // compile to .obj file
 
     bool findTempDecl(Scope *sc);
 

--- a/gcc/d/toir.cc
+++ b/gcc/d/toir.cc
@@ -1020,7 +1020,7 @@ public:
 	Dsymbol *dsym = (*s->imports)[i];
 
 	if (dsym != NULL)
-	  dsym->toObjFile(0);
+	  dsym->toObjFile(false);
       }
   }
 };

--- a/gcc/d/toir.cc
+++ b/gcc/d/toir.cc
@@ -1020,7 +1020,7 @@ public:
 	Dsymbol *dsym = (*s->imports)[i];
 
 	if (dsym != NULL)
-	  dsym->toObjFile(false);
+	  dsym->toObjFile();
       }
   }
 };


### PR DESCRIPTION
I believe this goes some way in fixing bug 202 , but it's intention was to address another problem with same symbols being emitted multiple types in the same assembly output.

In any case, there are some problems with our template emission strategy in the codegen phase, I'd like to get them addressed in here before continuing.
