### PR TITLE
Refactor Dsymbol::toImport as a visitor

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,9 @@
+2016-03-04  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* imports.cc: New file.
+	* d-decls.cc (Dsymbol::toImport): Remove function, update all callers
+	to use build_import_decl.
+
 2016-03-03  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-objfile.cc (gcc_attribute_p): New function.

--- a/gcc/d/Make-lang.in
+++ b/gcc/d/Make-lang.in
@@ -87,7 +87,7 @@ D_GLUE_OBJS = d/d-attribs.o d/d-lang.o d/d-decls.o \
               d/d-codegen.o d/d-objfile.o \
               d/d-convert.o d/d-todt.o d/d-longdouble.o \
               d/d-builtins.o d/d-incpath.o d/types.o \
-              d/d-elem.o d/toir.o d/d-typinf.o \
+              d/d-elem.o d/imports.o d/toir.o d/d-typinf.o \
               d/d-port.o d/d-target.o d/d-glue.o
 
 # Generated programs.

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -283,7 +283,7 @@ d_decl_context (Dsymbol *dsym)
 	  if (decl != NULL && decl->linkage != LINKd)
 	    return NULL_TREE;
 
-	  return parent->toImport()->Stree;
+	  return build_import_decl(parent);
 	}
 
       // Declarations marked as 'static' or '__gshared' are never

--- a/gcc/d/d-codegen.h
+++ b/gcc/d/d-codegen.h
@@ -43,6 +43,7 @@ struct FuncFrameInfo
 // Visitor routines for barrier between frontend and glue.
 extern void build_ir(FuncDeclaration *fd);
 extern tree build_ctype(Type *t);
+extern tree build_import_decl(Dsymbol *dsym);
 
 // Code generation routines.
 extern void push_binding_level(level_kind kind);

--- a/gcc/d/d-decls.cc
+++ b/gcc/d/d-decls.cc
@@ -83,67 +83,6 @@ Dsymbol::toSymbol()
   return NULL;
 }
 
-// Generate an import symbol for debug.  If this is a module or package symbol,
-// then build the chain of NAMESPACE_DECLs.
-
-Symbol *
-Dsymbol::toImport()
-{
-  if (!isym)
-    {
-      Module *m = this->isModule();
-      if (m != NULL)
-	{
-	  isym = new Symbol();
-	  isym->prettyIdent = this->toPrettyChars();
-
-	  // Build the module namespace, this is considered toplevel,
-	  // regardless if there are parent packages.
-	  tree decl = build_decl (UNKNOWN_LOCATION, NAMESPACE_DECL,
-				  get_identifier (isym->prettyIdent),
-				  void_type_node);
-	  isym->Stree = decl;
-	  d_keep (decl);
-
-	  Loc loc = (m->md != NULL) ? m->md->loc : Loc(m, 1, 0);
-	  set_decl_location (decl, loc);
-
-	  if (output_module_p (m))
-	    DECL_EXTERNAL (decl) = 1;
-
-	  TREE_PUBLIC (decl) = 1;
-	  DECL_CONTEXT (decl) = NULL_TREE;
-	}
-      else
-	{
-	  // Any other kind of symbol should have their csym set.
-	  // If this is an unexpected import, the compiler will throw an error.
-	  if (!csym)
-	    csym = toSymbol();
-
-	  isym = toImport (csym);
-	}
-    }
-
-  return isym;
-}
-
-// Generate an IMPORTED_DECL from symbol SYM.
-
-Symbol *
-Dsymbol::toImport (Symbol *sym)
-{
-  tree decl = make_node (IMPORTED_DECL);
-  TREE_TYPE (decl) = void_type_node;
-  IMPORTED_DECL_ASSOCIATED_DECL (decl) = sym->Stree;
-  d_keep (decl);
-
-  Symbol *s = new Symbol();
-  s->Stree = decl;
-  return s;
-}
-
-
 // Create the symbol with VAR_DECL tree for static variables.
 
 Symbol *

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -126,7 +126,7 @@ Dsymbol::toObjFile()
       if (cfun != NULL)
 	context = current_function_decl;
       else
-	context = current_module_decl->toImport()->Stree;
+	context = build_import_decl(current_module_decl);
 
       if (imp->ident == NULL)
 	{
@@ -134,33 +134,31 @@ Dsymbol::toObjFile()
 	  for (size_t i = 0; i < imp->names.dim; i++)
 	    {
 	      AliasDeclaration *aliasdecl = imp->aliasdecls[i];
-	      Dsymbol *dsym = aliasdecl->toAlias();
-	      Identifier *alias = imp->aliases[i];
+	      tree decl = build_import_decl(aliasdecl);
 
-              // Skip over importing non-decls, templates, and tuples.
-	      if (dsym == aliasdecl || !dsym->isDeclaration()
-		  || dsym->isTupleDeclaration())
+              // Skip over unhandled imports.
+	      if (decl == NULL_TREE)
 		continue;
 
-	      tree decl = dsym->toImport()->Stree;
-	      set_decl_location (decl, imp);
+	      set_decl_location(decl, imp);
 
+	      Identifier *alias = imp->aliases[i];
 	      tree name = (alias != NULL)
-		? get_identifier (alias->string) : NULL_TREE;
+		? get_identifier(alias->string) : NULL_TREE;
 
-	      (*debug_hooks->imported_module_or_decl) (decl, name, context, false);
+	      (*debug_hooks->imported_module_or_decl)(decl, name, context, false);
 	    }
 	}
       else
 	{
 	  // Importing the entire module.
-	  tree decl = imp->mod->toImport()->Stree;
-	  set_input_location (imp);
+	  tree decl = build_import_decl(imp->mod);
+	  set_input_location(imp);
 
 	  tree name = (imp->aliasId != NULL)
-	    ? get_identifier (imp->aliasId->string) : NULL_TREE;
+	    ? get_identifier(imp->aliasId->string) : NULL_TREE;
 
-	  (*debug_hooks->imported_module_or_decl) (decl, name, context, false);
+	  (*debug_hooks->imported_module_or_decl)(decl, name, context, false);
 	}
 
       return;

--- a/gcc/d/dfrontend/dsymbol.h
+++ b/gcc/d/dfrontend/dsymbol.h
@@ -228,9 +228,6 @@ public:
     virtual Symbol *toSymbol();                 // to backend symbol
     virtual void toObjFile();                       // compile to .obj file
 
-    Symbol *toImport();                         // to backend import symbol
-    static Symbol *toImport(Symbol *s);         // to backend import symbol
-
     Symbol *toSymbolX(const char *prefix, int sclass, TYPE *t, const char *suffix);     // helper
 
     // Eliminate need for dynamic_cast

--- a/gcc/d/imports.cc
+++ b/gcc/d/imports.cc
@@ -1,0 +1,158 @@
+// imports.cc -- D frontend for GCC.
+// Copyright (C) 2016 Free Software Foundation, Inc.
+
+// GCC is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free
+// Software Foundation; either version 3, or (at your option) any later
+// version.
+
+// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with GCC; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+
+
+#include "config.h"
+#include "system.h"
+#include "coretypes.h"
+
+#include "dfrontend/aggregate.h"
+#include "dfrontend/enum.h"
+#include "dfrontend/module.h"
+
+#include "tree.h"
+#include "diagnostic.h"
+#include "stringpool.h"
+
+#include "d-tree.h"
+#include "d-codegen.h"
+#include "d-lang.h"
+#include "d-objfile.h"
+
+// Implements the visitor interface to build debug trees for all module and
+// import declarations, where ISYM holds the cached backend representation
+// to be returned.
+
+class ImportVisitor : public Visitor
+{
+public:
+  ImportVisitor() {}
+
+  // This should be overridden by each symbol class.
+  void visit(Dsymbol *)
+  {
+    gcc_unreachable();
+  }
+
+  // Build the module namespace, this is considered toplevel, regardless
+  // of whether there are any parent packages in the module system.
+  void visit(Module *m)
+  {
+    m->isym = new Symbol();
+    m->isym->prettyIdent = m->toPrettyChars();
+
+    tree decl = build_decl(UNKNOWN_LOCATION, NAMESPACE_DECL,
+			   get_identifier(m->isym->prettyIdent),
+			   void_type_node);
+    m->isym->Stree = decl;
+    d_keep(decl);
+
+    Loc loc = (m->md != NULL) ? m->md->loc : Loc(m, 1, 0);
+    set_decl_location(decl, loc);
+
+    if (!output_module_p(m))
+      DECL_EXTERNAL (decl) = 1;
+
+    TREE_PUBLIC (decl) = 1;
+    DECL_CONTEXT (decl) = NULL_TREE;
+  }
+
+  // Alias symbols aren't imported, but their targets are.
+  void visit(AliasDeclaration *d)
+  {
+    Dsymbol *dsym = d->toAlias();
+
+    // This symbol is really an alias for another, visit the other.
+    if (dsym != d)
+      {
+	dsym->accept(this);
+	d->isym = dsym->isym;
+	return;
+      }
+
+    // Type imports should really be part of their own visit method.
+    if (d->type != NULL)
+      {
+	tree type = build_ctype(d->type);
+
+    	if (!TYPE_STUB_DECL (type))
+    	  return;
+
+    	tree decl = make_node(IMPORTED_DECL);
+    	TREE_TYPE (decl) = void_type_node;
+    	IMPORTED_DECL_ASSOCIATED_DECL (decl) = TYPE_STUB_DECL (type);
+    	d_keep(decl);
+
+	d->isym = new Symbol();
+	d->isym->Stree = decl;
+	return;
+      }
+  }
+
+  // Import a member of an enum declaration.
+  void visit(EnumMember *m)
+  {
+    if (m->vd != NULL)
+      {
+	m->vd->accept(this);
+	m->isym = m->vd->isym;
+      }
+  }
+
+  // Skip over importing templates and tuples.
+  void visit(TemplateDeclaration *)
+  {
+  }
+
+  void visit(TupleDeclaration *)
+  {
+  }
+
+  // Import any other kind of declaration.  If the class does not implement
+  // symbol generation routines, the compiler will throw an error.
+  void visit(Declaration *d)
+  {
+    if (!d->csym)
+      d->toSymbol();
+
+    tree decl = make_node(IMPORTED_DECL);
+    TREE_TYPE (decl) = void_type_node;
+    IMPORTED_DECL_ASSOCIATED_DECL (decl) = d->csym->Stree;
+    d_keep(decl);
+
+    d->isym = new Symbol();
+    d->isym->Stree = decl;
+  }
+};
+
+
+// Build a declaration for the symbol D that can be used for the debug_hook
+// imported_module_or_decl.
+
+tree
+build_import_decl(Dsymbol *d)
+{
+  if (!d->isym)
+    {
+      ImportVisitor v;
+      d->accept(&v);
+    }
+
+  // Not all visitors set 'isym'.
+  return d->isym ? d->isym->Stree : NULL_TREE;
+}
+


### PR DESCRIPTION
Also implement handling imports of EnumMember and Type symbols.

This moves the codegen routines to its own file, only benefit is the sake of encapsulation.  And I expect low extremely little maintenance needed here.
