### PR TITLE
Fix most failing tests that are marked 'unresolved'

### DIFF
--- a/gcc/testsuite/gdc.test/d_do_test.exp
+++ b/gcc/testsuite/gdc.test/d_do_test.exp
@@ -36,7 +36,7 @@ proc gdc-convert-args { args } {
             lappend out "-fno-bounds-check"
 
         } elseif [string match "-boundscheck=safeonly" $arg] {
-            lappend out "-fbounds-check=safe"
+            lappend out "-fbounds-check=safeonly"
 
         } elseif [string match "-c" $arg] {
             lappend out "-c"

--- a/gcc/testsuite/lib/gdc.exp
+++ b/gcc/testsuite/lib/gdc.exp
@@ -124,6 +124,12 @@ proc gdc_link_flags { paths } {
       if [file exists "${gccpath}/libiberty/libiberty.a"] {
           append flags "-L${gccpath}/libiberty "
       }
+      # For the tests that mix C++ and D, we should try and handle this better.
+      if { [file exists "${gccpath}/libstdc++-v3/src/.libs/libstdc++.a"] \
+           || [file exists "${gccpath}/libstdc++-v3/src/.libs/libstdc++.${shlib_ext}"] } {
+          append flags "-L${gccpath}/libstdc++-v3/src/.libs "
+          append ld_library_path ":${gccpath}/libstdc++-v3/src/.libs"
+      }
       append ld_library_path [gcc-set-multilib-library-path $GDC_UNDER_TEST]
     } else {
       global tool_root_dir


### PR DESCRIPTION
I've add `--enable-language=c++,d` to the semaphoreCI configure command, and set to build `libstdc++-v3` too.

There should now only be two unresolved tests because of C++-11 ABI changes.

See: https://github.com/D-Programming-Language/dmd/pull/5262
