### PR TITLE
Refactor array bounds generation.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,11 @@
+2016-03-20  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-codegen.cc (d_checked_index): Remove function.
+	(d_bounds_condition): Remove function.
+	(build_bounds_condition): New function.
+	* d-elem.cc (IndexExp::toElem): Use build_bounds_condition.
+	(SliceExp::toElem): Likewise.
+
 2016-03-19  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-codegen.cc (d_array_convert): New function overload.

--- a/gcc/d/d-codegen.h
+++ b/gcc/d/d-codegen.h
@@ -170,9 +170,8 @@ extern tree maybe_make_temp (tree t);
 extern bool d_has_side_effects (tree t);
 
 // Array operations
+extern tree build_bounds_condition(Loc loc, tree index, tree upr, bool inclusive);
 extern bool array_bounds_check();
-extern tree d_checked_index (Loc loc, tree index, tree upr, bool inclusive);
-extern tree d_bounds_condition (tree index, tree upr, bool inclusive);
 
 // Classes
 extern tree build_class_binfo (tree super, ClassDeclaration *cd);


### PR DESCRIPTION
The array length, index, and slice types should already be implicitly casted to an unsigned type by the frontend, so check whether (`INDEX >= LENGTH)` instead of `(INDEX >= 0 && INDEX < LENGTH)` when testing that the index/slice is in bounds.

Also refactor `SliceExp` to elude testing whether array bounds checks are enabled twice.
