### PR TITLE
Rewrite function duplicate handling

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,18 @@
+2016-03-29  Johannes Pfau  <johannespfau@gmail.com>
+
+	* d-objfile.cc (d_comdat_linkage): Rewrite template duplicate
+	handling to generate only one backend tree for all duplicates.
+	(FuncDeclaration::toObjFile): Likewise.
+	(VarDeclaration::toObjFile): Likewise.
+	* d-decls.cc (FuncDeclaration::toSymbol): Likewise.
+	(VarDeclaration::toSymbol): Likewise.
+	* d-objfile.cc (get_template_storage_info): Extract function from
+	setup_symbol_storage.
+	(setup_symbol_storage): Likewise.
+	* d-tree.h (lang_identifier): Add field for Dsymbol.
+	(IDENTIFIER_LANG_SPECIFIC): New macro.
+	(IDENTIFIER_DSYMBOL): Likewise.
+
 2016-03-29  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-codegen.cc (fill_alignment_field): Call layout_decl on field.

--- a/gcc/d/d-decls.cc
+++ b/gcc/d/d-decls.cc
@@ -100,7 +100,29 @@ VarDeclaration::toSymbol()
 	  return csym;
 	}
 
-      csym = new Symbol();
+      // Use same symbol for VarDeclaration templates with same mangle
+      bool local_p, template_p;
+      get_template_storage_info(this, &local_p, &template_p);
+      if (!this->mangleOverride && isDataseg () && !(storage_class & STCextern)
+	  && local_p && template_p)
+	{
+	  tree ident = get_identifier(mangle(this));
+	  if (!IDENTIFIER_DSYMBOL (ident))
+	    {
+	      csym = new Symbol();
+	      IDENTIFIER_DSYMBOL (ident) = this;
+	    }
+	  else
+	    {
+	      csym = IDENTIFIER_DSYMBOL (ident)->toSymbol();
+	      return csym;
+	    }
+	}
+      else
+	{
+	  csym = new Symbol();
+	}
+
       csym->Salignment = alignment;
 
       if (isDataseg())
@@ -251,8 +273,6 @@ FuncDeclaration::toSymbol()
 {
   if (!csym)
     {
-      csym = new Symbol();
-
       TypeFunction *ftype = (TypeFunction *) (tintro ? tintro : type);
       tree fntype = NULL_TREE;
       tree vindex = NULL_TREE;
@@ -260,8 +280,35 @@ FuncDeclaration::toSymbol()
       // Run full semantic on symbols we need to know about during compilation.
       if (inferRetType && type && !type->nextOf() && !functionSemantic())
 	{
+	  csym = new Symbol();
 	  csym->Stree = error_mark_node;
 	  return csym;
+	}
+
+      // Use same symbol for FuncDeclaration templates with same mangle
+      if (!this->mangleOverride && this->fbody)
+	{
+	  tree ident = get_identifier(mangleExact(this));
+	  if (!IDENTIFIER_DSYMBOL (ident))
+	    {
+	      csym = new Symbol();
+	      IDENTIFIER_DSYMBOL (ident) = this;
+	    }
+	  else
+	    {
+	      bool local_p, template_p;
+	      get_template_storage_info(this, &local_p, &template_p);
+	      // Non-templated functions shouldn't be defined twice
+	      if (!template_p)
+		ScopeDsymbol::multiplyDefined(loc, this, IDENTIFIER_DSYMBOL (ident));
+
+	      csym = IDENTIFIER_DSYMBOL (ident)->toSymbol();
+	      return csym;
+	    }
+	}
+      else
+	{
+	  csym = new Symbol();
 	}
 
       // Save mangle/debug names for making thunks.

--- a/gcc/d/d-objfile.h
+++ b/gcc/d/d-objfile.h
@@ -109,6 +109,7 @@ extern void set_function_end_locus (const Loc& loc);
 
 extern void get_unique_name (tree decl, const char *prefix = NULL);
 
+extern void get_template_storage_info (Dsymbol *dsym, bool *local_p, bool *template_p);
 extern void setup_symbol_storage (Dsymbol *dsym, tree decl, bool is_public);
 extern void d_comdat_linkage (tree decl);
 

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -27,6 +27,7 @@ class Expression;
 class Module;
 class Statement;
 class Type;
+class Dsymbol;
 
 // The kinds of scopes we recognise.
 enum level_kind
@@ -117,7 +118,14 @@ struct GTY(()) d_label_entry
 struct GTY(()) lang_identifier
 {
   struct tree_identifier common;
+  Dsymbol * GTY((skip)) dsymbol;
 };
+
+#define IDENTIFIER_LANG_SPECIFIC(NODE) \
+  ((struct lang_identifier*) IDENTIFIER_NODE_CHECK (NODE))
+
+#define IDENTIFIER_DSYMBOL(NODE) \
+  (IDENTIFIER_LANG_SPECIFIC (NODE)->dsymbol)
 
 // Global state pertinent to the current function.
 struct GTY(()) language_function


### PR DESCRIPTION
As already discussed the current fix for duplicate `FuncDeclaration`s generated by the frontend doesn't work for GCC <= 4.9. This approach keeps a hashmap of `Symbol`s in the `FuncDeclaration::toSymbol` function and makes sure we generate only one `Symbol` and therefore one `tree` per mangled name. It's a brute force method but there are some nice aspects as well. For example this is independent of the compiler backend version and we don't have to rely on backend internals. Additionally we still benefit from GCCs type checking: If the frontend provides to identically named functions with different types the GCC type checking will still detect the problem in some cases.

I'm not sure if the code handling `VarDeclaration`s is actually required. At least the unit tests and the test suite don't seem to produce duplicated `VarDeclaration`s.

The `loc` comparison is necessary for the `fail_compilation/fail5634.d` testcase. Right now if a user creates duplicate functions these are only caught by the assembler. This pull request instead generates a nice error message with the location of the conflicting functions. BTW: Is there a better way to abort the compilation in `toSymbol` than checking for `error_mark_node` in the `toObjfile` methods?

BTW2: I think the biggest backporting issue in the future will be the missing hash table. Pointer map only works for simple cases, but in cases like in this pull request I need a real hash table. So is there any reason I can't simply use the STL in GCC <= 4.9?
