### PR TITLE
Rewrite unit test handling in Makefiles

### DIFF
--- a/libphobos/libdruntime/Makefile.am
+++ b/libphobos/libdruntime/Makefile.am
@@ -127,17 +127,13 @@ else
 endif
 	$(RANLIB) $@
 
-libgdruntime_t.a : $(ALL_DRUNTIME_OBJS:.o=.t.o)
+unittest: libgdruntime.a $(ALL_DRUNTIME_OBJS:.o=.t.o) unittest.o
 if BACKTRACE_SUPPORTED
-	cp -f $(LIBBACKTRACE_LIB) $@
-	$(AR) -q $@ $(ALL_DRUNTIME_OBJS:.o=.t.o)
+	cp -f $(LIBBACKTRACE_LIB) libbacktrace.a
+	$(GDC) -o $@ $(CFLAGS) unittest.o -nophoboslib -L./ $(ALL_DRUNTIME_OBJS:.o=.t.o) -lbacktrace $(LIBS) $(DL_LIBS)
 else
-	$(AR) -r $@ $(ALL_DRUNTIME_OBJS:.o=.t.o)
+	$(GDC) -o $@ $(CFLAGS) unittest.o -nophoboslib -L./ $(ALL_DRUNTIME_OBJS:.o=.t.o) $(LIBS) $(DL_LIBS)
 endif
-	$(RANLIB) $@
-
-unittest: libgdruntime.a libgdruntime_t.a unittest.o
-	$(GDC) -o $@ $(CFLAGS) unittest.o -nophoboslib -L./ -lgdruntime_t $(LIBS) $(DL_LIBS)
 
 #--------------------------------------#
 # Install, doc, etc targets
@@ -185,7 +181,6 @@ clean-local:
 	rm -f unittest.o
 	rm -f unittest$(EXEEXT)
 	rm -f libgdruntime.a
-	rm -f libgdruntime_t.a
 
 check-local: unittest
 	./unittest

--- a/libphobos/libdruntime/Makefile.in
+++ b/libphobos/libdruntime/Makefile.in
@@ -472,14 +472,10 @@ libgdruntime.a : $(ALL_DRUNTIME_OBJS)
 @BACKTRACE_SUPPORTED_FALSE@	$(AR) -r $@ $(ALL_DRUNTIME_OBJS)
 	$(RANLIB) $@
 
-libgdruntime_t.a : $(ALL_DRUNTIME_OBJS:.o=.t.o)
-@BACKTRACE_SUPPORTED_TRUE@	cp -f $(LIBBACKTRACE_LIB) $@
-@BACKTRACE_SUPPORTED_TRUE@	$(AR) -q $@ $(ALL_DRUNTIME_OBJS:.o=.t.o)
-@BACKTRACE_SUPPORTED_FALSE@	$(AR) -r $@ $(ALL_DRUNTIME_OBJS:.o=.t.o)
-	$(RANLIB) $@
-
-unittest: libgdruntime.a libgdruntime_t.a unittest.o
-	$(GDC) -o $@ $(CFLAGS) unittest.o -nophoboslib -L./ -lgdruntime_t $(LIBS) $(DL_LIBS)
+unittest: libgdruntime.a $(ALL_DRUNTIME_OBJS:.o=.t.o) unittest.o
+@BACKTRACE_SUPPORTED_TRUE@	cp -f $(LIBBACKTRACE_LIB) libbacktrace.a
+@BACKTRACE_SUPPORTED_TRUE@	$(GDC) -o $@ $(CFLAGS) unittest.o -nophoboslib -L./ $(ALL_DRUNTIME_OBJS:.o=.t.o) -lbacktrace $(LIBS) $(DL_LIBS)
+@BACKTRACE_SUPPORTED_FALSE@	$(GDC) -o $@ $(CFLAGS) unittest.o -nophoboslib -L./ $(ALL_DRUNTIME_OBJS:.o=.t.o) $(LIBS) $(DL_LIBS)
 
 #--------------------------------------#
 # Install, doc, etc targets
@@ -527,7 +523,6 @@ clean-local:
 	rm -f unittest.o
 	rm -f unittest$(EXEEXT)
 	rm -f libgdruntime.a
-	rm -f libgdruntime_t.a
 
 check-local: unittest
 	./unittest

--- a/libphobos/src/Makefile.am
+++ b/libphobos/src/Makefile.am
@@ -130,12 +130,8 @@ libgphobos2.a : $(ALL_PHOBOS_OBJS) ../libdruntime/libgdruntime.a
 	$(AR) -q $@ $(ALL_PHOBOS_OBJS)
 	$(RANLIB) $@
 
-libgphobos2_t.a : $(ALL_PHOBOS_OBJS:.o=.t.o)
-	$(AR) -r $@ $(ALL_PHOBOS_OBJS:.o=.t.o)
-	$(RANLIB) $@
-
-unittest: libgphobos2.a libgphobos2_t.a unittest.o
-	$(GDC) -o $@ $(CFLAGS) unittest.o -nophoboslib -L./ -L../libdruntime -lgphobos2_t -lgdruntime $(LIBS) $(DL_LIBS)
+unittest: libgphobos2.a $(ALL_PHOBOS_OBJS:.o=.t.o) unittest.o
+	$(GDC) -o $@ $(CFLAGS) unittest.o -nophoboslib -L./ -L../libdruntime $(ALL_PHOBOS_OBJS:.o=.t.o) -lgdruntime -lcurl $(LIBS) $(DL_LIBS)
 
 #--------------------------------------#
 # Install, doc, etc targets
@@ -165,7 +161,6 @@ clean-local:
 	rm -f unittest.o
 	rm -f unittest$(EXEEXT)
 	rm -f libgphobos2.a
-	rm -f libgphobos2_t.a
 
 check-local: unittest
 	./unittest

--- a/libphobos/src/Makefile.in
+++ b/libphobos/src/Makefile.in
@@ -478,12 +478,8 @@ libgphobos2.a : $(ALL_PHOBOS_OBJS) ../libdruntime/libgdruntime.a
 	$(AR) -q $@ $(ALL_PHOBOS_OBJS)
 	$(RANLIB) $@
 
-libgphobos2_t.a : $(ALL_PHOBOS_OBJS:.o=.t.o)
-	$(AR) -r $@ $(ALL_PHOBOS_OBJS:.o=.t.o)
-	$(RANLIB) $@
-
-unittest: libgphobos2.a libgphobos2_t.a unittest.o
-	$(GDC) -o $@ $(CFLAGS) unittest.o -nophoboslib -L./ -L../libdruntime -lgphobos2_t -lgdruntime $(LIBS) $(DL_LIBS)
+unittest: libgphobos2.a $(ALL_PHOBOS_OBJS:.o=.t.o) unittest.o
+	$(GDC) -o $@ $(CFLAGS) unittest.o -nophoboslib -L./ -L../libdruntime $(ALL_PHOBOS_OBJS:.o=.t.o) -lgdruntime -lcurl $(LIBS) $(DL_LIBS)
 
 #--------------------------------------#
 # Install, doc, etc targets
@@ -513,7 +509,6 @@ clean-local:
 	rm -f unittest.o
 	rm -f unittest$(EXEEXT)
 	rm -f libgphobos2.a
-	rm -f libgphobos2_t.a
 
 check-local: unittest
 	./unittest


### PR DESCRIPTION
Do not link object files of modules to be tested into a static library. If we link a static library, the linker might not pull in all object files. Instead pass the object files directly to the linking command.

This uncovers some failing tests. However, we now have to link the phobos unittest executable with libcurl.
