### PR TITLE
Remove some include dependencies on d-codegen.h

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,11 @@
+2016-03-28  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-codegen.h (lang_dtype): Remove function.
+	(lang_ddecl): Remove function.
+	* d-tree.h (TYPE_LANG_FRONTEND): New macro, replace all uses of
+	lang_dtype function.
+	(DECL_LANG_FRONTEND): New macro.
+
 2016-03-27  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-codegen.h (function_type_p): Remove function.

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -5,6 +5,12 @@
 	* d-tree.h (TYPE_LANG_FRONTEND): New macro, replace all uses of
 	lang_dtype function.
 	(DECL_LANG_FRONTEND): New macro.
+	* d-attribs.c: Update includes.
+	* d-builtins.cc: Likewise.
+	* d-codegen.cc: Likewise.
+	* d-incpath.cc: Likewise.
+	* d-lang.cc: Likewise.
+	* d-objfile.cc: Likewise.
 
 2016-03-27  Iain Buclaw  <ibuclaw@gdcproject.org>
 

--- a/gcc/d/d-attribs.c
+++ b/gcc/d/d-attribs.c
@@ -23,24 +23,20 @@
 #include "system.h"
 #include "coretypes.h"
 
-#include "dfrontend/aggregate.h"
+#include "dfrontend/arraytypes.h"
 #include "dfrontend/mtype.h"
 
 #include "tree.h"
 #include "diagnostic.h"
 #include "tm.h"
-#include "hard-reg-set.h"
-#include "function.h"
 #include "cgraph.h"
 #include "toplev.h"
 #include "target.h"
 #include "common/common-target.h"
 #include "stringpool.h"
 #include "varasm.h"
-#include "attribs.h"
 
 #include "d-tree.h"
-#include "d-codegen.h"
 
 /* Internal attribute handlers for built-in functions.  */
 static tree handle_noreturn_attribute (tree *, tree, tree, int, bool *);

--- a/gcc/d/d-attribs.c
+++ b/gcc/d/d-attribs.c
@@ -465,7 +465,7 @@ d_handle_noinline_attribute (tree *node, tree name,
 			     tree ARG_UNUSED (args),
 			     int ARG_UNUSED (flags), bool *no_add_attrs)
 {
-  Type *t = lang_dtype (TREE_TYPE (*node));
+  Type *t = TYPE_LANG_FRONTEND (TREE_TYPE (*node));
 
   if (t->ty == Tfunction)
     DECL_UNINLINABLE (*node) = 1;
@@ -486,7 +486,7 @@ d_handle_forceinline_attribute (tree *node, tree name,
 				int ARG_UNUSED (flags),
 				bool *no_add_attrs)
 {
-  Type *t = lang_dtype (TREE_TYPE (*node));
+  Type *t = TYPE_LANG_FRONTEND (TREE_TYPE (*node));
 
   if (t->ty == Tfunction)
     {
@@ -517,7 +517,7 @@ d_handle_flatten_attribute (tree *node, tree name,
 			    tree args ATTRIBUTE_UNUSED,
 			    int flags ATTRIBUTE_UNUSED, bool *no_add_attrs)
 {
-  Type *t = lang_dtype (TREE_TYPE (*node));
+  Type *t = TYPE_LANG_FRONTEND (TREE_TYPE (*node));
 
   if (t->ty != Tfunction)
     {
@@ -534,7 +534,7 @@ static tree
 d_handle_target_attribute (tree *node, tree name, tree args, int flags,
 			   bool *no_add_attrs)
 {
-  Type *t = lang_dtype (TREE_TYPE (*node));
+  Type *t = TYPE_LANG_FRONTEND (TREE_TYPE (*node));
 
   /* Ensure we have a function type.  */
   if (t->ty != Tfunction)
@@ -556,7 +556,7 @@ d_handle_noclone_attribute (tree *node, tree name,
 				int ARG_UNUSED (flags),
 				bool *no_add_attrs)
 {
-  Type *t = lang_dtype (TREE_TYPE (*node));
+  Type *t = TYPE_LANG_FRONTEND (TREE_TYPE (*node));
 
   if (t->ty == Tfunction)
     {

--- a/gcc/d/d-builtins.cc
+++ b/gcc/d/d-builtins.cc
@@ -25,7 +25,6 @@
 #include "dfrontend/declaration.h"
 #include "dfrontend/module.h"
 #include "dfrontend/mtype.h"
-#include "dfrontend/template.h"
 
 #include "tree.h"
 #include "fold-const.h"
@@ -36,7 +35,6 @@
 #include "stor-layout.h"
 
 #include "d-tree.h"
-#include "d-codegen.h"
 #include "d-objfile.h"
 #include "id.h"
 

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -19,14 +19,14 @@
 #include "system.h"
 #include "coretypes.h"
 
+#include "dfrontend/aggregate.h"
 #include "dfrontend/attrib.h"
-#include "dfrontend/template.h"
+#include "dfrontend/declaration.h"
 #include "dfrontend/init.h"
 #include "dfrontend/module.h"
-#include "dfrontend/aggregate.h"
-#include "dfrontend/declaration.h"
 #include "dfrontend/statement.h"
 #include "dfrontend/target.h"
+#include "dfrontend/template.h"
 
 #include "tree.h"
 #include "tree-iterator.h"

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -489,12 +489,12 @@ get_decl_tree (Declaration *decl)
 tree
 d_convert(tree type, tree exp)
 {
-  // Check this first before passing to lang_dtype.
+  // Check this first before retrieving frontend type.
   if (error_operand_p(type) || error_operand_p(exp))
     return error_mark_node;
 
-  Type *totype = lang_dtype(type);
-  Type *etype = lang_dtype(TREE_TYPE (exp));
+  Type *totype = TYPE_LANG_FRONTEND (type);
+  Type *etype = TYPE_LANG_FRONTEND (TREE_TYPE (exp));
 
   if (totype && etype)
     return convert_expr(exp, etype, totype);

--- a/gcc/d/d-codegen.h
+++ b/gcc/d/d-codegen.h
@@ -213,24 +213,6 @@ d_types_same (Type *t1, Type *t2)
   return tb1->equals (tb2);
 }
 
-// Returns D Frontend type for GCC type T.
-inline Type *
-lang_dtype (tree t)
-{
-  gcc_assert (TYPE_P (t));
-  struct lang_type *lt = TYPE_LANG_SPECIFIC (t);
-  return lt ? lt->d_type : NULL;
-}
-
-// Returns D Frontend decl for GCC decl T.
-inline Declaration *
-lang_ddecl (tree t)
-{
-  gcc_assert (DECL_P (t));
-  struct lang_decl *ld = DECL_LANG_SPECIFIC (t);
-  return ld ? ld->d_decl : NULL;
-}
-
 // Returns D frontend type 'Object' which all classes are derived from.
 inline Type *
 build_object_type()

--- a/gcc/d/d-incpath.cc
+++ b/gcc/d/d-incpath.cc
@@ -20,9 +20,6 @@
 #include "coretypes.h"
 
 #include "dfrontend/init.h"
-#include "dfrontend/cond.h"
-#include "dfrontend/aggregate.h"
-#include "dfrontend/declaration.h"
 
 #include "tree.h"
 #include "diagnostic.h"
@@ -30,7 +27,6 @@
 #include "cppdefault.h"
 
 #include "d-tree.h"
-#include "d-codegen.h"
 
 // Read ENV_VAR for a PATH_SEPARATOR-separated list of file names; and
 // append all the names to the import search path.

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -1472,7 +1472,7 @@ d_finish_incomplete_decl (tree decl)
 static classify_record
 d_classify_record (tree type)
 {
-  Type *dtype = lang_dtype (type);
+  Type *dtype = TYPE_LANG_FRONTEND (type);
 
   if (dtype && dtype->ty == Tclass)
     {
@@ -1533,7 +1533,7 @@ d_eh_personality()
 static tree
 d_build_eh_type_type (tree type)
 {
-  Type *dtype = lang_dtype (type);
+  Type *dtype = TYPE_LANG_FRONTEND (type);
   Symbol *sym;
 
   if (dtype)

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -50,7 +50,6 @@
 #include "gimple-expr.h"
 #include "gimplify.h"
 #include "debug.h"
-#include "function.h"
 
 #include "d-tree.h"
 #include "d-codegen.h"

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -38,7 +38,6 @@
 #include "fold-const.h"
 #include "diagnostic.h"
 #include "tm.h"
-#include "hard-reg-set.h"
 #include "function.h"
 #include "dumpfile.h"
 #include "cgraph.h"

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -196,6 +196,16 @@ lang_tree_node
 #define D_LABEL_VARIABLE_CASE(NODE) \
   (DECL_LANG_FLAG_2 (LABEL_DECL_CHECK (NODE)))
 
+// The D frontend Type AST for GCC type NODE.
+#define TYPE_LANG_FRONTEND(NODE) \
+  (TYPE_LANG_SPECIFIC (NODE) \
+   ? TYPE_LANG_SPECIFIC (NODE)->d_type : NULL)
+
+// The D frontend Declaration AST for GCC decl NODE.
+#define DECL_LANG_FRONTEND(NODE) \
+  (DECL_LANG_SPECIFIC (NODE) \
+   ? DECL_LANG_SPECIFIC (NODE)->d_decl : NULL)
+
 enum d_tree_index
 {
   DTI_VTBL_PTR_TYPE,


### PR DESCRIPTION
It's also no longer necessary to include `hard-reg-set.h` - though I imagine this is specific to GCC trunk.
