### PR TITLE
Another stab at fixing 'alignment holes'.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,15 @@
 2016-03-28  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-tree.h (CLASS_TYPE_P): New macro.
+	* d-codegen.cc (build_struct_literal): Check RECORD_OR_UNION_TYPE_P
+	before testing ANON_AGGR_TYPE_P.
+	(fill_alignment_field): New function.
+	(fill_alignment_holes): New function.
+	(finish_aggregate_type): Call fill_alignment_holes before computing
+	backend type mode.
+
+2016-03-28  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* d-tree.h (D_METHOD_CALL_EXPR): Removed `D_' prefix from macro,
 	updated all callers.
 	(D_TYPE_IMAGINARY_FLOAT): Likewise.

--- a/gcc/d/d-elem.cc
+++ b/gcc/d/d-elem.cc
@@ -1749,8 +1749,6 @@ DotTypeExp::toElem()
 elem *
 DelegateExp::toElem()
 {
-  Type *t = e1->type->toBasetype();
-
   if (func->fbody)
     {
       // Add the function as nested function if it belongs to this module

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -181,6 +181,10 @@ lang_tree_node
 #define ANON_AGGR_TYPE_P(NODE) \
   (TYPE_LANG_FLAG_1 (RECORD_OR_UNION_CHECK (NODE)))
 
+// True if the type is the underlying record for a class.
+#define CLASS_TYPE_P(NODE) \
+  (TYPE_LANG_FLAG_2 (TREE_CHECK ((NODE), RECORD_TYPE)))
+
 // True if the symbol should be made "link one only".  This is used to
 // defer calling make_decl_one_only() before the decl has been prepared.
 #define D_DECL_ONE_ONLY(NODE) \

--- a/gcc/d/types.cc
+++ b/gcc/d/types.cc
@@ -461,6 +461,7 @@ public:
     // Note that this is set on both the reference type and record type.
     TYPE_LANG_SPECIFIC (t->ctype) = build_d_type_lang_specific(t);
     TYPE_LANG_SPECIFIC (basetype) = TYPE_LANG_SPECIFIC (t->ctype);
+    CLASS_TYPE_P (basetype) = 1;
 
     // Add the fields of each base class
     layout_aggregate_type(t->sym, basetype, t->sym);


### PR DESCRIPTION
  Insert padding into the aggregate type layout.

@jpf91 - supplementary fix for JSONValue unittest failures on ARM.
