### PR TITLE
Fix regression in test11.d in D2 testsuite

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,10 @@
 2016-03-29  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-codegen.cc (fill_alignment_field): Call layout_decl on field.
+	(finish_aggregate_type): Add assertion that TYPE_MODE is equal.
+
+2016-03-29  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* d-codegen.cc (convert_expr): Replace call build_integer_cst with
 	size_int.
 	(convert_for_assignment): Likewise.

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -4304,12 +4304,6 @@ layout_aggregate_members(Dsymbols *members, tree context, bool inherited_p)
 		  var->csym->Stree = field;
 		}
 
-	      if (var->size(var->loc))
-		{
-		  gcc_assert(DECL_MODE (field) != VOIDmode);
-		  gcc_assert(DECL_SIZE (field) != NULL_TREE);
-		}
-
 	      fields += 1;
 	      continue;
 	    }
@@ -4487,6 +4481,8 @@ fill_alignment_field(tree context, tree size, tree offset)
   DECL_FIELD_OFFSET (field) = offset;
   DECL_FIELD_BIT_OFFSET (field) = bitsize_zero_node;
 
+  layout_decl(field, 0);
+
   DECL_ARTIFICIAL (field) = 1;
   DECL_IGNORED_P (field) = 1;
 
@@ -4563,13 +4559,17 @@ finish_aggregate_type(unsigned structsize, unsigned alignsize, tree type,
   // Set the backend type mode.
   compute_record_mode(type);
 
-  // Set up variants.
-  for (tree x = TYPE_MAIN_VARIANT (type); x; x = TYPE_NEXT_VARIANT (x))
+  // Fix up all variants of this aggregate type.
+  for (tree t = TYPE_MAIN_VARIANT (type); t; t = TYPE_NEXT_VARIANT (t))
     {
-      TYPE_FIELDS (x) = TYPE_FIELDS (type);
-      TYPE_LANG_SPECIFIC (x) = TYPE_LANG_SPECIFIC (type);
-      TYPE_ALIGN (x) = TYPE_ALIGN (type);
-      TYPE_USER_ALIGN (x) = TYPE_USER_ALIGN (type);
+      if (t == type)
+	continue;
+
+      TYPE_FIELDS (t) = TYPE_FIELDS (type);
+      TYPE_LANG_SPECIFIC (t) = TYPE_LANG_SPECIFIC (type);
+      TYPE_ALIGN (t) = TYPE_ALIGN (type);
+      TYPE_USER_ALIGN (t) = TYPE_USER_ALIGN (type);
+      gcc_assert(TYPE_MODE (t) == TYPE_MODE (type));
     }
 }
 


### PR DESCRIPTION
ICE was caused by the field padding changing the `TYPE_MODE` of a struct in:

```
struct NODE27
{
    int data;
    shared(NODE27) *next;
}
```

Because the `DECL_SIZE` had not been set.  This has been sorted out by calling `layout_decl`.

~~However, I noticed that perhaps we should not be computing the backend `TYPE_MODE` until after all fields have been laid out.  Just going off size alone may not be enough.  So have deferred calling `compute_record_mode` until `finish_aggregate_type` (this also means that we won't call it twice), and explicitly overriding the `TYPE_MODE` of all existing variants will prevent this showing up in other forms.~~

Edit: Looks like how things work in my head differ from what really happens, however it may still be useful (if only a marginal speed-up) to prevent `compute_record_mode` from being called multiple times.
