### PR TITLE
Linking adjustments (for MinGW and system zlib)

### DIFF
--- a/gcc/d/Make-lang.in
+++ b/gcc/d/Make-lang.in
@@ -27,6 +27,12 @@ D_TARGET_INSTALL_NAME = $(target_noncanonical)-$(shell echo gdc|sed '$(program_t
 # Name of phobos library
 D_LIBPHOBOS = -DLIBPHOBOS=\"gphobos2\"
 
+# If ZLIBINC is empty we have been configured with --with-system-zlib
+D_ZLIB = -DUSE_SYSTEM_ZLIB=0
+ifeq ($(strip $(ZLIBINC)),)
+  D_ZLIB = -DUSE_SYSTEM_ZLIB=1
+endif
+
 # The name for selecting d in LANGUAGES.
 d: cc1d$(exeext)
 
@@ -37,7 +43,7 @@ d: cc1d$(exeext)
 D_INCLUDES = -I$(srcdir)/d -I$(srcdir)/d/dfrontend -Id
 
 # Create the compiler driver for D.
-CFLAGS-d/d-spec.o += $(DRIVER_DEFINES) $(D_LIBPHOBOS)
+CFLAGS-d/d-spec.o += $(DRIVER_DEFINES) $(D_LIBPHOBOS) $(D_ZLIB)
 
 GDC_OBJS = $(GCC_OBJS) d/d-spec.o
 gdc$(exeext): $(GDC_OBJS) $(EXTRA_GCC_OBJS) libcommon-target.a $(LIBDEPS)

--- a/gcc/d/d-spec.c
+++ b/gcc/d/d-spec.c
@@ -36,8 +36,12 @@
 #define WITHLIBCXX	(1<<5)
 /* this bit is set if they did `-lc'.  */
 #define WITHLIBC	(1<<6)
+/* this bit is set if they did `-lws2_32'.  */
+#define WIN32_SOCK_LIB	(1<<7)
+/* this bit is set if they did `-luuid'.  */
+#define WIN32_UUID_LIB	(1<<8)
 /* This bit is set when the argument should not be passed to gcc or the backend */
-#define SKIPOPT		(1<<8)
+#define SKIPOPT		(1<<9)
 
 #ifndef MATH_LIBRARY
 #define MATH_LIBRARY "m"
@@ -52,6 +56,14 @@
 
 #ifndef TIME_LIBRARY
 #define TIME_LIBRARY "rt"
+#endif
+
+#ifndef WIN32_SOCK_LIBRARY
+#define WIN32_SOCK_LIBRARY ""
+#endif
+
+#ifndef WIN32_UUID_LIBRARY
+#define WIN32_UUID_LIBRARY ""
 #endif
 
 #ifndef LIBSTDCXX
@@ -110,6 +122,12 @@ lang_specific_driver (cl_decoded_option **in_decoded_options,
   /* "-lrt" if it appears on the command line.  */
   const cl_decoded_option *saw_time = 0;
 
+  /* "-lws2_32" if it appears on the command line.  */
+  const cl_decoded_option *saw_win32_sock = 0;
+
+  /* "-luuid" if it appears on the command line.  */
+  const cl_decoded_option *saw_win32_uuid = 0;
+
   /* "-lc" if it appears on the command line.  */
   const cl_decoded_option *saw_libc = 0;
 
@@ -131,6 +149,12 @@ lang_specific_driver (cl_decoded_option **in_decoded_options,
 
   /* By default, we throw on the time library if we have one.  */
   int need_time = (TIME_LIBRARY[0] != '\0');
+
+  /* Whether we need the win32 socket library.  */
+  int need_win32_sock = (WIN32_SOCK_LIBRARY[0] != '\0');
+
+  /* Whether we need the win32 uuid library.  */
+  int need_win32_uuid = (WIN32_UUID_LIBRARY[0] != '\0');
 
   /* True if we saw -static. */
   int static_link = 0;
@@ -240,6 +264,16 @@ lang_specific_driver (cl_decoded_option **in_decoded_options,
 	    {
 	      args[i] |= TIMELIB;
 	      need_time = 0;
+	    }
+	  else if (strcmp (arg, WIN32_SOCK_LIBRARY) == 0)
+	    {
+	      args[i] |= WIN32_SOCK_LIB;
+	      need_win32_sock = 0;
+	    }
+	  else if (strcmp (arg, WIN32_UUID_LIBRARY) == 0)
+	    {
+	      args[i] |= WIN32_UUID_LIB;
+	      need_win32_uuid = 0;
 	    }
 	  else if (strcmp (arg, "c") == 0)
 	    args[i] |= WITHLIBC;
@@ -371,7 +405,8 @@ lang_specific_driver (cl_decoded_option **in_decoded_options,
   /* There is one extra argument added here for the runtime
      library: -lgphobos.  The -pthread argument is added by
      setting need_thread. */
-  num_args = argc + added + need_math + shared_libgcc + (library > 0) * 4 + 2;
+  num_args = argc + added + need_math + need_win32_sock + need_win32_uuid
+    + shared_libgcc + (library > 0) * 4 + 2;
   new_decoded_options = XNEWVEC (cl_decoded_option, num_args);
 
   i = 0;
@@ -409,6 +444,18 @@ lang_specific_driver (cl_decoded_option **in_decoded_options,
 	{
 	  --j;
 	  saw_time = &decoded_options[i];
+	}
+
+      if (!saw_win32_sock && (args[i] & WIN32_SOCK_LIB) && library > 0)
+	{
+	  --j;
+	  saw_win32_sock = &decoded_options[i];
+	}
+
+      if (!saw_win32_uuid && (args[i] & WIN32_UUID_LIB) && library > 0)
+	{
+	  --j;
+	  saw_win32_uuid = &decoded_options[i];
 	}
 
       if (!saw_libc && (args[i] & WITHLIBC) && library > 0)
@@ -545,6 +592,24 @@ lang_specific_driver (cl_decoded_option **in_decoded_options,
   else if (library > 0 && need_time)
     {
       generate_option (OPT_l, TIME_LIBRARY, 1, CL_DRIVER,
+		       &new_decoded_options[j++]);
+      added_libraries++;
+    }
+
+  if (saw_win32_sock)
+    new_decoded_options[j++] = *saw_win32_sock;
+  else if (library > 0 && need_win32_sock)
+    {
+      generate_option (OPT_l, WIN32_SOCK_LIBRARY, 1, CL_DRIVER,
+		       &new_decoded_options[j++]);
+      added_libraries++;
+    }
+
+  if (saw_win32_uuid)
+    new_decoded_options[j++] = *saw_win32_uuid;
+  else if (library > 0 && need_win32_uuid)
+    {
+      generate_option (OPT_l, WIN32_UUID_LIBRARY, 1, CL_DRIVER,
 		       &new_decoded_options[j++]);
       added_libraries++;
     }

--- a/gcc/d/patches/patch-gcc-6.x
+++ b/gcc/d/patches/patch-gcc-6.x
@@ -17,7 +17,7 @@ relevant documentation about the GDC front end.
  #define HAVE_ATEXIT
 --- a/gcc/config/i386/cygming.h
 +++ b/gcc/config/i386/cygming.h
-@@ -170,6 +170,10 @@ along with GCC; see the file COPYING3.  If not see
+@@ -170,6 +170,14 @@ along with GCC; see the file COPYING3.  If not see
  
  #undef MATH_LIBRARY
  #define MATH_LIBRARY ""
@@ -25,6 +25,10 @@ relevant documentation about the GDC front end.
 +#define THREAD_LIBRARY ""
 +#undef TIME_LIBRARY
 +#define TIME_LIBRARY ""
++#undef WIN32_SOCK_LIBRARY
++#define WIN32_SOCK_LIBRARY "ws2_32"
++#undef WIN32_UUID_LIBRARY
++#define WIN32_UUID_LIBRARY "uuid"
  
  #undef TARGET_LIBC_HAS_FUNCTION
  #define TARGET_LIBC_HAS_FUNCTION no_c99_libc_has_function


### PR DESCRIPTION
This contains two changes to the `d-spec.c` driver code:
- Phobos needs to be linked with `-lw2_32` and `-luuid` on MinGW targets
- `--with-system-zlib` only disabled compiling zlib into libgphobos. But when building an application the zlib symbols are missing as we do not link with `-lz`. Fixing this also means @Dicebot has to maintain one less Archlinux gdc patch.
