### PR TITLE
Load libcurl at runtime

### DIFF
--- a/gcc/d/Make-lang.in
+++ b/gcc/d/Make-lang.in
@@ -27,6 +27,12 @@ D_TARGET_INSTALL_NAME = $(target_noncanonical)-$(shell echo gdc|sed '$(program_t
 # Name of phobos library
 D_LIBPHOBOS = -DLIBPHOBOS=\"gphobos2\"
 
+# If ZLIBINC is empty we have been configured with --with-system-zlib
+D_ZLIB = -DUSE_SYSTEM_ZLIB=0
+ifeq ($(strip $(ZLIBINC)),)
+  D_ZLIB = -DUSE_SYSTEM_ZLIB=1
+endif
+
 # The name for selecting d in LANGUAGES.
 d: cc1d$(exeext)
 
@@ -37,7 +43,7 @@ d: cc1d$(exeext)
 D_INCLUDES = -I$(srcdir)/d -I$(srcdir)/d/dfrontend -Id
 
 # Create the compiler driver for D.
-CFLAGS-d/d-spec.o += $(DRIVER_DEFINES) $(D_LIBPHOBOS)
+CFLAGS-d/d-spec.o += $(DRIVER_DEFINES) $(D_LIBPHOBOS) $(D_ZLIB)
 
 GDC_OBJS = $(GCC_OBJS) d/d-spec.o
 gdc$(exeext): $(GDC_OBJS) $(EXTRA_GCC_OBJS) libcommon-target.a $(LIBDEPS)

--- a/gcc/d/d-spec.c
+++ b/gcc/d/d-spec.c
@@ -36,8 +36,12 @@
 #define WITHLIBCXX	(1<<5)
 /* this bit is set if they did `-lc'.  */
 #define WITHLIBC	(1<<6)
+/* this bit is set if they did `-lws2_32'.  */
+#define WIN32_SOCK_LIB	(1<<7)
+/* this bit is set if they did `-luuid'.  */
+#define WIN32_UUID_LIB	(1<<8)
 /* This bit is set when the argument should not be passed to gcc or the backend */
-#define SKIPOPT		(1<<8)
+#define SKIPOPT		(1<<9)
 
 #ifndef MATH_LIBRARY
 #define MATH_LIBRARY "m"
@@ -52,6 +56,14 @@
 
 #ifndef TIME_LIBRARY
 #define TIME_LIBRARY "rt"
+#endif
+
+#ifndef WIN32_SOCK_LIBRARY
+#define WIN32_SOCK_LIBRARY ""
+#endif
+
+#ifndef WIN32_UUID_LIBRARY
+#define WIN32_UUID_LIBRARY ""
 #endif
 
 #ifndef LIBSTDCXX
@@ -110,6 +122,12 @@ lang_specific_driver (cl_decoded_option **in_decoded_options,
   /* "-lrt" if it appears on the command line.  */
   const cl_decoded_option *saw_time = 0;
 
+  /* "-lws2_32" if it appears on the command line.  */
+  const cl_decoded_option *saw_win32_sock = 0;
+
+  /* "-luuid" if it appears on the command line.  */
+  const cl_decoded_option *saw_win32_uuid = 0;
+
   /* "-lc" if it appears on the command line.  */
   const cl_decoded_option *saw_libc = 0;
 
@@ -131,6 +149,12 @@ lang_specific_driver (cl_decoded_option **in_decoded_options,
 
   /* By default, we throw on the time library if we have one.  */
   int need_time = (TIME_LIBRARY[0] != '\0');
+
+  /* Whether we need the win32 socket library.  */
+  int need_win32_sock = (WIN32_SOCK_LIBRARY[0] != '\0');
+
+  /* Whether we need the win32 uuid library.  */
+  int need_win32_uuid = (WIN32_UUID_LIBRARY[0] != '\0');
 
   /* True if we saw -static. */
   int static_link = 0;
@@ -240,6 +264,16 @@ lang_specific_driver (cl_decoded_option **in_decoded_options,
 	    {
 	      args[i] |= TIMELIB;
 	      need_time = 0;
+	    }
+	  else if (strcmp (arg, WIN32_SOCK_LIBRARY) == 0)
+	    {
+	      args[i] |= WIN32_SOCK_LIB;
+	      need_win32_sock = 0;
+	    }
+	  else if (strcmp (arg, WIN32_UUID_LIBRARY) == 0)
+	    {
+	      args[i] |= WIN32_UUID_LIB;
+	      need_win32_uuid = 0;
 	    }
 	  else if (strcmp (arg, "c") == 0)
 	    args[i] |= WITHLIBC;
@@ -371,7 +405,8 @@ lang_specific_driver (cl_decoded_option **in_decoded_options,
   /* There is one extra argument added here for the runtime
      library: -lgphobos.  The -pthread argument is added by
      setting need_thread. */
-  num_args = argc + added + need_math + shared_libgcc + (library > 0) * 4 + 2;
+  num_args = argc + added + need_math + need_win32_sock + need_win32_uuid
+    + shared_libgcc + (library > 0) * 4 + 2;
   new_decoded_options = XNEWVEC (cl_decoded_option, num_args);
 
   i = 0;
@@ -409,6 +444,18 @@ lang_specific_driver (cl_decoded_option **in_decoded_options,
 	{
 	  --j;
 	  saw_time = &decoded_options[i];
+	}
+
+      if (!saw_win32_sock && (args[i] & WIN32_SOCK_LIB) && library > 0)
+	{
+	  --j;
+	  saw_win32_sock = &decoded_options[i];
+	}
+
+      if (!saw_win32_uuid && (args[i] & WIN32_UUID_LIB) && library > 0)
+	{
+	  --j;
+	  saw_win32_uuid = &decoded_options[i];
 	}
 
       if (!saw_libc && (args[i] & WITHLIBC) && library > 0)
@@ -545,6 +592,24 @@ lang_specific_driver (cl_decoded_option **in_decoded_options,
   else if (library > 0 && need_time)
     {
       generate_option (OPT_l, TIME_LIBRARY, 1, CL_DRIVER,
+		       &new_decoded_options[j++]);
+      added_libraries++;
+    }
+
+  if (saw_win32_sock)
+    new_decoded_options[j++] = *saw_win32_sock;
+  else if (library > 0 && need_win32_sock)
+    {
+      generate_option (OPT_l, WIN32_SOCK_LIBRARY, 1, CL_DRIVER,
+		       &new_decoded_options[j++]);
+      added_libraries++;
+    }
+
+  if (saw_win32_uuid)
+    new_decoded_options[j++] = *saw_win32_uuid;
+  else if (library > 0 && need_win32_uuid)
+    {
+      generate_option (OPT_l, WIN32_UUID_LIBRARY, 1, CL_DRIVER,
 		       &new_decoded_options[j++]);
       added_libraries++;
     }

--- a/gcc/d/patches/patch-gcc-6.x
+++ b/gcc/d/patches/patch-gcc-6.x
@@ -17,7 +17,7 @@ relevant documentation about the GDC front end.
  #define HAVE_ATEXIT
 --- a/gcc/config/i386/cygming.h
 +++ b/gcc/config/i386/cygming.h
-@@ -170,6 +170,10 @@ along with GCC; see the file COPYING3.  If not see
+@@ -170,6 +170,14 @@ along with GCC; see the file COPYING3.  If not see
  
  #undef MATH_LIBRARY
  #define MATH_LIBRARY ""
@@ -25,6 +25,10 @@ relevant documentation about the GDC front end.
 +#define THREAD_LIBRARY ""
 +#undef TIME_LIBRARY
 +#define TIME_LIBRARY ""
++#undef WIN32_SOCK_LIBRARY
++#define WIN32_SOCK_LIBRARY "ws2_32"
++#undef WIN32_UUID_LIBRARY
++#define WIN32_UUID_LIBRARY "uuid"
  
  #undef TARGET_LIBC_HAS_FUNCTION
  #define TARGET_LIBC_HAS_FUNCTION no_c99_libc_has_function

--- a/gcc/d/patches/patch-gcc-6.x
+++ b/gcc/d/patches/patch-gcc-6.x
@@ -32,6 +32,18 @@ relevant documentation about the GDC front end.
  
  #undef TARGET_LIBC_HAS_FUNCTION
  #define TARGET_LIBC_HAS_FUNCTION no_c99_libc_has_function
+--- a/gcc/config/linux.h
++++ b/gcc/config/linux.h
+@@ -42,6 +42,9 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+ #define OPTION_MUSL   (linux_libc == LIBC_MUSL)
+ #endif
+ 
++#undef LINKER_LIBRARY
++#define LINKER_LIBRARY "dl"
++
+ #define GNU_USER_TARGET_OS_CPP_BUILTINS()			\
+     do {							\
+ 	if (OPTION_GLIBC)					\
 --- a/gcc/config/linux-android.h
 +++ b/gcc/config/linux-android.h
 @@ -57,3 +57,9 @@

--- a/gcc/d/patches/patch-versym-os-6.x
+++ b/gcc/d/patches/patch-versym-os-6.x
@@ -250,7 +250,7 @@ These official OS versions are not implemented:
  #else
 --- a/gcc/config/linux.h
 +++ b/gcc/config/linux.h
-@@ -53,6 +53,28 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+@@ -56,6 +56,28 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
  	builtin_assert ("system=posix");			\
      } while (0)
  

--- a/libphobos/src/Makefile.am
+++ b/libphobos/src/Makefile.am
@@ -135,7 +135,7 @@ libgphobos2_t.a : $(ALL_PHOBOS_OBJS:.o=.t.o)
 	$(RANLIB) $@
 
 unittest: libgphobos2.a libgphobos2_t.a unittest.o
-	$(GDC) -o $@ $(CFLAGS) unittest.o -nophoboslib -L./ -L../libdruntime -lgphobos2_t -lgdruntime $(LIBS) $(DL_LIBS)
+	$(GDC) -o $@ $(CFLAGS) unittest.o -nophoboslib -L./ -L../libdruntime -lgphobos2_t -lgdruntime $(LIBS)
 
 #--------------------------------------#
 # Install, doc, etc targets

--- a/libphobos/src/Makefile.in
+++ b/libphobos/src/Makefile.in
@@ -111,7 +111,6 @@ DCFG_THREAD_MODEL = @DCFG_THREAD_MODEL@
 DEFS = @DEFS@
 DFLAGS = @DFLAGS@
 DFLAGSX = @DFLAGSX@
-DL_LIBS = @DL_LIBS@
 DRUNTIME_OBJS = @DRUNTIME_OBJS@
 D_EXTRA_OBJS = @D_EXTRA_OBJS@
 D_GC_MODULES = @D_GC_MODULES@
@@ -483,7 +482,7 @@ libgphobos2_t.a : $(ALL_PHOBOS_OBJS:.o=.t.o)
 	$(RANLIB) $@
 
 unittest: libgphobos2.a libgphobos2_t.a unittest.o
-	$(GDC) -o $@ $(CFLAGS) unittest.o -nophoboslib -L./ -L../libdruntime -lgphobos2_t -lgdruntime $(LIBS) $(DL_LIBS)
+	$(GDC) -o $@ $(CFLAGS) unittest.o -nophoboslib -L./ -L../libdruntime -lgphobos2_t -lgdruntime $(LIBS)
 
 #--------------------------------------#
 # Install, doc, etc targets

--- a/libphobos/src/etc/c/curl.d
+++ b/libphobos/src/etc/c/curl.d
@@ -35,9 +35,6 @@
 
 module etc.c.curl;
 
-version (GNU) {}
-else version (Windows) pragma(lib, "curl");
-
 import core.stdc.time;
 import core.stdc.config;
 import std.socket;

--- a/libphobos/src/std/net/curl.d
+++ b/libphobos/src/std/net/curl.d
@@ -199,8 +199,6 @@ version(unittest)
 }
 version(StdDdoc) import std.stdio;
 
-version (GNU) {}
-else version (Windows) pragma(lib, "curl");
 extern (C) void exit(int);
 
 // Default data timeout for Protocols
@@ -2094,7 +2092,7 @@ struct HTTP
         ~this()
         {
             if (headersOut !is null)
-                curl_slist_free_all(headersOut);
+                Curl.curl.slist_free_all(headersOut);
             if (curl.handle !is null) // work around RefCounted/emplace bug
                 curl.shutdown();
         }
@@ -2209,7 +2207,7 @@ struct HTTP
         curl_slist* newlist = null;
         while (cur)
         {
-            newlist = curl_slist_append(newlist, cur.data);
+            newlist = Curl.curl.slist_append(newlist, cur.data);
             cur = cur.next;
         }
         copy.p.headersOut = newlist;
@@ -2509,7 +2507,7 @@ struct HTTP
     void clearRequestHeaders()
     {
         if (p.headersOut !is null)
-            curl_slist_free_all(p.headersOut);
+            Curl.curl.slist_free_all(p.headersOut);
         p.headersOut = null;
         p.curl.clear(CurlOption.httpheader);
     }
@@ -2532,8 +2530,8 @@ struct HTTP
         if (icmp(name, "User-Agent") == 0)
             return setUserAgent(value);
         string nv = format("%s: %s", name, value);
-        p.headersOut = curl_slist_append(p.headersOut,
-                                         nv.tempCString().buffPtr);
+        p.headersOut = Curl.curl.slist_append(p.headersOut,
+                                              nv.tempCString().buffPtr);
         p.curl.set(CurlOption.httpheader, p.headersOut);
     }
 
@@ -2541,9 +2539,7 @@ struct HTTP
      * The default "User-Agent" value send with a request.
      * It has the form "Phobos-std.net.curl/$(I PHOBOS_VERSION) (libcurl/$(I CURL_VERSION))"
      */
-    static immutable string defaultUserAgent;
-
-    shared static this()
+    static string defaultUserAgent() @property
     {
         import std.compiler : version_major, version_minor;
 
@@ -2551,12 +2547,17 @@ struct HTTP
         enum fmt = "Phobos-std.net.curl/%d.%03d (libcurl/%d.%d.%d)";
         enum maxLen = fmt.length - "%d%03d%d%d%d".length + 10 + 10 + 3 + 3 + 3;
 
-        __gshared char[maxLen] buf = void;
+        static char[maxLen] buf = void;
+        static string userAgent;
 
-        auto curlVer = curl_version_info(CURLVERSION_NOW).version_num;
-        defaultUserAgent = cast(immutable)sformat(
-            buf, fmt, version_major, version_minor,
-            curlVer >> 16 & 0xFF, curlVer >> 8 & 0xFF, curlVer & 0xFF);
+        if (!userAgent.length)
+        {
+            auto curlVer = Curl.curl.version_info(CURLVERSION_NOW).version_num;
+            userAgent = cast(immutable)sformat(
+                buf, fmt, version_major, version_minor,
+                curlVer >> 16 & 0xFF, curlVer >> 8 & 0xFF, curlVer & 0xFF);
+        }
+        return userAgent;
     }
 
     /** Set the value of the user agent request header field.
@@ -2883,7 +2884,7 @@ struct FTP
         ~this()
         {
             if (commands !is null)
-                curl_slist_free_all(commands);
+                Curl.curl.slist_free_all(commands);
             if (curl.handle !is null) // work around RefCounted/emplace bug
                 curl.shutdown();
         }
@@ -2922,7 +2923,7 @@ struct FTP
         curl_slist* newlist = null;
         while (cur)
         {
-            newlist = curl_slist_append(newlist, cur.data);
+            newlist = Curl.curl.slist_append(newlist, cur.data);
             cur = cur.next;
         }
         copy.p.commands = newlist;
@@ -3138,7 +3139,7 @@ struct FTP
     void clearCommands()
     {
         if (p.commands !is null)
-            curl_slist_free_all(p.commands);
+            Curl.curl.slist_free_all(p.commands);
         p.commands = null;
         p.curl.clear(CurlOption.postquote);
     }
@@ -3159,8 +3160,8 @@ struct FTP
      */
     void addCommand(const(char)[] command)
     {
-        p.commands = curl_slist_append(p.commands,
-                                       command.tempCString().buffPtr);
+        p.commands = Curl.curl.slist_append(p.commands,
+                                            command.tempCString().buffPtr);
         p.curl.set(CurlOption.postquote, p.commands);
     }
 
@@ -3265,7 +3266,7 @@ struct SMTP
         curl_slist* newlist = null;
         while (cur)
         {
-            newlist = curl_slist_append(newlist, cur.data);
+            newlist = Curl.curl.slist_append(newlist, cur.data);
             cur = cur.next;
         }
         copy.p.commands = newlist;
@@ -3499,7 +3500,7 @@ struct SMTP
         foreach(recipient; recipients)
         {
             recipients_list =
-                curl_slist_append(recipients_list,
+                Curl.curl.slist_append(recipients_list,
                                   recipient.tempCString().buffPtr);
         }
         p.curl.set(CurlOption.mail_rcpt, recipients_list);
@@ -3566,6 +3567,119 @@ import std.typecons : Flag;
 /// Flag to specify whether or not an exception is thrown on error.
 alias ThrowOnError = Flag!"throwOnError";
 
+private struct CurlAPI
+{
+    static struct API
+    {
+    extern(C):
+        import core.stdc.config : c_long;
+        CURLcode function(c_long flags) global_init;
+        void function() global_cleanup;
+        curl_version_info_data * function(CURLversion) version_info;
+        CURL* function() easy_init;
+        CURLcode function(CURL *curl, CURLoption option,...) easy_setopt;
+        CURLcode function(CURL *curl) easy_perform;
+        CURL* function(CURL *curl) easy_duphandle;
+        char* function(CURLcode) easy_strerror;
+        CURLcode function(CURL *handle, int bitmask) easy_pause;
+        void function(CURL *curl) easy_cleanup;
+        curl_slist* function(curl_slist *, char *) slist_append;
+        void function(curl_slist *) slist_free_all;
+    }
+    __gshared API _api;
+    __gshared void* _handle;
+
+    static ref API instance() @property
+    {
+        import std.concurrency;
+        initOnce!_handle(loadAPI());
+        return _api;
+    }
+
+    static void* loadAPI()
+    {
+        version (Posix)
+        {
+            import core.sys.posix.dlfcn;
+            alias loadSym = dlsym;
+        }
+        else version (Windows)
+        {
+            import core.sys.windows.windows;
+            alias loadSym = GetProcAddress;
+        }
+        else
+            static assert(0, "unimplemented");
+
+        void* handle;
+        version (Posix)
+            handle = dlopen(null, RTLD_LAZY);
+        else version (Windows)
+            handle = GetModuleHandleA(null);
+        assert(handle !is null);
+
+        // try to load curl from the executable to allow static linking
+        if (loadSym(handle, "curl_global_init") is null)
+        {
+            version (Posix)
+                dlclose(handle);
+
+            version (OSX)
+                static immutable names = ["libcurl.4.dylib"];
+            else version (Posix)
+                static immutable names = ["libcurl.so", "libcurl.so.4", "libcurl-gnutls.so.4", "libcurl-nss.so.4", "libcurl.so.3"];
+            else version (Windows)
+                static immutable names = ["libcurl.dll", "curl.dll"];
+
+            foreach (name; names)
+            {
+                version (Posix)
+                    handle = dlopen(name.ptr, RTLD_LAZY);
+                else version (Windows)
+                    handle = LoadLibraryA(name.ptr);
+                if (handle !is null) break;
+            }
+
+            enforce!CurlException(handle !is null, "Failed to load curl, tried %(%s, %).".format(names));
+        }
+
+        foreach (mem; __traits(allMembers, API))
+        {
+            void* p = loadSym(handle, "curl_"~mem);
+
+            __traits(getMember, _api, mem) = cast(typeof(__traits(getMember, _api, mem)))
+                enforce!CurlException(p, "Couldn't load curl_"~mem~" from libcurl.");
+        }
+
+        enforce!CurlException(!_api.global_init(CurlGlobal.all),
+                              "Failed to initialize libcurl");
+
+        return handle;
+    }
+
+    shared static ~this()
+    {
+        if (_handle is null) return;
+
+        _api.global_cleanup();
+        version (Posix)
+        {
+            import core.sys.posix.dlfcn;
+            dlclose(_handle);
+        }
+        else version (Windows)
+        {
+            import core.sys.windows.windows;
+            FreeLibrary(_handle);
+        }
+        else
+            static assert(0, "unimplemented");
+
+        _api = API.init;
+        _handle = null;
+    }
+}
+
 /**
   Wrapper to provide a better interface to libcurl than using the plain C API.
   It is recommended to use the $(D HTTP)/$(D FTP) etc. structs instead unless
@@ -3578,21 +3692,11 @@ alias ThrowOnError = Flag!"throwOnError";
 */
 struct Curl
 {
-    shared static this()
-    {
-        // initialize early to prevent thread races
-        enforce!CurlException(!curl_global_init(CurlGlobal.all),
-                                "Couldn't initialize libcurl");
-    }
-
-    shared static ~this()
-    {
-        curl_global_cleanup();
-    }
-
     alias OutData = void[];
     alias InData = ubyte[];
     bool stopped;
+
+    private static auto ref curl() @property { return CurlAPI.instance(); }
 
     // A handle should not be used by two threads simultaneously
     private CURL* handle;
@@ -3615,7 +3719,7 @@ struct Curl
     void initialize()
     {
         enforce!CurlException(!handle, "Curl instance already initialized");
-        handle = curl_easy_init();
+        handle = curl.easy_init();
         enforce!CurlException(handle, "Curl instance couldn't be initialized");
         stopped = false;
         set(CurlOption.nosignal, 1);
@@ -3632,7 +3736,7 @@ struct Curl
     Curl dup()
     {
         Curl copy;
-        copy.handle = curl_easy_duphandle(handle);
+        copy.handle = curl.easy_duphandle(handle);
         copy.stopped = false;
 
         with (CurlOption) {
@@ -3697,7 +3801,7 @@ struct Curl
     {
         import core.stdc.string : strlen;
 
-        auto msgZ = curl_easy_strerror(code);
+        auto msgZ = curl.easy_strerror(code);
         // doing the following (instead of just using std.conv.to!string) avoids 1 allocation
         return format("%s on handle %s", msgZ[0 .. core.stdc.string.strlen(msgZ)], handle);
     }
@@ -3717,7 +3821,7 @@ struct Curl
     {
         throwOnStopped();
         stopped = true;
-        curl_easy_cleanup(this.handle);
+        curl.easy_cleanup(this.handle);
         this.handle = null;
     }
 
@@ -3727,7 +3831,7 @@ struct Curl
     void pause(bool sendingPaused, bool receivingPaused)
     {
         throwOnStopped();
-        _check(curl_easy_pause(this.handle,
+        _check(curl.easy_pause(this.handle,
                                (sendingPaused ? CurlPause.send_cont : CurlPause.send) |
                                (receivingPaused ? CurlPause.recv_cont : CurlPause.recv)));
     }
@@ -3741,7 +3845,7 @@ struct Curl
     void set(CurlOption option, const(char)[] value)
     {
         throwOnStopped();
-        _check(curl_easy_setopt(this.handle, option, value.tempCString().buffPtr));
+        _check(curl.easy_setopt(this.handle, option, value.tempCString().buffPtr));
     }
 
     /**
@@ -3753,7 +3857,7 @@ struct Curl
     void set(CurlOption option, long value)
     {
         throwOnStopped();
-        _check(curl_easy_setopt(this.handle, option, value));
+        _check(curl.easy_setopt(this.handle, option, value));
     }
 
     /**
@@ -3765,7 +3869,7 @@ struct Curl
     void set(CurlOption option, void* value)
     {
         throwOnStopped();
-        _check(curl_easy_setopt(this.handle, option, value));
+        _check(curl.easy_setopt(this.handle, option, value));
     }
 
     /**
@@ -3776,7 +3880,7 @@ struct Curl
     void clear(CurlOption option)
     {
         throwOnStopped();
-        _check(curl_easy_setopt(this.handle, option, null));
+        _check(curl.easy_setopt(this.handle, option, null));
     }
 
     /**
@@ -3788,7 +3892,7 @@ struct Curl
     void clearIfSupported(CurlOption option)
     {
         throwOnStopped();
-        auto rval = curl_easy_setopt(this.handle, option, null);
+        auto rval = curl.easy_setopt(this.handle, option, null);
         if (rval != CurlError.unknown_telnet_option)
         {
             _check(rval);
@@ -3805,7 +3909,7 @@ struct Curl
     CurlCode perform(ThrowOnError throwOnError = ThrowOnError.yes)
     {
         throwOnStopped();
-        CurlCode code = curl_easy_perform(this.handle);
+        CurlCode code = curl.easy_perform(this.handle);
         if (throwOnError)
             _check(code);
         return code;


### PR DESCRIPTION
Load libcurl dynamically at runtime.

Also link executables against `-ldl` on linux. This should be the last library we have to add to `d-spec.c`. Requires / includes https://github.com/D-Programming-GDC/GDC/pull/181 so https://github.com/D-Programming-GDC/GDC/pull/181 should be merged before merging this.
