### PR TITLE
GDC without -o option produces truncated output file name

### DIFF
--- a/gcc/d/d-spec.c
+++ b/gcc/d/d-spec.c
@@ -455,7 +455,7 @@ lang_specific_driver (cl_decoded_option **in_decoded_options,
       char *out;
 
       base = lbasename (first_d_file);
-      baselen = strlen (base) - 3;
+      baselen = strlen (base) - 2;
       alen = baselen + 3;
       out = XNEWVEC (char, alen);
       memcpy (out, base, baselen);


### PR DESCRIPTION
Current behaviour: `gdc -c test.d` => `tes.o`

@ibuclaw I guess this was only an oversight? We only look for `.d` files, `strlen` does not include terminating 0 so we certainly only have to subtract 2?
