### PR TITLE
Some small clean-ups pulled from other branches.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -4,6 +4,10 @@
 	* d-lang.cc (d_init_exceptions): Remove function.
 	* d-codegen.h: Move visitor declarations to ...
 	* d-tree.h: ... here.
+	(lang_decl): Remove `d_` prefix from fields.
+	(lang_type): Likewise.
+	* d-lang.cc (build_d_type_lang_specific): Rename to build_lang_type.
+	(build_d_decl_lang_specific): Rename to build_lang_decl.
 	* imports.cc: Update includes.
 
 2016-03-29  Johannes Pfau  <johannespfau@gmail.com>

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2016-04-23  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-builtins.cc (build_dtype): Make function static.
+	* d-lang.cc (d_init_exceptions): Remove function.
+
 2016-03-29  Johannes Pfau  <johannespfau@gmail.com>
 
 	* d-objfile.cc (d_comdat_linkage): Rewrite template duplicate

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -2,6 +2,9 @@
 
 	* d-builtins.cc (build_dtype): Make function static.
 	* d-lang.cc (d_init_exceptions): Remove function.
+	* d-codegen.h: Move visitor declarations to ...
+	* d-tree.h: ... here.
+	* imports.cc: Update includes.
 
 2016-03-29  Johannes Pfau  <johannespfau@gmail.com>
 

--- a/gcc/d/d-builtins.cc
+++ b/gcc/d/d-builtins.cc
@@ -737,8 +737,7 @@ d_init_builtins()
   // Need to avoid errors in gimplification, else, need to not ICE
   // in targetm.canonical_va_list_type
   Type::tvalist->ctype = va_list_type_node;
-  TYPE_LANG_SPECIFIC (va_list_type_node) =
-    build_d_type_lang_specific(Type::tvalist);
+  TYPE_LANG_SPECIFIC (va_list_type_node) = build_lang_type(Type::tvalist);
 
 
   if (TREE_CODE (va_list_type_node) == ARRAY_TYPE)

--- a/gcc/d/d-builtins.cc
+++ b/gcc/d/d-builtins.cc
@@ -65,7 +65,7 @@ tree d_global_trees[DTI_MAX];
 // For others, it is not useful or, in the cast of (C char) -> (D char), will
 // cause errors.  This also means char * ...
 
-Type *
+static Type *
 build_dtype(tree type)
 {
   Type *dtype;

--- a/gcc/d/d-codegen.h
+++ b/gcc/d/d-codegen.h
@@ -40,11 +40,6 @@ struct FuncFrameInfo
   };
 };
 
-// Visitor routines for barrier between frontend and glue.
-extern void build_ir(FuncDeclaration *fd);
-extern tree build_ctype(Type *t);
-extern tree build_import_decl(Dsymbol *dsym);
-
 // Code generation routines.
 extern void push_binding_level(level_kind kind);
 extern tree pop_binding_level();

--- a/gcc/d/d-decls.cc
+++ b/gcc/d/d-decls.cc
@@ -175,7 +175,7 @@ VarDeclaration::toSymbol()
 	  setup_symbol_storage (this, decl, false);
 	}
 
-      DECL_LANG_SPECIFIC (decl) = build_d_decl_lang_specific (this);
+      DECL_LANG_SPECIFIC (decl) = build_lang_decl (this);
       d_keep (decl);
       csym->Stree = decl;
 
@@ -323,7 +323,7 @@ FuncDeclaration::toSymbol()
       csym->Stree = fndecl;
 
       TREE_TYPE (fndecl) = build_ctype(ftype);
-      DECL_LANG_SPECIFIC (fndecl) = build_d_decl_lang_specific (this);
+      DECL_LANG_SPECIFIC (fndecl) = build_lang_decl (this);
       d_keep (fndecl);
 
       if (isNested())

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -259,7 +259,7 @@ d_init()
   d_init_builtins();
 
   if (flag_exceptions)
-    d_init_exceptions();
+    using_eh_for_cleanups();
 
   // This is the C main, not the D main.
   main_identifier_node = get_identifier ("main");
@@ -1542,12 +1542,6 @@ d_build_eh_type_type (tree type)
   sym = ((TypeClass *) dtype)->sym->toSymbol();
 
   return convert (ptr_type_node, build_address (sym->Stree));
-}
-
-void
-d_init_exceptions()
-{
-  using_eh_for_cleanups();
 }
 
 

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -1490,18 +1490,18 @@ d_classify_record (tree type)
 
 
 struct lang_type *
-build_d_type_lang_specific (Type *t)
+build_lang_type (Type *t)
 {
   struct lang_type *lt = ggc_cleared_alloc<struct lang_type>();
-  lt->d_type = t;
+  lt->type = t;
   return lt;
 }
 
 struct lang_decl *
-build_d_decl_lang_specific (Declaration *d)
+build_lang_decl (Declaration *d)
 {
   struct lang_decl *ld = ggc_cleared_alloc<struct lang_decl>();
-  ld->d_decl = d;
+  ld->decl = d;
   return ld;
 }
 

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -20,6 +20,7 @@
 #define GCC_D_TREE_H
 
 // Forward type declarations to avoid including unnecessary headers.
+class Dsymbol;
 class Declaration;
 class FuncDeclaration;
 class VarDeclaration;
@@ -296,5 +297,14 @@ extern tree d_pushdecl (tree);
 extern tree d_unsigned_type (tree);
 extern tree d_signed_type (tree);
 extern void d_keep (tree);
+
+// In imports.cc
+extern tree build_import_decl (Dsymbol *);
+
+// In toir.cc
+extern void build_ir (FuncDeclaration *);
+
+// In types.cc
+extern tree build_ctype (Type *);
 
 #endif

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -279,10 +279,7 @@ extern void d_init_builtins (void);
 extern void d_register_builtin_type (tree, const char *);
 extern void d_build_builtins_module (Module *);
 extern void d_maybe_set_builtin (Module *);
-extern void d_backend_init (void);
-extern void d_backend_term (void);
 extern Expression *build_expression (tree);
-extern Type *build_dtype (tree);
 
 // In d-convert.cc.
 extern tree d_truthvalue_conversion (tree);
@@ -298,7 +295,6 @@ extern struct lang_decl *build_d_decl_lang_specific (Declaration *);
 extern tree d_pushdecl (tree);
 extern tree d_unsigned_type (tree);
 extern tree d_signed_type (tree);
-extern void d_init_exceptions (void);
 extern void d_keep (tree);
 
 #endif

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -156,13 +156,13 @@ struct GTY(()) language_function
 // collection system.  Handle this by using the "skip" attribute. */
 struct GTY(()) lang_decl
 {
-  Declaration * GTY((skip)) d_decl;
+  Declaration * GTY((skip)) decl;
 };
 
 // The lang_type field is not set for every GCC type.
 struct GTY(()) lang_type
 {
-  Type * GTY((skip)) d_type;
+  Type * GTY((skip)) type;
 };
 
 // Another required, but unused declaration.  This could be simplified, since
@@ -212,12 +212,12 @@ lang_tree_node
 // The D frontend Type AST for GCC type NODE.
 #define TYPE_LANG_FRONTEND(NODE) \
   (TYPE_LANG_SPECIFIC (NODE) \
-   ? TYPE_LANG_SPECIFIC (NODE)->d_type : NULL)
+   ? TYPE_LANG_SPECIFIC (NODE)->type : NULL)
 
 // The D frontend Declaration AST for GCC decl NODE.
 #define DECL_LANG_FRONTEND(NODE) \
   (DECL_LANG_SPECIFIC (NODE) \
-   ? DECL_LANG_SPECIFIC (NODE)->d_decl : NULL)
+   ? DECL_LANG_SPECIFIC (NODE)->decl : NULL)
 
 enum d_tree_index
 {
@@ -291,8 +291,8 @@ extern void add_import_paths (const char *, const char *, bool);
 // In d-lang.cc.
 extern void d_add_global_declaration (tree);
 extern Module *d_gcc_get_output_module (void);
-extern struct lang_type *build_d_type_lang_specific (Type *);
-extern struct lang_decl *build_d_decl_lang_specific (Declaration *);
+extern struct lang_type *build_lang_type (Type *);
+extern struct lang_decl *build_lang_decl (Declaration *);
 extern tree d_pushdecl (tree);
 extern tree d_unsigned_type (tree);
 extern tree d_signed_type (tree);

--- a/gcc/d/imports.cc
+++ b/gcc/d/imports.cc
@@ -20,16 +20,15 @@
 #include "system.h"
 #include "coretypes.h"
 
-#include "dfrontend/aggregate.h"
+#include "dfrontend/arraytypes.h"
+#include "dfrontend/declaration.h"
 #include "dfrontend/enum.h"
 #include "dfrontend/module.h"
 
 #include "tree.h"
-#include "diagnostic.h"
 #include "stringpool.h"
 
 #include "d-tree.h"
-#include "d-codegen.h"
 #include "d-objfile.h"
 
 // Implements the visitor interface to build debug trees for all module and

--- a/gcc/d/types.cc
+++ b/gcc/d/types.cc
@@ -196,7 +196,7 @@ public:
 
     t->ctype = make_node(ENUMERAL_TYPE);
     ENUM_IS_SCOPED (t->ctype) = 1;
-    TYPE_LANG_SPECIFIC (t->ctype) = build_d_type_lang_specific(t);
+    TYPE_LANG_SPECIFIC (t->ctype) = build_lang_type(t);
     d_keep(t->ctype);
 
     if (flag_short_enums)
@@ -256,7 +256,7 @@ public:
     t->ctype = make_node(t->sym->isUnionDeclaration() ? UNION_TYPE : RECORD_TYPE);
     d_keep(t->ctype);
 
-    TYPE_LANG_SPECIFIC (t->ctype) = build_d_type_lang_specific(t);
+    TYPE_LANG_SPECIFIC (t->ctype) = build_lang_type(t);
 
     // Must set up the overall size, etc. before determining the context or
     // laying out fields as those types may make references to this type.
@@ -315,7 +315,7 @@ public:
 
     // Function type could be referenced by parameters, so set ctype earlier?
     t->ctype = build_function_type(ret_type, type_list);
-    TYPE_LANG_SPECIFIC (t->ctype) = build_d_type_lang_specific(t);
+    TYPE_LANG_SPECIFIC (t->ctype) = build_lang_type(t);
     d_keep(t->ctype);
 
     if (t->next && !t->isref)
@@ -400,7 +400,7 @@ public:
 
     t->ctype = build_two_field_type(lentype, build_pointer_type(ptrtype),
 				    t, "length", "ptr");
-    TYPE_LANG_SPECIFIC (t->ctype) = build_d_type_lang_specific(t);
+    TYPE_LANG_SPECIFIC (t->ctype) = build_lang_type(t);
     d_keep(t->ctype);
   }
 
@@ -418,7 +418,7 @@ public:
     TYPE_TRANSPARENT_AGGR (t->ctype) = 1;
     layout_type(t->ctype);
 
-    TYPE_LANG_SPECIFIC (t->ctype) = build_d_type_lang_specific(t);
+    TYPE_LANG_SPECIFIC (t->ctype) = build_lang_type(t);
     d_keep(t->ctype);
   }
 
@@ -445,7 +445,7 @@ public:
 
     t->ctype = build_two_field_type(objtype, build_pointer_type(funtype),
 				    t, "object", "func");
-    TYPE_LANG_SPECIFIC (t->ctype) = build_d_type_lang_specific(t);
+    TYPE_LANG_SPECIFIC (t->ctype) = build_lang_type(t);
     d_keep(t->ctype);
   }
 
@@ -459,7 +459,7 @@ public:
     d_keep(t->ctype);
 
     // Note that this is set on both the reference type and record type.
-    TYPE_LANG_SPECIFIC (t->ctype) = build_d_type_lang_specific(t);
+    TYPE_LANG_SPECIFIC (t->ctype) = build_lang_type(t);
     TYPE_LANG_SPECIFIC (basetype) = TYPE_LANG_SPECIFIC (t->ctype);
     CLASS_TYPE_P (basetype) = 1;
 


### PR DESCRIPTION
- Identify extern functions in d-tree.h that can be made static
- Move visitor declarations to d-tree.h (clean-up includes)
- Simplify names for building lang_specific decls.
