### PR TITLE
Backport AArch64 definitions from druntime commit b8b0899

### DIFF
--- a/libphobos/libdruntime/core/stdc/fenv.d
+++ b/libphobos/libdruntime/core/stdc/fenv.d
@@ -93,6 +93,17 @@ version( GNUFP )
 
         alias fexcept_t = ushort;
     }
+    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/aarch64/bits/fenv.h
+    else version (AArch64)
+    {
+        struct fenv_t
+        {
+            uint __fpcr;
+            uint __fpsr;
+        }
+
+        alias fexcept_t = uint;
+    }
     // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/arm/bits/fenv.h
     else version (ARM)
     {

--- a/libphobos/libdruntime/core/sys/posix/setjmp.d
+++ b/libphobos/libdruntime/core/sys/posix/setjmp.d
@@ -62,6 +62,10 @@ version( linux )
     {
         alias int[3] __jmp_buf;
     }
+    else version (AArch64)
+    {
+        alias long[22] __jmp_buf;
+    }
     else version (ARM)
     {
         alias int[64] __jmp_buf;

--- a/libphobos/libdruntime/core/sys/posix/sys/msg.d
+++ b/libphobos/libdruntime/core/sys/posix/sys/msg.d
@@ -205,6 +205,26 @@ else version (X86_64)
 		c_ulong __glibc_reserved5;
 	};
 } 
+else version (AArch64)
+{
+ // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/generic/bits/msq.h
+ alias c_ulong msgqnum_t;
+ alias c_ulong msglen_t;
+
+ struct msqid_ds {
+   ipc_perm msg_perm;
+   time_t          msg_stime;
+   time_t          msg_rtime;
+   time_t          msg_ctime;
+   c_ulong         __msg_cbytes;
+   msgqnum_t       msg_qnum;
+   msglen_t        msg_qbytes;
+   pid_t           msg_lspid;
+   pid_t           msg_lrpid;
+   c_ulong __glibc_reserved4;
+   c_ulong __glibc_reserved5;
+ };
+}
 else version (ARM) 
 {
 	// https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/generic/bits/msq.h

--- a/libphobos/libdruntime/core/sys/posix/sys/socket.d
+++ b/libphobos/libdruntime/core/sys/posix/sys/socket.d
@@ -467,6 +467,40 @@ version( linux )
             SO_TYPE         = 3
         }
     }
+    else version (AArch64)
+    {
+        enum
+        {
+            SOCK_DGRAM      = 2,
+            SOCK_SEQPACKET  = 5,
+            SOCK_STREAM     = 1
+        }
+
+        enum
+        {
+            SOL_SOCKET      = 1
+        }
+
+        enum
+        {
+            SO_ACCEPTCONN   = 30,
+            SO_BROADCAST    = 6,
+            SO_DEBUG        = 1,
+            SO_DONTROUTE    = 5,
+            SO_ERROR        = 4,
+            SO_KEEPALIVE    = 9,
+            SO_LINGER       = 13,
+            SO_OOBINLINE    = 10,
+            SO_RCVBUF       = 8,
+            SO_RCVLOWAT     = 18,
+            SO_RCVTIMEO     = 20,
+            SO_REUSEADDR    = 2,
+            SO_SNDBUF       = 7,
+            SO_SNDLOWAT     = 19,
+            SO_SNDTIMEO     = 21,
+            SO_TYPE         = 3
+        }
+    }
     else
         static assert(0, "unimplemented");
 


### PR DESCRIPTION
Found via native compilation of gdc on pine64 board.

Patches from here:

https://github.com/dlang/druntime/commit/b8b0899f2f9e09c2113857cb23d8da74e5a57245

Should be already in 2.068 or newer.
