### PR TITLE
Set is64bit for all known 64-bit architectures to the frontend

### DIFF
--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -226,8 +226,12 @@ d_add_builtin_version(const char* ident)
     global.params.isOpenBSD = true;
   else if (strcmp (ident, "Solaris") == 0)
     global.params.isSolaris = true;
-  else if (strcmp (ident, "X86_64") == 0)
-    global.params.is64bit = true;
+  else if (strcmp (ident, "AArch64") == 0 || strcmp (ident, "Alpha") == 0
+           || strcmp (ident, "HPPA64") == 0 || strcmp (ident, "IA64") == 0
+           || strcmp (ident, "MIPS64") == 0 || strcmp (ident, "PPC64") == 0
+           || strcmp (ident, "SH64") == 0 || strcmp (ident, "SPARC64") == 0
+           || strcmp (ident, "SystemZ") == 0 || strcmp (ident, "X86_64") == 0)
+     global.params.is64bit = true;
 
   VersionCondition::addPredefinedGlobalIdent (ident);
 }


### PR DESCRIPTION
With small exception of NVPTX64, which is supported in llvm, but not gcc. Other archs do have some level of support in gcc.

This should avoid compiler confusion when it have LP64 set, but not is64bit in frontend. This manifests for example in cases like in object.d

alias size_t ulong;

auto len = x.length;
for (a; 0 .. len) {
}

where compiler say that the foreach key must be int or uint, not ulong. This should fix it.
