### PR TITLE
Remove special case for array of vectors.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2016-04-29  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+       * d-todt.cc (TypeSArray::toDtElem): Remove special handling for
+       arrays of vectors.
+
 2016-04-23  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-builtins.cc (build_dtype): Make function static.

--- a/gcc/d/d-todt.cc
+++ b/gcc/d/d-todt.cc
@@ -964,8 +964,6 @@ TypeSArray::toDtElem (dt_t **pdt, Expression *e)
       tree dt = NULL_TREE;
       Type *tnext = next;
       Type *tbn = tnext->toBasetype();
-      if (tbn->ty == Tvector)
-	tbn = ((TypeVector *) tbn)->basetype;
 
       if (e && (e->op == TOKstring || e->op == TOKarrayliteral))
 	{


### PR DESCRIPTION
`TypeVector::defaultInit` as of 2.067 now creates a proper vector expression from a single value.

I was seeing an ICE from gcc-6 where the constructor for `__vector(float[4])[2]` was creating a constructor of type `float[4][4][2]`
