### PR TITLE
Bug 167: override size_t, ptrdiff_t, and hash_t in Target::init

### DIFF
--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -235,9 +235,6 @@ d_add_builtin_version(const char* ident)
 static bool
 d_init()
 {
-  if(POINTER_SIZE == 64)
-    global.params.isLP64 = true;
-
   Lexer::initLexer();
   Type::init();
   Id::initialize();

--- a/gcc/d/d-target.cc
+++ b/gcc/d/d-target.cc
@@ -56,22 +56,21 @@ Target::init()
   reverseCppOverloads = false;
 
   // Define what type to use for size_t, ptrdiff_t.
-  size_t wordsize = int_size_in_bytes(size_type_node);
-  if (wordsize == 2)
-    Tsize_t = Tuns16;
-  else if (wordsize == 4)
-    Tsize_t = Tuns32;
-  else if (wordsize == 8)
-    Tsize_t = Tuns64;
+  if (POINTER_SIZE == 64)
+    {
+      global.params.isLP64 = true;
+      Tsize_t = Tuns64;
+      Tptrdiff_t = Tint64;
+    }
   else
-    gcc_unreachable();
+    {
+      Tsize_t = Tuns32;
+      Tptrdiff_t = Tint32;
+    }
 
-  if (POINTER_SIZE == 32)
-    Tptrdiff_t = Tint32;
-  else if (POINTER_SIZE == 64)
-    Tptrdiff_t = Tint64;
-  else
-    gcc_unreachable();
+  Type::tsize_t = Type::basic[Tsize_t];
+  Type::tptrdiff_t = Type::basic[Tptrdiff_t];
+  Type::thash_t = Type::tsize_t;
 
   ptrsize = (POINTER_SIZE / BITS_PER_UNIT);
   c_longsize = int_size_in_bytes(long_integer_type_node);


### PR DESCRIPTION
http://bugzilla.gdcproject.org/show_bug.cgi?id=167
