### PR TITLE
Sync together changes in toDt rewrite into ExprVisitor

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,16 @@
+2016-05-06  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* expr.cc (ExprVisitor::ExprVisitor): Update signature.
+	(ExprVisitor::visit(AddrExp)): Handle constant expressions.
+	(ExprVisitor::visit(FuncExp)): Likewise.
+	(ExprVisitor::visit(ComplexExp)): Likewise.
+	(ExprVisitor::visit(StringExp)): Likewise.
+	(ExprVisitor::visit(ArrayLiteralExp)): Likewise.
+	(ExprVisitor::visit(StructLiteralExp)): Likewise.
+	(ExprVisitor::visit(NullExp)): Likewise.
+	(ExprVisitor::visit(ClassReferenceExp)): Likewise.
+	(build_expr): Update signature.
+
 2016-05-05  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* Make-lang.in (D_GLUE_OBJS): Add d/expr.o.

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -286,8 +286,8 @@ extern Expression *build_expression (tree);
 extern tree d_truthvalue_conversion (tree);
 
 // In d-expr.cc.
-extern tree build_expr(Expression *);
-extern tree build_expr_dtor(Expression *);
+extern tree build_expr (Expression *, bool = false);
+extern tree build_expr_dtor (Expression *);
 
 // In d-incpath.cc.
 extern void add_import_paths (const char *, const char *, bool);


### PR DESCRIPTION
Taking some of the changes or refactorings from #179 and putting them into `ExprVisitor`.

There is also a new parameter `const_p` (or `constp_` as it is seen internally), but is not yet turned on anywhere.

The goal or idea being that what was `toElem` and `toDt` can now be joined together into the same visitor pass.  This should have a net effect of at least 1500 _less_ lines of code, and removing the intermediate `dt_t` representation which needs converting to `tree`.

Probably best viewed using [`w=1`](https://github.com/D-Programming-GDC/GDC/pull/193/files?w=1)
