### PR TITLE
[refactor] Encapsulate creating anonymous static variables

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,12 @@
+2016-05-09  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-objfile.cc (get_unique_name): Remove function.
+	(build_artificial_decl): New function.
+	(d_finish_symbol): Use build_artificial_decl.
+	(build_moduleinfo): Likewise.
+	* d-decls.cc (StructLiteralExp::toSymbol): Likewise.
+	(ClassReferenceExp::toSymbol): Likewise.
+
 2016-05-07  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* expr.cc (ExprVisitor::visit(BinExp)): New function.

--- a/gcc/d/d-decls.cc
+++ b/gcc/d/d-decls.cc
@@ -608,14 +608,8 @@ StructLiteralExp::toSymbol()
 
       // Build reference symbol.
       tree ctype = build_ctype(type);
-      tree decl = build_decl(UNKNOWN_LOCATION, VAR_DECL, NULL_TREE, ctype);
-      get_unique_name(decl, "S");
+      tree decl = build_artificial_decl(ctype, NULL_TREE, "S");
       set_decl_location(decl, loc);
-
-      TREE_PUBLIC (decl) = 0;
-      TREE_STATIC (decl) = 1;
-      TREE_USED (decl) = 1;
-      DECL_ARTIFICIAL (decl) = 1;
 
       sym->Stree = decl;
       this->sinit = sym;
@@ -635,20 +629,11 @@ ClassReferenceExp::toSymbol()
       value->sym = new Symbol();
 
       // Build reference symbol.
-      tree decl = build_decl(UNKNOWN_LOCATION, VAR_DECL, NULL_TREE, unknown_type_node);
-      char *ident;
-
-      ASM_FORMAT_PRIVATE_NAME (ident, "C", DECL_UID (decl));
-      DECL_NAME (decl) = get_identifier(ident);
+      tree decl = build_artificial_decl(unknown_type_node, NULL_TREE, "C");
       set_decl_location(decl, loc);
 
-      TREE_PUBLIC (decl) = 0;
-      TREE_STATIC (decl) = 1;
-      TREE_USED (decl) = 1;
-      DECL_ARTIFICIAL (decl) = 1;
-
       value->sym->Stree = decl;
-      value->sym->Sident = ident;
+      value->sym->Sident = IDENTIFIER_POINTER (DECL_NAME (decl));
 
       toInstanceDt(&value->sym->Sdt);
       d_finish_symbol(value->sym);

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -1621,26 +1621,6 @@ set_function_end_locus (const Loc& loc)
     cfun->function_end_locus = DECL_SOURCE_LOCATION (cfun->decl);
 }
 
-void
-get_unique_name (tree decl, const char *prefix)
-{
-  const char *name;
-  char *label;
-
-  if (prefix)
-    name = prefix;
-  else if (DECL_NAME (decl))
-    name = IDENTIFIER_POINTER (DECL_NAME (decl));
-  else
-    name = "___s";
-
-  ASM_FORMAT_PRIVATE_NAME (label, name, DECL_UID (decl));
-  SET_DECL_ASSEMBLER_NAME (decl, get_identifier (label));
-
-  if (!DECL_NAME (decl))
-    DECL_NAME (decl) = DECL_ASSEMBLER_NAME (decl);
-}
-
 // Return the COMDAT group into which DECL should be placed.
 
 static tree
@@ -1811,20 +1791,9 @@ d_finish_symbol (Symbol *sym)
 {
   if (!sym->Stree)
     {
-      gcc_assert (!sym->Sident);
-
       tree init = dtvector_to_tree (sym->Sdt);
-      tree var = build_decl (UNKNOWN_LOCATION, VAR_DECL, NULL_TREE, TREE_TYPE (init));
-      get_unique_name (var);
-
-      DECL_INITIAL (var) = init;
-      TREE_STATIC (var) = 1;
-      TREE_PUBLIC (var) = 0;
-      TREE_USED (var) = 1;
-      DECL_IGNORED_P (var) = 1;
-      DECL_ARTIFICIAL (var) = 1;
-
-      sym->Stree = var;
+      sym->Stree = build_artificial_decl(TREE_TYPE (init), init);
+      gcc_assert (!sym->Sident);
     }
 
   tree decl = sym->Stree;
@@ -1969,6 +1938,33 @@ d_finish_compilation(tree *vec, int len)
 	  rest_of_decl_compilation(decl, toplevel, 0);
 	}
     }
+}
+
+// Return an anonymous static variable of type TYPE, initialized with
+// INIT, and optionally prefixing the name with PREFIX.
+// At some point the INIT constant should be hashed to remove duplicates.
+
+tree
+build_artificial_decl(tree type, tree init, const char *prefix)
+{
+  tree decl = build_decl(UNKNOWN_LOCATION, VAR_DECL, NULL_TREE, type);
+  const char *name = prefix ? prefix : "___s";
+  char *label;
+
+  ASM_FORMAT_PRIVATE_NAME (label, name, DECL_UID (decl));
+  SET_DECL_ASSEMBLER_NAME (decl, get_identifier(label));
+  DECL_NAME (decl) = DECL_ASSEMBLER_NAME (decl);
+
+  TREE_PUBLIC (decl) = 0;
+  TREE_STATIC (decl) = 1;
+  TREE_USED (decl) = 1;
+  DECL_IGNORED_P (decl) = 1;
+  DECL_ARTIFICIAL (decl) = 1;
+
+  DECL_INITIAL (decl) = init;
+  d_add_global_declaration(decl);
+
+  return decl;
 }
 
 // Build TYPE_DECL for the declaration DSYM.
@@ -2420,16 +2416,9 @@ build_moduleinfo (Symbol *sym)
   TREE_PUBLIC (dmodule_ref) = 1;
 
   // private ModuleReference modref = { next: null, mod: _ModuleInfo_xxx };
-  tree modref = build_decl (UNKNOWN_LOCATION, VAR_DECL, NULL_TREE, tmodref);
-  d_keep (modref);
-
-  get_unique_name (modref, "__mod_ref");
+  tree modref = build_artificial_decl (tmodref, NULL_TREE, "__mod_ref");
   set_decl_location (modref, current_module_decl);
-
-  DECL_ARTIFICIAL (modref) = 1;
-  DECL_IGNORED_P (modref) = 1;
-  TREE_PUBLIC (modref) = 0;
-  TREE_STATIC (modref) = 1;
+  d_keep (modref);
 
   vec<constructor_elt, va_gc> *ce = NULL;
   CONSTRUCTOR_APPEND_ELT (ce, nextfield, null_pointer_node);

--- a/gcc/d/d-objfile.h
+++ b/gcc/d/d-objfile.h
@@ -107,8 +107,6 @@ extern void set_decl_location (tree t, const Loc& loc);
 extern void set_decl_location (tree t, Dsymbol *decl);
 extern void set_function_end_locus (const Loc& loc);
 
-extern void get_unique_name (tree decl, const char *prefix = NULL);
-
 extern void get_template_storage_info (Dsymbol *dsym, bool *local_p, bool *template_p);
 extern void setup_symbol_storage (Dsymbol *dsym, tree decl, bool is_public);
 extern void d_comdat_linkage (tree decl);
@@ -118,6 +116,7 @@ extern void d_finish_function (FuncDeclaration *f);
 extern void d_finish_module();
 extern void d_finish_compilation (tree *vec, int len);
 
+extern tree build_artificial_decl(tree type, tree init, const char *prefix = NULL);
 extern void build_type_decl (tree t, Dsymbol *dsym);
 
 extern Modules output_modules;


### PR DESCRIPTION
Needed for #195 as there are parts of `toDt` that create anonymous symbols on the fly.

To do later, add in a CST hashing function to de-duplicate the symbols we create.  Because if the initializer will land in readonly data, it's safe to merge them together.
