### PR TITLE
Use a constructor when initializing a static array from a single element

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2016-05-12  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-codegen.cc (build_array_from_val): New function.
+	* expr.cc (ExprVisitor::visit(StructLiteralExp)): Use it.
+
 2016-05-11  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-codegen.cc (convert_expr): Use build_nop to cast between two

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -2474,6 +2474,33 @@ build_array_set(tree ptr, tree length, tree value)
 		BLOCK_VARS (block), stmt_list, block);
 }
 
+
+// Build an array of type TYPE where all the elements are VAL.
+
+tree
+build_array_from_val(Type *type, tree val)
+{
+  gcc_assert(type->ty == Tsarray);
+
+  TypeSArray *satype = (TypeSArray *) type;
+  Type *etype = type->nextOf();
+
+  // Initializing a multidimensional array.
+  if (etype->ty == Tsarray)
+    val = build_array_from_val(etype, val);
+
+  size_t dims = satype->dim->toInteger();
+  vec<constructor_elt, va_gc> *elms = NULL;
+  vec_safe_reserve(elms, dims);
+
+  val = d_convert(build_ctype(etype), val);
+
+  for (size_t i = 0; i < dims; i++)
+    CONSTRUCTOR_APPEND_ELT (elms, size_int(i), val);
+
+  return build_constructor(build_ctype(satype), elms);
+}
+
 // Implicitly converts void* T to byte* as D allows { void[] a; &a[3]; }
 
 tree

--- a/gcc/d/d-codegen.h
+++ b/gcc/d/d-codegen.h
@@ -129,6 +129,7 @@ extern tree build_offset_op (tree_code op, tree ptr, tree idx);
 extern tree build_offset (tree ptr_node, tree byte_offset);
 extern tree build_memref (tree type, tree ptr, tree byte_offset);
 extern tree build_array_set(tree ptr, tree length, tree value);
+extern tree build_array_from_val(Type *type, tree val);
 
 // Function calls
 extern tree d_build_call (FuncDeclaration *fd, tree object, Expressions *args);

--- a/gcc/d/expr.cc
+++ b/gcc/d/expr.cc
@@ -2600,23 +2600,14 @@ public:
 
 	if (ftype->ty == Tsarray && !d_types_same(type, ftype))
 	  {
-	    value = build_local_temp(build_ctype(ftype));
-	    Type *etype = ftype;
+	    // Initialize a static array with a single element.
+	    tree elem = build_expr(exp, this->constp_);
+	    elem = maybe_make_temp(elem);
 
-	    while (etype->ty == Tsarray)
-	      etype = etype->nextOf();
-
-	    gcc_assert(ftype->size() % etype->size() == 0);
-	    tree size = fold_build2(TRUNC_DIV_EXPR, size_type_node,
-				    size_int(ftype->size()),
-				    size_int(etype->size()));
-
-	    tree ptr_tree = build_nop(build_ctype(etype->pointerTo()),
-				      build_address(value));
-	    ptr_tree = void_okay_p(ptr_tree);
-	    tree set_exp = build_array_set(ptr_tree, size,
-					   build_expr(exp, this->constp_));
-	    value = compound_expr(set_exp, value);
+	    if (initializer_zerop(elem))
+	      value = build_constructor(build_ctype(ftype), NULL);
+	    else
+	      value = build_array_from_val(ftype, elem);
 	  }
 	else
 	  {


### PR DESCRIPTION
`build_array_set` should be used only when initializing a dynamic array of a size only known at runtime.

Using it for initializing a static array is both inefficient, and not `constp` friendly.
