### PR TITLE
Offload some more code generation from toDt to ExprVisitor

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,17 @@
+2016-05-14  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-codegen.cc (get_decl_tree): First check if cfun is set.
+	* d-todt.cc (StructLiteralExp::toDt): Update call to build_expr.
+	(SymOffExp::toDt): Likewise.
+	(VarExp::toDt): Likewise.
+	(FuncExp::toDt): Likewise.
+	(VectorExp::toDt): Likewise.
+	* expr.cc (ExprVisitor::visit(SymbolExp)): Remove function
+	(ExprVisitor::visit(SymOffExp)): New function.
+	(ExprVisitor::visit(VarExp)): New function.
+	(ExprVisitor::visit(StructLiteralExp)): Don't return static
+	initializer symbol if constant literal requested.
+
 2016-05-13  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-codegen.cc (build_struct_literal): Maybe set TREE_CONSTANT or

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -416,11 +416,12 @@ expand_decl (tree decl)
 tree
 get_decl_tree (Declaration *decl)
 {
+  FuncDeclaration *func = cfun ? cfun->language->function : NULL;
   VarDeclaration *vd = decl->isVarDeclaration();
 
-  if (vd)
+  // If cfun is NULL, then this is a global static.
+  if (func != NULL && vd != NULL)
     {
-      FuncDeclaration *func = cfun->language->function;
       Symbol *vsym = vd->toSymbol();
       if (vsym->SnamedResult != NULL_TREE)
 	{


### PR DESCRIPTION
At the point where pretty much all expressions are safely handled by `ExprVisitor`.

`TypeInfo` generation should be shunted into it's own encapsulated source next.
