### PR TITLE
Fix destructors of temporaries called out of order

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,11 @@
+2016-05-16  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* expr.cc (ExprVisitor::visit(AssignExp)): Build the rhs constructor
+	before the lhs declaration.
+	(ExprVisitor::visit(DeclarationExp)): Compile the declaration and
+	initializer before pushing it to vars_in_scope.
+	(build_expr_dtor): Compound all dtors in reverse.
+
 2016-05-16  Johannes Pfau  <johannespfau@gmail.com>
 
 	* expr.cc (ExprVisitor::visit(IdentityExp*)): Remove side-effects


### PR DESCRIPTION
The list of dtors in `build_expr_dtor` have actually never been executed in reverse.  It's just relied on a feature of the code generator that builds/pushes the LHS declaration into the list of things to destruct before the RHS is compiled (which may have more temporaries).

For DeclarationExp and reference initializations at the very least, we should be compiling the expression from right to left to ensure the reverse order is correct.
