### PR TITLE
Always add `-o' option when compiling D sources

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,10 @@
 2017-07-28  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-spec.c (lang_specific_driver): Always add `-o' option when
+	compiling D sources.
+
+2017-07-28  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* d-frontend.cc (genCmain): Don't error if entrypoint not found.
 
 2017-07-18  Iain Buclaw  <ibuclaw@gdcproject.org>


### PR DESCRIPTION
So the driver behaves more like dmd where multiple sources passed are always compiled at once, rather than separately.

Closes at least http://bugzilla.gdcproject.org/show_bug.cgi?id=103
