### PR TITLE
Bug 224: [ICE] std/datetime.o: in reload_combine_note_use, at postreload.c:1535

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,11 @@
+2016-05-21  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-codegen.cc (build_struct_literal): Don't set TREE_STATIC.
+	(build_boolop): Remove side effects from aggregate types only.
+	* expr.cc (ExprVisitor::visit(ArrayLiteralExp)): Don't check
+	initializer_constant_valid_p until after constructor is built.
+	(ExprVisitor::visit(StructLiteralExp)): Likewise.
+
 2016-05-16  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* expr.cc (ExprVisitor::visit(AssignExp)): Build the rhs constructor

--- a/gcc/d/expr.cc
+++ b/gcc/d/expr.cc
@@ -2441,7 +2441,6 @@ public:
     vec<constructor_elt, va_gc> *elms = NULL;
     vec_safe_reserve(elms, e->elements->dim);
     bool constant_p = true;
-    bool simple_p = true;
 
     Type *etype = tb->nextOf();
     tree satype = d_array_type(etype, e->elements->dim);
@@ -2459,10 +2458,6 @@ public:
 		value = maybe_make_temp(value);
 		constant_p = false;
 	      }
-
-	    // Initializer is not suitable for static data.
-	    if (!initializer_constant_valid_p(value, TREE_TYPE (value)))
-	      simple_p = false;
 
 	    CONSTRUCTOR_APPEND_ELT (elms, size_int(i),
 				    convert_expr(value, expr->type, etype));
@@ -2488,9 +2483,10 @@ public:
 	      ctor = d_array_value(type, size_int(e->elements->dim), ctor);
 	  }
 
+	// If the array literal is readonly or static.
 	if (constant_p)
 	  TREE_CONSTANT (ctor) = 1;
-	if (constant_p && simple_p)
+	if (constant_p && initializer_constant_valid_p(ctor, TREE_TYPE (ctor)))
 	  TREE_STATIC (ctor) = 1;
 
 	this->result_ = d_convert(type, ctor);
@@ -2665,6 +2661,11 @@ public:
     // Nothing more to do for constant literals.
     if (this->constp_)
       {
+	// If the struct literal is a valid for static data.
+	if (TREE_CONSTANT (ctor)
+	    && initializer_constant_valid_p(ctor, TREE_TYPE (ctor)))
+	  TREE_STATIC (ctor) = 1;
+
 	this->result_ = ctor;
 	return;
       }


### PR DESCRIPTION
@jpf91 - I know your tests included `returnsReal() is returnsReal()`, does ARM really lower real comparisons to:

```
__builtin_memcmp(&real, &real, real.sizeof)
```
