### PR TITLE
Return empty constructor for null to AA conversions.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,9 @@
+2016-05-24  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-codegen.cc (convert_expr): Return empty constructor for null to
+	associative array conversions.
+	* expr.cc (ExprVisitor::visit(NullExp)): Likewise.
+
 2016-05-21  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-codegen.cc (build_struct_literal): Don't set TREE_STATIC.

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -729,9 +729,9 @@ convert_expr(tree exp, Type *etype, Type *totype)
 			       build_nop(ptrtype, exp));
 	}
       else if (tbtype->ty == Taarray)
-	  return build_vconvert(build_ctype(totype), exp);
+	return build_constructor(build_ctype(totype), NULL);
       else if (tbtype->ty == Tdelegate)
-	  return build_delegate_cst(exp, null_pointer_node, totype);
+	return build_delegate_cst(exp, null_pointer_node, totype);
       break;
 
     case Tvector:

--- a/gcc/d/expr.cc
+++ b/gcc/d/expr.cc
@@ -2705,13 +2705,7 @@ public:
 	value = d_array_value(type, size_int(0), null_pointer_node);
       }
     else if (tb->ty == Taarray)
-      {
-	vec<constructor_elt, va_gc> *ce = NULL;
-	tree type = build_ctype(e->type);
-
-	CONSTRUCTOR_APPEND_ELT (ce, TYPE_FIELDS (type), null_pointer_node);
-	value = build_constructor(type, ce);
-      }
+      value = build_constructor(build_ctype(e->type), NULL);
     else if (tb->ty == Tdelegate)
       value = build_delegate_cst(null_pointer_node, null_pointer_node, e->type);
     else


### PR DESCRIPTION
The former codegen was wrong anyway, as it resulted the compiler generating `*(AA*)&null`
