### PR TITLE
Bug 227: Fix spurious warning of function returning address of local variable.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,13 @@
+2016-06-05  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-codegen.cc (d_build_call): Separate parameter to pass from it's
+	construction expression.
+	* expr.cc (build_dtor_list): New function.
+	(get_compound_value): New function.
+	(build_expr_dtor): Update to use helper functions.
+	(build_return_dtor): New function.
+	* toir.cc (IRVisitor::visit(ReturnStatement)): Use it.
+
 2016-06-04  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-codegen.cc (build_deref): Handle ERROR_MARK nodes early.

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -2921,8 +2921,20 @@ d_build_call(TypeFunction *tf, tree callable, tree object, Expressions *argument
 	  // Needed for left to right evaluation.
 	  if (tf->linkage == LINKd && TREE_SIDE_EFFECTS (targ))
 	    {
-	      targ = maybe_make_temp(targ);
-	      saved_args = maybe_vcompound_expr(saved_args, targ);
+	      // Push left side of comma expressions into the saved args
+	      // list, so that only the result is maybe made a temporary.
+	      if (TREE_CODE (targ) == COMPOUND_EXPR)
+		{
+		  tree tleft = TREE_OPERAND (targ, 0);
+		  saved_args = maybe_vcompound_expr(saved_args, tleft);
+		  targ = TREE_OPERAND (targ, 1);
+		}
+
+	      if (TREE_SIDE_EFFECTS (targ))
+		{
+		  targ = maybe_make_temp(targ);
+		  saved_args = maybe_vcompound_expr(saved_args, targ);
+		}
 	    }
 	  arg_list = chainon(arg_list, build_tree_list(0, targ));
 	}

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -28,6 +28,7 @@ class Expression;
 class Module;
 class Statement;
 class Type;
+class TypeFunction;
 class Dsymbol;
 
 // The kinds of scopes we recognise.
@@ -288,6 +289,7 @@ extern tree d_truthvalue_conversion (tree);
 // In d-expr.cc.
 extern tree build_expr (Expression *, bool = false);
 extern tree build_expr_dtor (Expression *);
+extern tree build_return_dtor (Expression *, Type *, TypeFunction *);
 
 // In d-incpath.cc.
 extern void add_import_paths (const char *, const char *, bool);

--- a/gcc/d/toir.cc
+++ b/gcc/d/toir.cc
@@ -621,27 +621,18 @@ public:
     if (this->func_->isMain() && type->toBasetype()->ty == Tvoid)
       type = Type::tint32;
 
-    tree decl = DECL_RESULT (this->func_->toSymbol()->Stree);
-
     if (this->func_->nrvo_can && this->func_->nrvo_var)
       {
-	// Just refer to the DECL_RESULT; this is a nop, but differs
-	// from using NULL_TREE in that it indicates that we care about
-	// the value of the DECL_RESULT.
+	// Just refer to the DECL_RESULT; this differs from using NULL_TREE in
+	// that it indicates that we care about the value of the DECL_RESULT.
+	tree decl = DECL_RESULT (this->func_->toSymbol()->Stree);
 	add_stmt(return_expr(decl));
       }
     else
       {
 	// Convert for initialising the DECL_RESULT.
-	tree value = convert_expr(build_expr_dtor(s->exp),
-				  s->exp->type, type);
-
-	// If we are returning a reference, take the address.
-	if (tf->isref)
-	  value = build_address(value);
-
-	tree assign = build2(INIT_EXPR, TREE_TYPE (decl), decl, value);
-	add_stmt(return_expr(assign));
+	tree expr = build_return_dtor(s->exp, type, tf);
+	add_stmt(expr);
       }
   }
 


### PR DESCRIPTION
- First, this does a small refactor/clean-up of codegen for passing parameters that have been lowered to a COMPOUND_EXPR, spliting the value from the rest of the construction/destruction expression if possible.
- A similar rewrite is done in build_expr, where the following rewrites are done for simple expressions:

```
  cast(T)(e1, e2) => (e1, cast(T)e2)
  &(e1, e2) => (e1, &e2)
  *(e1, e2) => (e1, *e2)
```

Moving the COMPOUND_EXPR up to the top allows us to have more control on when inserting dtors into the expression.

Where before we may have done (a contrived example):

```
  SAVE<tmp = __ctor(), tmp>, __dtor(&tmp), SAVE<tmp = __ctor(), tmp>;
```

Rewriting `&(e1, e2)` into `(e1, &e2)` means we can inspect the right hand side for any side effects, if there are none pressent, then we can bypass saving the comma expression, eliding any artificial temporaries being created by the code generator/optimizer.

```
  tmp = __ctor(), __dtor(&tmp), tmp;
```
- Finally, for fixing bug 227, the code generation for running destructors on return expressions has been separated from normal expressions, because we should be returning the result directly, rather than returning the temporary created to evaluate the expression before calling its destructors.

```
  return &(try
    {
      SAVE<*(SAVE<*(SAVE<&(tmp = __ctor(), tmp)>), {}>,
           __cpctor(this, SAVE<*(SAVE<&(tmp = __ctor(), tmp)>), {}>))>;
    }
  finally
    {
      __dtor(&tmp);
    }, SAVE<*(SAVE<*(SAVE<&(tmp = __ctor(), tmp)>), {}>,
            __cpctor(this, SAVE<*(SAVE<&(tmp = __ctor(), tmp)>), {}>))>);

```

With the first refactor in passing parameters, we remove one layer of temporaries being created in the call to `__cpctor()`.

```
  return &(try
    {
      SAVE<*(*(SAVE<&(tmp = __ctor(), tmp)>), __cpctor(this, {}))>;
    }
  finally
    {
      __dtor(&tmp);
    }, SAVE<*(*(SAVE<&(tmp = __ctor(), tmp)>), __cpctor(this, {}))>);
```

With the second refactor, another layer is removed, as the construction of the temporary is not needed when dereferencing the result of `__cpctor()`.

```
  return &(try
    {
      *(SAVE<&(tmp = __ctor(), tmp)>);, SAVE<*__cpctor(this, {})>;;
    }
  finally
    {
      __dtor(&tmp);
    }, SAVE<*__cpctor(this, {})>;);
```

Finally, moving the return expression into `build_return_dtor`, the return is inserted directory into the try block, removing the bogus temporary that was causing the warning in the first place.

```
  try
    {
      *(SAVE<&(tmp = __ctor(), tmp)>);
      return __cpctor(this, {});
    }
  finally
    {
      __dtor(&tmp);
    }
```
