### PR TITLE
Move logic of fill_alignment_holes into build_struct_literal.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,12 @@
+2016-06-07  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-codegen.cc (build_alignment_field): New function.
+	(build_struct_literal): Update signature, updated all callers.
+	Add anonymous fields to fill alignment holes in constructor.
+	(fill_alignment_field): Remove function.
+	(fill_alignment_holes): Remove function.
+	(finish_aggregate_type): Don't add anonymous fields.
+
 2016-06-05  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-codegen.cc (d_build_call): Separate parameter to pass from it's

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -2027,21 +2027,48 @@ build_array_struct_comparison(tree_code code, StructDeclaration *sd,
   return compound_expr(body, result);
 }
 
+// Create an anonymous field of type ubyte[T] at OFFSET to fill
+// the alignment hole between OFFSET and FIELDPOS.
+
+static tree
+build_alignment_field(HOST_WIDE_INT offset, HOST_WIDE_INT fieldpos)
+{
+  tree type = d_array_type(Type::tuns8, fieldpos - offset);
+  tree field = build_decl(UNKNOWN_LOCATION, FIELD_DECL, NULL_TREE, type);
+
+  SET_DECL_OFFSET_ALIGN (field, TYPE_ALIGN (type));
+  DECL_FIELD_OFFSET (field) = size_int(offset);
+  DECL_FIELD_BIT_OFFSET (field) = bitsize_zero_node;
+
+  layout_decl(field, 0);
+
+  DECL_ARTIFICIAL (field) = 1;
+  DECL_IGNORED_P (field) = 1;
+
+  return field;
+}
+
 // Build a constructor for a variable of aggregate type TYPE using the
 // initializer INIT, an ordered flat list of fields and values provided
 // by the frontend.
 // The returned constructor should be a value that matches the layout of TYPE.
 
 tree
-build_struct_literal(tree type, tree init)
+build_struct_literal(tree type, vec<constructor_elt, va_gc> *init)
 {
   // If the initializer was empty, use default zero initialization.
-  if (vec_safe_is_empty(CONSTRUCTOR_ELTS (init)))
+  if (vec_safe_is_empty(init))
     return build_constructor(type, NULL);
 
   vec<constructor_elt, va_gc> *ve = NULL;
   HOST_WIDE_INT offset = 0;
   bool constant_p = true;
+  bool fillholes = true;
+
+  // Filling alignment holes this only applies to structs.
+  if (TREE_CODE (type) != RECORD_TYPE
+      || CLASS_TYPE_P (type) || TYPE_PACKED (type))
+    fillholes = false;
 
   // Walk through each field, matching our initializer list
   for (tree field = TYPE_FIELDS (type); field; field = DECL_CHAIN (field))
@@ -2064,16 +2091,16 @@ build_struct_literal(tree type, tree init)
 	}
       else
 	{
+	  // Search for the value to initialize the next field.  Once found,
+	  // pop it from the init list so we don't look at it again.
 	  unsigned HOST_WIDE_INT idx;
 	  tree index;
 
-	  // Search for the value to initialize the next field.  Once found,
-	  // pop it from the init list so we don't look at it again.
-	  FOR_EACH_CONSTRUCTOR_ELT (CONSTRUCTOR_ELTS (init), idx, index, value)
+	  FOR_EACH_CONSTRUCTOR_ELT (init, idx, index, value)
 	    {
 	      if (index == field)
 		{
-		  CONSTRUCTOR_ELTS (init)->ordered_remove(idx);
+		  init->ordered_remove(idx);
 		  is_initialized = true;
 		  break;
 		}
@@ -2085,10 +2112,17 @@ build_struct_literal(tree type, tree init)
 	  HOST_WIDE_INT fieldpos = int_byte_position(field);
 	  gcc_assert(value != NULL_TREE);
 
+	  // Insert anonymous fields in the constructor for padding out
+	  // alignment holes in-place between fields.
+	  if (fillholes && offset < fieldpos)
+	    {
+	      tree pfield = build_alignment_field(offset, fieldpos);
+	      tree pvalue = build_constructor(TREE_TYPE (pfield), NULL);
+	      CONSTRUCTOR_APPEND_ELT (ve, pfield, pvalue);
+	    }
+
 	  // Must not initialize fields that overlap.
-	  if (fieldpos >= offset)
-	    offset = fieldpos;
-	  else
+	  if (fieldpos < offset)
 	    {
 	      // Find the nearest user defined type and field.
 	      tree vtype = type;
@@ -2104,22 +2138,33 @@ build_struct_literal(tree type, tree init)
 	      gcc_assert(TYPE_NAME (vtype) && DECL_NAME (vfield));
 	      error("overlapping initializer for field %qT.%qD",
 		    TYPE_NAME (vtype), DECL_NAME (vfield));
-	      continue;
 	    }
 
 	  if (!TREE_CONSTANT (value))
 	    constant_p = false;
 
 	  CONSTRUCTOR_APPEND_ELT (ve, field, value);
-	  // If all initializers have been assigned, there's nothing else to do.
-	  if (vec_safe_is_empty(CONSTRUCTOR_ELTS (init)))
-	    break;
 	}
+
+      // Move offset to the next position in the struct.
+      if (TREE_CODE (type) == RECORD_TYPE)
+	offset = int_byte_position(field) + int_size_in_bytes(TREE_TYPE (field));
+
+      // If all initializers have been assigned, there's nothing else to do.
+      if (vec_safe_is_empty(init))
+	break;
+    }
+
+  // Finally pad out the end of the record.
+  if (fillholes && offset < int_size_in_bytes(type))
+    {
+      tree pfield = build_alignment_field(offset, int_size_in_bytes(type));
+      tree pvalue = build_constructor(TREE_TYPE (pfield), NULL);
+      CONSTRUCTOR_APPEND_ELT (ve, pfield, pvalue);
     }
 
   // Ensure that we have consumed all values.
-  gcc_assert(vec_safe_is_empty(CONSTRUCTOR_ELTS (init))
-	     || ANON_AGGR_TYPE_P (type));
+  gcc_assert(vec_safe_is_empty(init) || ANON_AGGR_TYPE_P (type));
 
   tree ctor = build_constructor(type, ve);
 
@@ -4567,71 +4612,6 @@ insert_aggregate_field(const Loc& loc, tree type, tree field, size_t offset)
   TYPE_FIELDS (type) = chainon(TYPE_FIELDS (type), field);
 }
 
-// Create an anonymous field of type ubyte[SIZE] at OFFSET.
-// CONTEXT is the record type where the field will be inserted.
-
-static tree
-fill_alignment_field(tree context, tree size, tree offset)
-{
-  tree type = d_array_type(Type::tuns8, tree_to_uhwi(size));
-  tree field = build_decl(UNKNOWN_LOCATION, FIELD_DECL, NULL_TREE, type);
-
-  // As per insert_aggregate_field.
-  DECL_FIELD_CONTEXT (field) = context;
-  SET_DECL_OFFSET_ALIGN (field, TYPE_ALIGN (TREE_TYPE (field)));
-  DECL_FIELD_OFFSET (field) = offset;
-  DECL_FIELD_BIT_OFFSET (field) = bitsize_zero_node;
-
-  layout_decl(field, 0);
-
-  DECL_ARTIFICIAL (field) = 1;
-  DECL_IGNORED_P (field) = 1;
-
-  return field;
-}
-
-// Insert anonymous fields in the record TYPE for padding out alignment holes.
-
-static void
-fill_alignment_holes(tree type)
-{
-  // Filling alignment holes this way only applies for structs.
-  if (TREE_CODE (type) != RECORD_TYPE
-      || CLASS_TYPE_P (type) || TYPE_PACKED (type))
-    return;
-
-  tree offset = size_zero_node;
-  tree prev = NULL_TREE;
-
-  for (tree field = TYPE_FIELDS (type); field; field = DECL_CHAIN (field))
-    {
-      tree voffset = DECL_FIELD_OFFSET (field);
-      tree vsize = TYPE_SIZE_UNIT (TREE_TYPE (field));
-
-      // If there is an alignment hole, pad with a static array of type ubyte[].
-      if (prev != NULL_TREE && tree_int_cst_lt(offset, voffset))
-	{
-	  tree psize = size_binop(MINUS_EXPR, voffset, offset);
-	  tree pfield = fill_alignment_field(type, psize, offset);
-
-	  // Insert before the current field position.
-	  DECL_CHAIN (pfield) = DECL_CHAIN (prev);
-	  DECL_CHAIN (prev) = pfield;
-	}
-
-      prev = field;
-      offset = size_binop(PLUS_EXPR, voffset, vsize);
-    }
-
-  // Finally pad out the end of the record.
-  if (tree_int_cst_lt(offset, TYPE_SIZE_UNIT (type)))
-    {
-      tree psize = size_binop(MINUS_EXPR, TYPE_SIZE_UNIT (type), offset);
-      tree pfield = fill_alignment_field(type, psize, offset);
-      TYPE_FIELDS (type) = chainon(TYPE_FIELDS (type), pfield);
-    }
-}
-
 // Wrap-up and compute finalised aggregate type.
 
 void
@@ -4653,9 +4633,6 @@ finish_aggregate_type(unsigned structsize, unsigned alignsize, tree type,
   TYPE_SIZE_UNIT (type) = size_int(structsize);
   SET_TYPE_ALIGN (type, alignsize * BITS_PER_UNIT);
   TYPE_PACKED (type) = (alignsize == 1);
-
-  // Add padding to fill in any alignment holes.
-  fill_alignment_holes(type);
 
   // Set the backend type mode.
   compute_record_mode(type);

--- a/gcc/d/d-codegen.h
+++ b/gcc/d/d-codegen.h
@@ -61,7 +61,7 @@ extern tree build_address (tree exp);
 extern bool identity_compare_p(StructDeclaration *sd);
 extern tree build_struct_comparison(tree_code code, StructDeclaration *sd, tree t1, tree t2);
 extern tree build_array_struct_comparison(tree_code code, StructDeclaration *sd, tree length, tree t1, tree t2);
-extern tree build_struct_literal(tree type, tree init);
+extern tree build_struct_literal(tree type, vec<constructor_elt, va_gc> *init);
 
 // Routines to handle variables that are references.
 extern bool declaration_reference_p (Declaration *decl);

--- a/gcc/d/expr.cc
+++ b/gcc/d/expr.cc
@@ -2655,8 +2655,7 @@ public:
       }
 
     // Build a constructor in the correct shape of the aggregate type.
-    tree ctor = build_struct_literal(build_ctype(e->type),
-				     build_constructor(unknown_type_node, ve));
+    tree ctor = build_struct_literal(build_ctype(e->type), ve);
 
     // Nothing more to do for constant literals.
     if (this->constp_)
@@ -2677,7 +2676,7 @@ public:
       }
     else if (e->sd->isUnionDeclaration())
       {
-	// Initialize all alignment 'holes' to zero.
+	// For unions, use memset to fill holes in the object.
 	tree var = build_local_temp(TREE_TYPE (ctor));
 	tree init = d_build_call_nary(builtin_decl_explicit(BUILT_IN_MEMSET), 3,
 				      build_address(var), size_zero_node,


### PR DESCRIPTION
This is because inserting anonymous fields into the type can change the ABI of it.

This fixes the C++ ABI test in the testsuite.
