### PR TITLE
Bug 228: First pass at reducing the number of temporaries created.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,15 @@
+2016-06-09  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-codegen.cc (build_address): Handle ERROR_MARK and COMPOUND_EXPR.
+	(build_nop): Likewise.
+	(indirect_ref): Likewise.
+	(build_deref): Likewise.
+	(d_build_call): Only create temporaries if more than one argument has
+	side effects.
+	* expr.cc (get_compound_value): Remove function.
+	(build_expr_dtor): Wrap cleanups in a TRY_FINALLY_EXPR only if the
+	expression has side effects.
+
 2016-06-08  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* Make-lang.in (D_GLUE_OBJS): Remove d-typinf.o, add typeinfo.o.


### PR DESCRIPTION
Improves upon #217 by removing the get_compound_value pass and moving the generation directly into the expression builders.

The compiler now only wraps cleanups in a try/finally if the result has side effects.

Also omproves d_build_call by only creating temporaries if more than argument needs saving.

@jpf91 - This should be enough to fix the regression in 4.8 branch.  But there may be new regressions created as a result, let's find out... :smile:
