### PR TITLE
Return the NRVO variable by reference

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,28 @@
 2016-06-19  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-codegen.cc (get_decl_tree): Remove assert for RESULT_DECL.
+	(convert_for_argument): Handle lazy arguments early.
+	(argument_reference_p): Handle types marked TREE_ADDRESSABLE.
+	(lvalue_p): Add case for TARGET_EXPR.
+	(d_mark_addressable): Likewise.
+	(build_assign): Likewise.
+	(compound_expr): Likewise.
+	(build_target_expr): New function.
+	(d_build_call): Always set CALL_EXPR_RETURN_SLOT_OPT for all calls
+	that return an aggregate in memory.
+	* d-decls.cc (VarDeclaration::toSymbol): Handle reference parameters.
+	* d-lang.cc (d_gimplify_expr): Handle taking address of constructor.
+	* d-objfile.cc (FuncDeclaration::toObjFile): Handle reference return.
+	* expr.cc (ExprVisitor::visit(AssignExp)): Mark LHS as addressable if
+	RHS assignment is a returned aggregate.
+	* types.cc (TypeVisitor::visit(TypeStruct)): Mark the RECORD_TYPE of
+	non-trivial structs as TREE_ADDRESSABLE.
+	(TypeVisitor::visit(TypeClass)): Mark all classes as TREE_ADDRESSABLE.
+	(TypeVisitor::visit(TypeFunction)): Don't set TREE_ADDRESSABLE.
+	(TypeVisitor::visit(TypeDelegate)): Likewise.
+
+2016-06-19  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* d-codegen.cc (lvalue_p): Add more cases to look for.
 	(build_address): Mark expression as addressable after stabilizing.
 	(d_mark_addressable): Remove special cases.

--- a/gcc/d/d-codegen.h
+++ b/gcc/d/d-codegen.h
@@ -160,6 +160,7 @@ extern tree get_decl_tree(Declaration *decl);
 // Temporaries (currently just SAVE_EXPRs)
 extern tree d_save_expr (tree t);
 extern tree stabilize_expr (tree *valuep);
+extern tree build_target_expr (tree exp);
 
 // Array operations
 extern tree build_bounds_condition(const Loc& loc, tree index, tree upr, bool inclusive);

--- a/gcc/d/d-decls.cc
+++ b/gcc/d/d-decls.cc
@@ -145,6 +145,19 @@ VarDeclaration::toSymbol()
 
       if (isParameter())
 	{
+	  // Pass non-trivial structs by invisible reference.
+	  if (TREE_ADDRESSABLE (TREE_TYPE (decl)))
+	    {
+	      tree argtype = build_reference_type(TREE_TYPE (decl));
+	      argtype = build_qualified_type(argtype, TYPE_QUAL_RESTRICT);
+	      gcc_assert (!DECL_BY_REFERENCE (decl));
+	      TREE_TYPE (decl) = argtype;
+	      DECL_BY_REFERENCE (decl) = 1;
+	      TREE_ADDRESSABLE (decl) = 0;
+	      relayout_decl (decl);
+	      this->storage_class |= STCref;
+	    }
+
 	  DECL_ARG_TYPE (decl) = TREE_TYPE (decl);
 	  gcc_assert (TREE_CODE (DECL_CONTEXT (decl)) == FUNCTION_DECL);
 	}

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -721,6 +721,16 @@ d_gimplify_expr(tree *expr_p, gimple_seq *pre_p ATTRIBUTE_UNUSED,
 	}
       break;
 
+    case ADDR_EXPR:
+      op0 = TREE_OPERAND (*expr_p, 0);
+      // Constructors are not lvalues, so make them one.
+      if (TREE_CODE (op0) == CONSTRUCTOR)
+	{
+	  TREE_OPERAND (*expr_p, 0) = build_target_expr(op0);
+	  ret = GS_OK;
+	}
+      break;
+
     case UNSIGNED_RSHIFT_EXPR:
       // Convert op0 to an unsigned type.
       op0 = TREE_OPERAND (*expr_p, 0);

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -1305,10 +1305,10 @@ FuncDeclaration::toObjFile()
   if (v_argptr)
     push_stmt_list();
 
-  /* The fabled D named return value optimisation.
-     Implemented by overriding all the RETURN_EXPRs and replacing all
-     occurrences of VAR with the RESULT_DECL for the function.
-     This is only worth doing for functions that can return in memory.  */
+  // The fabled D named return value optimisation.
+  // Implemented by overriding all the RETURN_EXPRs and replacing all
+  // occurrences of VAR with the RESULT_DECL for the function.
+  // This is only worth doing for functions that can return in memory.
   if (nrvo_can)
     {
       if (!AGGREGATE_TYPE_P (return_type))
@@ -1325,9 +1325,14 @@ FuncDeclaration::toObjFile()
       // Copy name from VAR to RESULT.
       DECL_NAME (result_decl) = DECL_NAME (var);
       // Don't forget that we take it's address.
-      TREE_ADDRESSABLE (TREE_TYPE (fndecl)) = 1;
       TREE_ADDRESSABLE (var) = 1;
-      TREE_ADDRESSABLE (result_decl) = 1;
+
+      TREE_TYPE (result_decl) = build_reference_type(TREE_TYPE (result_decl));
+      DECL_BY_REFERENCE (result_decl) = 1;
+      TREE_ADDRESSABLE (result_decl) = 0;
+      relayout_decl(result_decl);
+
+      result_decl = build_deref(result_decl);
 
       SET_DECL_VALUE_EXPR (var, result_decl);
       DECL_HAS_VALUE_EXPR_P (var) = 1;

--- a/gcc/d/expr.cc
+++ b/gcc/d/expr.cc
@@ -992,9 +992,8 @@ public:
 	tree t2 = convert_for_assignment(build_expr(e->e2),
 					 e->e2->type, e->e1->type);
 
-	if (e->op == TOKconstruct && TREE_CODE (t2) == CALL_EXPR
-	    && aggregate_value_p(TREE_TYPE (t2), t2))
-	  CALL_EXPR_RETURN_SLOT_OPT (t2) = true;
+	if (e->op == TOKconstruct && e->e2->op == TOKcall)
+	  d_mark_addressable(t1);
 
 	if (e->e2->op == TOKint64)
 	  {
@@ -1048,9 +1047,8 @@ public:
 	    tree t2 = convert_for_assignment(build_expr(e->e2),
 					     e->e2->type, e->e1->type);
 
-	    if (e->op == TOKconstruct && TREE_CODE (t2) == CALL_EXPR
-		&& aggregate_value_p(TREE_TYPE (t2), t2))
-	      CALL_EXPR_RETURN_SLOT_OPT (t2) = true;
+	    if (e->op == TOKconstruct && e->e2->op == TOKcall)
+	      d_mark_addressable(t1);
 
 	    this->result_ = build_assign(modifycode, t1, t2);
 	  }
@@ -1613,7 +1611,7 @@ public:
 		tree thisexp = build_expr(dve->e1);
 
 		// Want reference to 'this' object.
-		if (dve->e1->type->ty != Tclass && dve->e1->type->ty != Tpointer)
+		if (!POINTER_TYPE_P (TREE_TYPE (thisexp)))
 		  thisexp = build_address(thisexp);
 
 		// Make the callee a virtual call.

--- a/gcc/d/types.cc
+++ b/gcc/d/types.cc
@@ -274,6 +274,14 @@ public:
 
     TYPE_CONTEXT (t->ctype) = d_decl_context(t->sym);
     build_type_decl(t->ctype, t->sym);
+
+    // For struct with a copy constructor or a destructor, also set
+    // TREE_ADDRESSABLE.  This will cause it to be passed by reference.
+    if (t->sym->postblit || t->sym->dtor)
+      {
+	for (tree tv = t->ctype; tv != NULL_TREE; tv = TYPE_NEXT_VARIANT (tv))
+	  TREE_ADDRESSABLE (tv) = 1;
+      }
   }
 
   //
@@ -317,24 +325,6 @@ public:
     t->ctype = build_function_type(ret_type, type_list);
     TYPE_LANG_SPECIFIC (t->ctype) = build_lang_type(t);
     d_keep(t->ctype);
-
-    if (t->next && !t->isref)
-      {
-	Type *tn = t->next->baseElemOf();
-	if (tn->ty == Tstruct)
-	  {
-	    // Non-POD structs must return in memory.
-	    TypeStruct *ts = (TypeStruct *) tn->toBasetype();
-	    if (!ts->sym->isPOD())
-	      TREE_ADDRESSABLE (t->ctype) = 1;
-	  }
-
-	// Aggregate types that don't return in registers are eligable for
-	// returning via slot optimisation.
-	if (AGGREGATE_TYPE_P (TREE_TYPE (t->ctype))
-	    && aggregate_value_p(TREE_TYPE (t->ctype), t->ctype))
-	  TREE_ADDRESSABLE (t->ctype) = 1;
-      }
 
     switch (t->linkage)
       {
@@ -441,7 +431,6 @@ public:
 
     TYPE_ATTRIBUTES (funtype) = TYPE_ATTRIBUTES (nexttype);
     TYPE_LANG_SPECIFIC (funtype) = TYPE_LANG_SPECIFIC (nexttype);
-    TREE_ADDRESSABLE (funtype) = TREE_ADDRESSABLE (nexttype);
 
     t->ctype = build_two_field_type(objtype, build_pointer_type(funtype),
 				    t, "object", "func");
@@ -466,6 +455,10 @@ public:
     // Add the fields of each base class
     layout_aggregate_type(t->sym, basetype, t->sym);
     finish_aggregate_type(t->sym->structsize, t->sym->alignsize, basetype, t->sym->userAttribDecl);
+
+    // Set the TREE_ADDRESSABLE bit, as classes always live in memory.
+    for (tree tv = basetype; tv != NULL_TREE; tv = TYPE_NEXT_VARIANT (tv))
+      TREE_ADDRESSABLE (tv) = 1;
 
     // Type is final, there are no derivations.
     if (t->sym->storage_class & STCfinal)


### PR DESCRIPTION
This should fix the broken builds after updating to latest GCC snapshot.  The test in sdtor has always been flaky because of this anyway.  With this the compiler should now consistently generate the same code regardless of optimization level.
