### PR TITLE
Bug 228: Second pass at reducing the number of temporaries created.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,22 @@
+2016-06-15  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-codegen.cc (add_stmt): Don't add statements without side effects.
+	Push each COMPOUND_EXPR as a separate statement.
+	(build_local_temp): Use input_location.
+	(create_temporary_var): Likewise.
+	(d_has_side_effects): Remove function.
+	Updated all callers to use TREE_SIDE_EFFECTS.
+	(stabilize_expr): New function.
+	Updated all routines that check for COMPOUND_EXPR to use it.
+	* expr.cc (ExprVisitor::visit(EqualExp)): Use maybe_make_temp to save
+	expressions.  Use build_boolop for constructed conditions.
+	(ExprVisitor::visit(CatAssignExp)): Stabilize RHS before assignment.
+	(ExprVisitor::visit(NewExp)): Don't always create SAVE_EXPR.
+	(ExprVisitor::visit(AssocArrayLiteralExp)): Likewise.
+	(ExprVisitor::visit(ArrayLiteralExp)): Evaluate elements before
+	appending to constructor fields.
+	(ExprVisitor::visit(StructLiteralExp)): Likewise.
+
 2016-06-12  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-convert.cc (d_build_truthvalue_op): Fold truthvalue operation.

--- a/gcc/d/d-codegen.h
+++ b/gcc/d/d-codegen.h
@@ -163,7 +163,7 @@ extern tree get_decl_tree(Declaration *decl);
 // Temporaries (currently just SAVE_EXPRs)
 extern tree make_temp (tree t);
 extern tree maybe_make_temp (tree t);
-extern bool d_has_side_effects (tree t);
+extern tree stabilize_expr (tree *valuep);
 
 // Array operations
 extern tree build_bounds_condition(const Loc& loc, tree index, tree upr, bool inclusive);


### PR DESCRIPTION
Improves upon #219 by refactoring the checks for `COMPOUND_EXPR` into a routine that recursively iterates all expressions, splitting the result from the rest of the expression.

There are a few more cases that are caught too, including component references, and when generating constructors for array and struct literals, both when using `new()` and without.

The compiler also now extracts the temporary object from constructor expressions in `build_expr_dtor()`, which elides a temporary of the call result being made.

Finally, `add_stmt()` both now recursively adds `COMPOUND_EXPR` expressions as separate statements, and checks for side effects in all statements to be written.  This removes a lot of noise from common rewrites where `((e1, e2), e3)` is generated, but only the first and last expression actually do anything.
