### PR TITLE
Add switches for DIP25 and to limit max error messages

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,9 @@
+2016-06-20  Johannes Pfau  <johannespfau@gmail.com>
+
+	* d-lang.cc (d_handle_option): Add new -ftransition=dip25 and
+	-fmax-error-messages switches.
+	* lang.opt: Likewise.
+
 2016-06-19  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-codegen.cc (get_decl_tree): Remove assert for RESULT_DECL.

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -514,6 +514,10 @@ d_handle_option (size_t scode, const char *arg, int value,
       global.params.vtls = value;
       break;
 
+    case OPT_ftransition_dip25:
+      global.params.useDIP25 = value;
+      break;
+
     case OPT_funittest:
       global.params.useUnitTests = value;
       break;
@@ -580,6 +584,16 @@ d_handle_option (size_t scode, const char *arg, int value,
       if (value)
 	global.params.warnings = 1;
       break;
+
+    case OPT_fmax_error_messages_:
+      {
+	int limit = integral_argument(arg);
+	if (limit == -1)
+	  error ("bad argument for -fmax-error-messages '%s'", arg);
+	else
+	  global.errorLimit = limit;
+	break;
+      }
 
     default:
       break;

--- a/gcc/d/lang.opt
+++ b/gcc/d/lang.opt
@@ -189,6 +189,10 @@ ftransition=tls
 D RejectNegative
 List all variables going into thread local storage.
 
+ftransition=dip25
+D RejectNegative
+Implement http://wiki.dlang.org/DIP25 (experimental)
+
 funittest
 D
 Compile in unittest code.
@@ -261,3 +265,6 @@ Wunknown-pragmas
 D
 ; Documented in C
 
+fmax-error-messages=
+D Joined RejectNegative
+Limit the number of error messages (0 means unlimited)


### PR DESCRIPTION
When updating GDMD for the `2.068` frontend I noticed we don't have equivalents for the `-dip25` and `-verror=` switches. Implemented as `-ftransition=dip25` and `-fmax-error-messages=`. I'll of course change the names if there are better suggestions. Ping @ibuclaw 
