### PR TITLE
Bug 228: Third pass at reducing number of temporaries created.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,14 @@
+2016-06-19  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-codegen.cc (lvalue_p): Add more cases to look for.
+	(build_address): Mark expression as addressable after stabilizing.
+	(d_mark_addressable): Remove special cases.
+	(d_mark_used): Add cases for other kinds of DECLs.
+	(build_struct_comparison): Stabilize before saving.
+	(modify_expr): Remove overload.  Updated all callers.
+	(build_vinit): Remove function.  Updated all callers to use ...
+	(build_init_expr): ... New function.
+
 2016-06-16  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-codegen.cc (make_temp): Rename to d_save_expr.

--- a/gcc/d/d-codegen.h
+++ b/gcc/d/d-codegen.h
@@ -216,9 +216,8 @@ build_object_type()
 
 // Common codegen helpers.
 extern tree component_ref(tree obj, tree field);
-extern tree modify_expr(tree dst, tree src);
-extern tree modify_expr(tree type, tree dst, tree src);
-extern tree build_vinit(tree dst, tree src);
+extern tree modify_expr(tree lhs, tree rhs);
+extern tree build_init_expr(tree lhs, tree rhs);
 
 extern tree build_nop(tree t, tree e);
 extern tree build_vconvert(tree t, tree e);

--- a/gcc/d/expr.cc
+++ b/gcc/d/expr.cc
@@ -824,7 +824,7 @@ public:
 	    tree expr = stabilize_expr(&t2);
 
 	    t2 = d_save_expr(t2);
-	    result = modify_expr(build_ctype(etype), build_deref(ptrexp), t2);
+	    result = modify_expr(build_deref(ptrexp), t2);
 	    result = compound_expr(t2, result);
 
 	    this->result_ = compound_expr(expr, result);
@@ -1018,7 +1018,7 @@ public:
 	    this->result_ = compound_expr(result, t1);
 	  }
 	else
-	  this->result_ = modify_expr(build_ctype(e->type), t1, t2);
+	  this->result_ = modify_expr(t1, t2);
 
 	return;
       }
@@ -1051,7 +1051,7 @@ public:
 		&& aggregate_value_p(TREE_TYPE (t2), t2))
 	      CALL_EXPR_RETURN_SLOT_OPT (t2) = true;
 
-	    this->result_ = modify_expr(build_ctype(e->type), t1, t2);
+	    this->result_ = modify_expr(t1, t2);
 	  }
 	else if (e->op == TOKconstruct)
 	  {
@@ -1090,7 +1090,7 @@ public:
     tree t2 = convert_for_assignment(build_expr(e->e2),
 				     e->e2->type, e->e1->type);
 
-    this->result_ = modify_expr(build_ctype(e->type), t1, t2);
+    this->result_ = modify_expr(t1, t2);
   }
 
   //
@@ -2950,7 +2950,7 @@ build_return_dtor(Expression *e, Type *type, TypeFunction *tf)
 
   // Split comma expressions, so that the result is returned directly.
   tree expr = stabilize_expr(&result);
-  result = build2(INIT_EXPR, TREE_TYPE (decl), decl, result);
+  result = build_init_expr(decl, result);
   result = compound_expr(expr, return_expr(result));
 
   // Nest the return expression inside the try/finally expression.

--- a/gcc/d/toir.cc
+++ b/gcc/d/toir.cc
@@ -795,7 +795,7 @@ public:
 		object = build_nop(build_ctype(vcatch->type), object);
 
 		tree var = vcatch->var->toSymbol()->Stree;
-		tree init = build_vinit(var, object);
+		tree init = build_init_expr(var, object);
 
 		build_local_var(vcatch->var);
 		add_stmt(init);


### PR DESCRIPTION
Improves some more upon #221 by improving `lvalue_p` to handle more expressions, added case in `stabilize_expr` for assignment expressions, and fixed `build_comparison_expr` to stabilize aggregates before creating temporaries.  I don't think there is much more that can be done for the time being.

There is a small refactor in `modify_expr` and `build_vinit` so that all assignments go through a common path.  This is needed for #220 which will use them later...
