### PR TITLE
Do not set =void initialized fields in constructor

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,24 @@
+2016-07-05  Johannes Pfau  <johannespfau@gmail.com>
+
+	* d-codegen.cc (build_alignment_field): Set DECL_CONTEXT.
+	(build_zero_constructor): New function.
+	(build_struct_literal): Do not clear =void initialized fields.
+	* expr.cc (ExprVisitor::visit(StructLiteralExp)): Likewise.
+	* d-codegen.cc (convert_expr): Explicitly zero initialize using
+	build_zero_constructor.
+	(convert_for_assignment): Likewise.
+	(build_struct_literal): Likewise.
+	(d_build_call): Likewise.
+	(d_build_call): Likewise.
+	* d-todt.cc (dt_zeropad): Likewise.
+	(dt_container2): Likewise.
+	(VoidInitializer::toDt): Likewise.
+	* expr.cc (ExprVisitor::visit(ArrayLiteralExp)): Likewise.
+	(ExprVisitor::visit(AssocArrayLiteralExp)): Likewise.
+	(ExprVisitor::visit(StructLiteralExp)): Likewise.
+	* (ExprVisitor::visit(ArrayLiteralExp)): Handle zero intialized array
+	in frontend.
+
 2016-07-02  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-objfile.cc (FuncDeclaration::toObjFile): Always convert the

--- a/gcc/d/d-codegen.h
+++ b/gcc/d/d-codegen.h
@@ -62,6 +62,7 @@ extern bool identity_compare_p(StructDeclaration *sd);
 extern tree build_struct_comparison(tree_code code, StructDeclaration *sd, tree t1, tree t2);
 extern tree build_array_struct_comparison(tree_code code, StructDeclaration *sd, tree length, tree t1, tree t2);
 extern tree build_struct_literal(tree type, vec<constructor_elt, va_gc> *init);
+extern tree build_zero_constructor(tree type);
 
 // Routines to handle variables that are references.
 extern bool declaration_reference_p (Declaration *decl);

--- a/gcc/d/d-todt.cc
+++ b/gcc/d/d-todt.cc
@@ -77,7 +77,7 @@ dt_zeropad(dt_t **pdt, size_t size)
 {
   tree type = d_array_type(Type::tuns8, size);
   gcc_assert(size != 0);
-  return dt_cons(pdt, build_constructor(type, NULL));
+  return dt_cons(pdt, build_zero_constructor(type));
 }
 
 // It is necessary to give static array data its original
@@ -125,7 +125,7 @@ dt_container2(dt_t *dt)
 	}
     }
   else
-    dt = build_constructor(aggtype, NULL);
+    dt = build_zero_constructor(aggtype);
 
   TYPE_FIELDS(aggtype) = fields;
   TYPE_SIZE(aggtype) = size_binop(MULT_EXPR, offset, size_int(BITS_PER_UNIT));
@@ -239,7 +239,7 @@ VoidInitializer::toDt()
   // void initialisers are set to 0, just because we need something
   // to set them to in the static data segment.
   tree dt = NULL_TREE;
-  dt_cons (&dt, build_constructor (build_ctype(type), NULL));
+  dt_cons (&dt, build_zero_constructor (build_ctype(type)));
   return dt;
 }
 


### PR DESCRIPTION
Step 1 for https://issues.dlang.org/show_bug.cgi?id=15951

``` d
struct Foo
{
    size_t a = void;
    size_t b = 42;
    size_t c = 42;
}

auto foo()
{
    Foo res = {b: 2};
    return res;
}
```

before:

``` asm
_D4test3fooFNaNbNiNfZS4test3Foo:
    movq    %rdi, %rax
    movq    $0, (%rdi)
    movq    $2, 8(%rdi)
    movq    $42, 16(%rdi)
    ret
```

after:

``` asm
_D4test3fooFNaNbNiNfZS4test3Foo:
    movq    %rdi, %rax
    movq    $2, 8(%rdi)
    movq    $42, 16(%rdi)
    ret
```
