### PR TITLE
Small codegen improvement for in/out contracts

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2016-07-11  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-codegen.cc (get_frameinfo): Use hasNestedFrameRefs to determine
+	whether a frame should be created.
+
 2016-07-02  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-objfile.cc (FuncDeclaration::toObjFile): Always convert the

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -4333,14 +4333,10 @@ get_frameinfo(FuncDeclaration *fd)
 
   // Nested functions, or functions with nested refs must create
   // a static frame for local variables to be referenced from.
-  if (fd->closureVars.dim != 0)
+  if (fd->hasNestedFrameRefs())
     ffi->creates_frame = true;
 
   if (fd->vthis && fd->vthis->type == Type::tvoidptr)
-    ffi->creates_frame = true;
-
-  // Functions with In/Out contracts pass parameters to nested frame.
-  if (fd->fensure || fd->frequire)
     ffi->creates_frame = true;
 
   // D2 maybe setup closure instead.


### PR DESCRIPTION
We were creating a stack frame even though the contract body was inlined by the frontend.
