### PR TITLE
Remove toDt from Type class

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,12 @@
 2016-09-11  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-todt.cc (Type::toDt): Remove function, inline into callers.
+	(TypeVector::toDt): Likewise.
+	(TypeSArray::toDt): Likewise.
+	(TypeStruct::toDt): Likewise.
+
+2016-09-11  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* d-decls.cc (FuncDeclaration::toSymbol): Save current module decl
 	before calling function semantic.
 	* d-objfile.cc (FuncDeclaration::toObjFile): Likewise.

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -875,7 +875,15 @@ VarDeclaration::toObjFile()
 	    s->Sdt = init->toDt();
 	}
       else
-	type->toDt(&s->Sdt);
+	{
+	  if (type->ty == Tstruct)
+	    ((TypeStruct *) type)->sym->toDt(&s->Sdt);
+	  else
+	    {
+	      Expression *e = type->defaultInitLiteral(loc);
+	      dt_cons(&s->Sdt, build_expr(e, true));
+	    }
+	}
 
       // Frontend should have already caught this.
       gcc_assert (sz || type->toBasetype()->ty == Tsarray);

--- a/gcc/d/dfrontend/mtype.h
+++ b/gcc/d/dfrontend/mtype.h
@@ -347,9 +347,6 @@ public:
     // For eliminating dynamic_cast
     virtual TypeBasic *isTypeBasic();
     virtual void accept(Visitor *v) { v->visit(this); }
-#ifdef IN_GCC
-    virtual dt_t **toDt(dt_t **pdt);
-#endif
 };
 
 class TypeError : public Type
@@ -444,9 +441,6 @@ public:
     bool isZeroInit(Loc loc);
 
     void accept(Visitor *v) { v->visit(this); }
-#ifdef IN_GCC
-    dt_t **toDt(dt_t **pdt);
-#endif
 };
 
 class TypeArray : public TypeNext
@@ -485,7 +479,6 @@ public:
 
     void accept(Visitor *v) { v->visit(this); }
 #ifdef IN_GCC
-    dt_t **toDt(dt_t **pdt);
     dt_t **toDtElem(dt_t **pdt, Expression *e);
 #endif
 };
@@ -796,9 +789,6 @@ public:
     Type *toHeadMutable();
 
     void accept(Visitor *v) { v->visit(this); }
-#ifdef IN_GCC
-    dt_t **toDt(dt_t **pdt);
-#endif
 };
 
 class TypeEnum : public Type


### PR DESCRIPTION
For now just inline implementation into callers.  Later this will be gone anyway, either folded into `ExprVisitor` or rewritten without the `dt_xxx` routines.
