### PR TITLE
Remove old implementation for ArrayInitializer::toDt

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,9 @@
+2016-09-17  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-todc.cc (ArrayInitializer::toDt): Update to use build_expr.
+	* d-codegen.cc (d_array_value): Don't override default const and
+	static bits for array constructors.
+
 2016-09-16  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-codegen.cc (lower_struct_comparison): Don't compare vectors in the

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -1398,12 +1398,7 @@ d_array_value (tree type, tree len, tree data)
   CONSTRUCTOR_APPEND_ELT (ce, len_field, len);
   CONSTRUCTOR_APPEND_ELT (ce, ptr_field, data);
 
-  tree ctor = build_constructor (type, ce);
-  // TREE_STATIC and TREE_CONSTANT can be set by caller if needed
-  TREE_STATIC (ctor) = 0;
-  TREE_CONSTANT (ctor) = 0;
-
-  return ctor;
+  return build_constructor (type, ce);
 }
 
 // Builds a D string value from the C string STR.


### PR DESCRIPTION
The expression visitor handles this without issue.
