### PR TITLE
Guard against X32 for x86_64 implementation of fiber_switchContext

### DIFF
--- a/libphobos/libdruntime/core/threadasm.S
+++ b/libphobos/libdruntime/core/threadasm.S
@@ -565,7 +565,7 @@ CSYM(fiber_switchContext):
 
     // 'return' to complete switch
     ret
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) && !defined(__ILP32__)
 .text
 .p2align 4
 .globl CSYM(fiber_switchContext)
@@ -594,5 +594,5 @@ CSYM(fiber_switchContext):
 
     // 'return' to complete switch
     ret
-#endif	// __x86_64__
+#endif	// __x86_64__ && !__ILP32__
 #endif	// posix


### PR DESCRIPTION
Wasn't detected until turning on shared libphobos. Without this, get duplicate definitions of `fiber_switchContext`.

For the moment we still want to use `ucontext_t` fallback as neither x86 nor 64-bit asm implementations work for x32.
