### PR TITLE
Remove -lcurl from link flags

### DIFF
--- a/libphobos/src/Makefile.am
+++ b/libphobos/src/Makefile.am
@@ -99,7 +99,7 @@ EXTRA_libgphobos_t_la_DEPENDENCIES = $(PHOBOS_TEST_LOBJECTS)
 unittest_SOURCES = ../libdruntime/test_runner.d
 unittest_LIBTOOLFLAGS = --tag=D
 unittest_LDFLAGS = -Xcompiler -nophoboslib -shared
-unittest_LDADD = libgphobos_t.la ../libdruntime/libgdruntime.la -lcurl
+unittest_LDADD = libgphobos_t.la ../libdruntime/libgdruntime.la
 
 # Extra install and clean rules.
 # This does not delete the .libs/.t.o files, but deleting

--- a/libphobos/src/Makefile.in
+++ b/libphobos/src/Makefile.in
@@ -493,7 +493,7 @@ EXTRA_libgphobos_t_la_DEPENDENCIES = $(PHOBOS_TEST_LOBJECTS)
 unittest_SOURCES = ../libdruntime/test_runner.d
 unittest_LIBTOOLFLAGS = --tag=D
 unittest_LDFLAGS = -Xcompiler -nophoboslib -shared
-unittest_LDADD = libgphobos_t.la ../libdruntime/libgdruntime.la -lcurl
+unittest_LDADD = libgphobos_t.la ../libdruntime/libgdruntime.la
 
 # Zlib sources when not using system libz
 ZLIB_CSOURCES = $(top_srcdir)/../zlib/adler32.c $(top_srcdir)/../zlib/compress.c \


### PR DESCRIPTION
The shared library support pull request added code to load curl dynamically, but I forgot to remove the `-lcurl` link flag in one place.
