### PR TITLE
Fix issue 231 (mixin template emitted into multiple object files)

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,7 @@
+2016-09-26  Johannes Pfau  <johannespfau@gmail.com>
+
+	* d-objfile.cc (d_finish_function): Handle template mixins (issue 231).
+
 2016-09-18  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* imports.cc (ImportVisitor::visit(ScopeDsymbol)): New visit method.

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -1897,18 +1897,10 @@ d_finish_function(FuncDeclaration *fd)
   // If we generated the function, but it's really extern.
   // Such as external inlinable functions or thunk aliases.
   bool extern_p = false;
-  for (FuncDeclaration *fdp = fd; fdp != NULL;)
+
+  if (!fd->isInstantiated() && fd->getModule() && !fd->getModule()->isRoot())
     {
-      if (fdp->inNonRoot())
-	{
-	  extern_p = true;
-	  break;
-	}
-
-      if (!fdp->isNested())
-	break;
-
-      fdp = fdp->toParent2()->isFuncDeclaration();
+      extern_p = true;
     }
 
   if (extern_p)

--- a/gcc/testsuite/gdc.test/compilable/gdc231.d
+++ b/gcc/testsuite/gdc.test/compilable/gdc231.d
@@ -1,0 +1,16 @@
+// EXTRA_SOURCES: imports/gdc231a.d
+module gdc231;
+
+import imports.gdc231a;
+
+class Range : Widget
+{
+    void* getStruct()
+    {
+        return null;
+    }
+}
+
+void main()
+{
+}

--- a/gcc/testsuite/gdc.test/compilable/gdc27.d
+++ b/gcc/testsuite/gdc.test/compilable/gdc27.d
@@ -1,0 +1,18 @@
+// EXTRA_SOURCES: imports/gdc27a.d
+module gdc27;
+
+import imports.gdc27a;
+
+interface I_B : I_A
+{
+    void b();
+}
+
+abstract class C_B : C_A, I_B
+{
+    abstract void b();
+}
+
+void main()
+{
+}

--- a/gcc/testsuite/gdc.test/compilable/imports/gdc231a.d
+++ b/gcc/testsuite/gdc.test/compilable/imports/gdc231a.d
@@ -1,0 +1,24 @@
+module imports.gdc231a;
+
+interface ImplementorIF
+{
+    void* getImplementorStruct();
+    void* getStruct();
+}
+
+template ImplementorT()
+{
+    void* getImplementorStruct()
+    {
+        return null;
+    }
+}
+
+class Widget : ImplementorIF
+{
+    mixin ImplementorT;
+    void* getStruct()
+    {
+        return null;
+    }
+}

--- a/gcc/testsuite/gdc.test/compilable/imports/gdc27a.d
+++ b/gcc/testsuite/gdc.test/compilable/imports/gdc27a.d
@@ -1,0 +1,14 @@
+module imports.gdc27a;
+
+interface I_A
+{
+    bool a();
+}
+
+class C_A : I_A
+{
+    bool a()
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
See https://bugzilla.gdcproject.org/show_bug.cgi?id=231

The main problem is that our `FuncDeclaration::toThunkSymbol` function calls `toObjFile` whereas DMD doesn't call `toObjFile` here. I tried modifying the thunk code to work without this `toObjFile` call, but I couldn't get this into a working state.

So because of this `toObjFile` call we should not really emit functions in some cases (external functions, thunk in current module). We have to handle these cases in `d_finish_function`. The old code uses `inNonRoot` which does neither handle templates **nor template mixins**. It simply returns false for any function in a template mixin.

`isInstantiated` on the other hand explicitly checks for templates and  does return `null` for template mixins. So `isInstantiated` is true for functions in normal templates only which can always be emitted (functions are marked weak anyway). For all other cases - including template mixins - `getModule` will get the correct root module.

I don't know why the old code explicitly called `toParent2`, but the new code should be equivalent (`getModule` traverses the parent dsymbols in the same way)
