### PR TITLE
Backport: rt.aaA: Do not use a struct without fields as AA index in u…

### DIFF
--- a/libphobos/libdruntime/rt/aaA.d
+++ b/libphobos/libdruntime/rt/aaA.d
@@ -907,6 +907,7 @@ unittest
 {
     static struct T
     {
+        ubyte field;
         static size_t postblit, dtor;
         this(this)
         {


### PR DESCRIPTION
…nittest

Backport of https://github.com/dlang/druntime/pull/1661
Fixes 236: https://bugzilla.gdcproject.org/show_bug.cgi?id=236
