### PR TITLE
Bug 242: Do constant propagation of enums when frontend doesn't.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,10 @@
+2016-10-03  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-objfile.cc (VarDeclaration::toObjFile): Always generate
+	DECL_INITIAL for all kinds of var decls.
+	* d-codegen.cc (build_address): Use the DECL_INITIAL directly if
+	taking the address of a CONST_DECL.
+
 2016-09-26  Johannes Pfau  <johannespfau@gmail.com>
 
 	* d-objfile.cc (d_finish_function): Handle template mixins (issue 231).

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -1734,8 +1734,12 @@ build_address(tree exp)
   else
     ptrtype = build_pointer_type(type);
 
-  // Maybe rewrite: (e1, e2) => (e1, &e2)
+  // Maybe rewrite: &(e1, e2) => (e1, &e2)
   tree init = stabilize_expr(&exp);
+
+  // Can't take the address of a manifest constant, instead use its value.
+  if (TREE_CODE (exp) == CONST_DECL)
+    exp = DECL_INITIAL (exp);
 
   d_mark_addressable(exp);
   exp = build_fold_addr_expr_with_type_loc(input_location, exp, ptrtype);

--- a/gcc/testsuite/gdc.test/compilable/gdc242.d
+++ b/gcc/testsuite/gdc.test/compilable/gdc242.d
@@ -1,0 +1,23 @@
+// PERMUTE_ARGS:
+
+struct S242a
+{
+    enum M = S242a();
+    void iter() { }
+}
+
+void test242a()
+{
+    return S242a.M.iter;
+}
+
+struct S242b
+{
+    enum M = S242b();
+    void iter() { }
+}
+
+void test242b()
+{
+    S242b.M.iter;
+}

--- a/gcc/testsuite/gdc.test/runnable/gdc.d
+++ b/gcc/testsuite/gdc.test/runnable/gdc.d
@@ -1031,6 +1031,32 @@ void test210()
 
 /******************************************/
 
+// Bug 242
+
+struct S242
+{
+    enum M = S242();
+    int a = 42;
+
+    auto iter()
+    {
+        this.a = 24;
+        return this;
+    }
+}
+
+S242 test242a()
+{
+    return S242.M.iter;
+}
+
+void test242()
+{
+    assert(test242a() == S242(24));
+}
+
+/******************************************/
+
 void main()
 {
     test2();


### PR DESCRIPTION
Always generate the constructor for a non-scalar manifest constant on the off-chance that it is referenced instead of propagated in the AST provided by the front-end.  Also taking into account that if taking the address of the enum, as what happens when the manifest is the object of a method call, that it's DECL_INITIAL (or constructor) is always used instead.

This is a special case, but the right thing to do anyway.
