### PR TITLE
Do not compile .c and .S files in D mode

### DIFF
--- a/libphobos/d_rules.am
+++ b/libphobos/d_rules.am
@@ -28,12 +28,33 @@ LTDCOMPILE = $(LIBTOOL) --tag=D $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) \
 	@:
 
 # Override executable linking commands: We have to use GDC for linking
-unittest_static_LINK = $(LIBTOOL) --tag=CC \
+# to make sure we link pthreads and other dependencies
+unittest_static_LINK = $(LIBTOOL) --tag=D \
 	$(unittest_static_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link \
 	$(GDC) $(AM_CFLAGS) $(CFLAGS) $(unittest_static_LDFLAGS) \
 	$(LDFLAGS) -o $@
 
-unittest_LINK = $(LIBTOOL) --tag=CC \
+unittest_LINK = $(LIBTOOL) --tag=D \
 	$(unittest_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link \
 	$(GDC) $(AM_CFLAGS) $(CFLAGS) $(unittest_LDFLAGS) \
+	$(LDFLAGS) -o $@
+
+# Also override library link commands: This is not strictly
+# required, but we want to record additional dependencies such
+# as pthread in the library
+libgdruntime_la_LINK = $(LIBTOOL) --tag=D $(AM_LIBTOOLFLAGS) \
+	$(LIBTOOLFLAGS) --mode=link $(GDC) $(AM_CFLAGS) $(CFLAGS) \
+	$(libgdruntime_la_LDFLAGS) $(LDFLAGS) -o $@
+
+libgdruntime_t_la_LINK = $(LIBTOOL) --tag=D $(AM_LIBTOOLFLAGS) \
+	$(LIBTOOLFLAGS) --mode=link $(GDC) $(AM_CFLAGS) $(CFLAGS) \
+	$(libgdruntime_t_la_LDFLAGS) $(LDFLAGS) -o $@
+
+libgphobos_la_LINK = $(LIBTOOL) --tag=D $(libgphobos_la_LIBTOOLFLAGS) \
+	$(LIBTOOLFLAGS) --mode=link $(GDC) $(AM_CFLAGS) $(CFLAGS) \
+	$(libgphobos_la_LDFLAGS) $(LDFLAGS) -o $@
+
+libgphobos_t_la_LINK = $(LIBTOOL) --tag=D \
+	$(libgphobos_t_la_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link \
+	$(GDC) $(AM_CFLAGS) $(CFLAGS) $(libgphobos_t_la_LDFLAGS) \
 	$(LDFLAGS) -o $@

--- a/libphobos/libdruntime/Makefile.am
+++ b/libphobos/libdruntime/Makefile.am
@@ -89,21 +89,21 @@ endif
 
 toolexeclib_LTLIBRARIES = libgdruntime.la
 libgdruntime_la_SOURCES = $(ALL_DRUNTIME_SOURCES)
-libgdruntime_la_LIBTOOLFLAGS = --tag=D
+libgdruntime_la_LIBTOOLFLAGS =
 libgdruntime_la_LDFLAGS = -Xcompiler -nophoboslib $(DRUNTIME_VER_FLAG)
 libgdruntime_la_LIBADD = $(BACKTRACE_LIB) $(LIBADD_DLOPEN)
 
 # For static unittest, link objects directly
 unittest_static_SOURCES = test_runner.d $(DRUNTIME_CSOURCES) \
     $(DRUNTIME_SSOURCES)
-unittest_static_LIBTOOLFLAGS = --tag=D
+unittest_static_LIBTOOLFLAGS =
 unittest_static_LDFLAGS = -Xcompiler -nophoboslib
 unittest_static_LDADD = $(DRUNTIME_TEST_OBJECTS) $(BACKTRACE_LIB)
 EXTRA_unittest_static_DEPENDENCIES = $(DRUNTIME_TEST_OBJECTS)
 
 # For unittest with dynamic library
 libgdruntime_t_la_SOURCES = $(DRUNTIME_CSOURCES) $(DRUNTIME_SSOURCES)
-libgdruntime_t_la_LIBTOOLFLAGS = --tag=D
+libgdruntime_t_la_LIBTOOLFLAGS =
 # Automake by default does not generate shared libs for non-installed
 # libraries. Use -rpath to force shared lib generation.
 libgdruntime_t_la_LDFLAGS = -Xcompiler -nophoboslib -rpath /foo -shared
@@ -113,7 +113,7 @@ EXTRA_libgdruntime_t_la_DEPENDENCIES = $(DRUNTIME_TEST_LOBJECTS)
 
 # For unittest
 unittest_SOURCES = test_runner.d
-unittest_LIBTOOLFLAGS = --tag=D
+unittest_LIBTOOLFLAGS =
 unittest_LDFLAGS = -Xcompiler -nophoboslib
 unittest_LDADD = libgdruntime_t.la
 

--- a/libphobos/libdruntime/Makefile.in
+++ b/libphobos/libdruntime/Makefile.in
@@ -268,10 +268,6 @@ am__objects_21 = libgdruntime_la-threadasm.lo
 am__objects_22 = $(am__objects_19) $(am__objects_20) $(am__objects_21)
 am_libgdruntime_la_OBJECTS = $(am__objects_22)
 libgdruntime_la_OBJECTS = $(am_libgdruntime_la_OBJECTS)
-libgdruntime_la_LINK = $(LIBTOOL) --tag=CC \
-	$(libgdruntime_la_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link \
-	$(CCLD) $(AM_CFLAGS) $(CFLAGS) $(libgdruntime_la_LDFLAGS) \
-	$(LDFLAGS) -o $@
 libgdruntime_t_la_DEPENDENCIES = $(DRUNTIME_TEST_LOBJECTS) \
 	$(BACKTRACE_LIB) $(am__DEPENDENCIES_1)
 am__objects_23 = libgdruntime_t_la-errno_.lo \
@@ -279,10 +275,6 @@ am__objects_23 = libgdruntime_t_la-errno_.lo \
 am__objects_24 = libgdruntime_t_la-threadasm.lo
 am_libgdruntime_t_la_OBJECTS = $(am__objects_23) $(am__objects_24)
 libgdruntime_t_la_OBJECTS = $(am_libgdruntime_t_la_OBJECTS)
-libgdruntime_t_la_LINK = $(LIBTOOL) --tag=CC \
-	$(libgdruntime_t_la_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link \
-	$(CCLD) $(AM_CFLAGS) $(CFLAGS) $(libgdruntime_t_la_LDFLAGS) \
-	$(LDFLAGS) -o $@
 @ENABLE_SHARED_TRUE@am_libgdruntime_t_la_rpath =
 @ENABLE_SHARED_TRUE@am__EXEEXT_1 = unittest$(EXEEXT)
 @ENABLE_STATIC_TRUE@am__EXEEXT_2 = unittest_static$(EXEEXT)
@@ -469,14 +461,36 @@ LTDCOMPILE = $(LIBTOOL) --tag=D $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) \
 
 
 # Override executable linking commands: We have to use GDC for linking
-unittest_static_LINK = $(LIBTOOL) --tag=CC \
+# to make sure we link pthreads and other dependencies
+unittest_static_LINK = $(LIBTOOL) --tag=D \
 	$(unittest_static_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link \
 	$(GDC) $(AM_CFLAGS) $(CFLAGS) $(unittest_static_LDFLAGS) \
 	$(LDFLAGS) -o $@
 
-unittest_LINK = $(LIBTOOL) --tag=CC \
+unittest_LINK = $(LIBTOOL) --tag=D \
 	$(unittest_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link \
 	$(GDC) $(AM_CFLAGS) $(CFLAGS) $(unittest_LDFLAGS) \
+	$(LDFLAGS) -o $@
+
+
+# Also override library link commands: This is not strictly
+# required, but we want to record additional dependencies such
+# as pthread in the library
+libgdruntime_la_LINK = $(LIBTOOL) --tag=D $(AM_LIBTOOLFLAGS) \
+	$(LIBTOOLFLAGS) --mode=link $(GDC) $(AM_CFLAGS) $(CFLAGS) \
+	$(libgdruntime_la_LDFLAGS) $(LDFLAGS) -o $@
+
+libgdruntime_t_la_LINK = $(LIBTOOL) --tag=D $(AM_LIBTOOLFLAGS) \
+	$(LIBTOOLFLAGS) --mode=link $(GDC) $(AM_CFLAGS) $(CFLAGS) \
+	$(libgdruntime_t_la_LDFLAGS) $(LDFLAGS) -o $@
+
+libgphobos_la_LINK = $(LIBTOOL) --tag=D $(libgphobos_la_LIBTOOLFLAGS) \
+	$(LIBTOOLFLAGS) --mode=link $(GDC) $(AM_CFLAGS) $(CFLAGS) \
+	$(libgphobos_la_LDFLAGS) $(LDFLAGS) -o $@
+
+libgphobos_t_la_LINK = $(LIBTOOL) --tag=D \
+	$(libgphobos_t_la_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link \
+	$(GDC) $(AM_CFLAGS) $(CFLAGS) $(libgphobos_t_la_LDFLAGS) \
 	$(LDFLAGS) -o $@
 
 
@@ -519,7 +533,7 @@ DRUNTIME_TEST_LOBJECTS = $(filter-out rt/util/typeinfo.t.lo \
 @ENABLE_SHARED_TRUE@check_LTLIBRARIES = libgdruntime_t.la
 toolexeclib_LTLIBRARIES = libgdruntime.la
 libgdruntime_la_SOURCES = $(ALL_DRUNTIME_SOURCES)
-libgdruntime_la_LIBTOOLFLAGS = --tag=D
+libgdruntime_la_LIBTOOLFLAGS = 
 libgdruntime_la_LDFLAGS = -Xcompiler -nophoboslib $(DRUNTIME_VER_FLAG)
 libgdruntime_la_LIBADD = $(BACKTRACE_LIB) $(LIBADD_DLOPEN)
 
@@ -527,14 +541,14 @@ libgdruntime_la_LIBADD = $(BACKTRACE_LIB) $(LIBADD_DLOPEN)
 unittest_static_SOURCES = test_runner.d $(DRUNTIME_CSOURCES) \
     $(DRUNTIME_SSOURCES)
 
-unittest_static_LIBTOOLFLAGS = --tag=D
+unittest_static_LIBTOOLFLAGS = 
 unittest_static_LDFLAGS = -Xcompiler -nophoboslib
 unittest_static_LDADD = $(DRUNTIME_TEST_OBJECTS) $(BACKTRACE_LIB)
 EXTRA_unittest_static_DEPENDENCIES = $(DRUNTIME_TEST_OBJECTS)
 
 # For unittest with dynamic library
 libgdruntime_t_la_SOURCES = $(DRUNTIME_CSOURCES) $(DRUNTIME_SSOURCES)
-libgdruntime_t_la_LIBTOOLFLAGS = --tag=D
+libgdruntime_t_la_LIBTOOLFLAGS = 
 # Automake by default does not generate shared libs for non-installed
 # libraries. Use -rpath to force shared lib generation.
 libgdruntime_t_la_LDFLAGS = -Xcompiler -nophoboslib -rpath /foo -shared
@@ -545,7 +559,7 @@ EXTRA_libgdruntime_t_la_DEPENDENCIES = $(DRUNTIME_TEST_LOBJECTS)
 
 # For unittest
 unittest_SOURCES = test_runner.d
-unittest_LIBTOOLFLAGS = --tag=D
+unittest_LIBTOOLFLAGS = 
 unittest_LDFLAGS = -Xcompiler -nophoboslib
 unittest_LDADD = libgdruntime_t.la
 DRUNTIME_DSOURCES_GENERATED = gcc/config.d gcc/libbacktrace.d

--- a/libphobos/src/Makefile.am
+++ b/libphobos/src/Makefile.am
@@ -75,13 +75,13 @@ endif
 
 toolexeclib_LTLIBRARIES = libgphobos.la
 libgphobos_la_SOURCES = $(ALL_PHOBOS_SOURCES) $(ZLIB_SRC)
-libgphobos_la_LIBTOOLFLAGS = --tag=D
+libgphobos_la_LIBTOOLFLAGS =
 libgphobos_la_LDFLAGS = -Xcompiler -nophoboslib $(PHOBOS_VER_FLAG)
 libgphobos_la_LIBADD = ../libdruntime/libgdruntime.la $(ZLIB_LIB)
 
 # For static unittest, link objects directly
 unittest_static_SOURCES = ../libdruntime/test_runner.d $(ZLIB_SRC)
-unittest_static_LIBTOOLFLAGS = --tag=D
+unittest_static_LIBTOOLFLAGS =
 unittest_static_LDFLAGS = -Xcompiler -nophoboslib -static-libtool-libs
 unittest_static_LDADD = $(PHOBOS_TEST_OBJECTS) $(ZLIB_LIB) \
     ../libdruntime/libgdruntime.la
@@ -89,7 +89,7 @@ EXTRA_unittest_static_DEPENDENCIES = $(PHOBOS_TEST_OBJECTS)
 
 # For unittest with dynamic library
 libgphobos_t_la_SOURCES = $(ZLIB_SRC)
-libgphobos_t_la_LIBTOOLFLAGS = --tag=D
+libgphobos_t_la_LIBTOOLFLAGS =
 libgphobos_t_la_LDFLAGS = -Xcompiler -nophoboslib -rpath /foo -shared
 libgphobos_t_la_LIBADD = $(PHOBOS_TEST_LOBJECTS) $(ZLIB_LIB) \
     ../libdruntime/libgdruntime.la
@@ -97,7 +97,7 @@ EXTRA_libgphobos_t_la_DEPENDENCIES = $(PHOBOS_TEST_LOBJECTS)
 
 # For unittest
 unittest_SOURCES = ../libdruntime/test_runner.d
-unittest_LIBTOOLFLAGS = --tag=D
+unittest_LIBTOOLFLAGS =
 unittest_LDFLAGS = -Xcompiler -nophoboslib -shared
 unittest_LDADD = libgphobos_t.la ../libdruntime/libgdruntime.la
 

--- a/libphobos/src/Makefile.in
+++ b/libphobos/src/Makefile.in
@@ -212,9 +212,6 @@ am__objects_13 = libgphobos_la-adler32.lo libgphobos_la-compress.lo \
 @DRUNTIME_ZLIB_SYSTEM_FALSE@am__objects_14 = $(am__objects_13)
 am_libgphobos_la_OBJECTS = $(am__objects_12) $(am__objects_14)
 libgphobos_la_OBJECTS = $(am_libgphobos_la_OBJECTS)
-libgphobos_la_LINK = $(LIBTOOL) --tag=CC $(libgphobos_la_LIBTOOLFLAGS) \
-	$(LIBTOOLFLAGS) --mode=link $(CCLD) $(AM_CFLAGS) $(CFLAGS) \
-	$(libgphobos_la_LDFLAGS) $(LDFLAGS) -o $@
 libgphobos_t_la_DEPENDENCIES = $(PHOBOS_TEST_LOBJECTS) \
 	$(am__DEPENDENCIES_1) ../libdruntime/libgdruntime.la
 am__objects_15 = libgphobos_t_la-adler32.lo \
@@ -228,10 +225,6 @@ am__objects_15 = libgphobos_t_la-adler32.lo \
 @DRUNTIME_ZLIB_SYSTEM_FALSE@am__objects_16 = $(am__objects_15)
 am_libgphobos_t_la_OBJECTS = $(am__objects_16)
 libgphobos_t_la_OBJECTS = $(am_libgphobos_t_la_OBJECTS)
-libgphobos_t_la_LINK = $(LIBTOOL) --tag=CC \
-	$(libgphobos_t_la_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link \
-	$(CCLD) $(AM_CFLAGS) $(CFLAGS) $(libgphobos_t_la_LDFLAGS) \
-	$(LDFLAGS) -o $@
 @ENABLE_SHARED_TRUE@am_libgphobos_t_la_rpath =
 @ENABLE_SHARED_TRUE@am__EXEEXT_1 = unittest$(EXEEXT)
 @ENABLE_STATIC_TRUE@am__EXEEXT_2 = unittest_static$(EXEEXT)
@@ -417,14 +410,36 @@ LTDCOMPILE = $(LIBTOOL) --tag=D $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) \
 
 
 # Override executable linking commands: We have to use GDC for linking
-unittest_static_LINK = $(LIBTOOL) --tag=CC \
+# to make sure we link pthreads and other dependencies
+unittest_static_LINK = $(LIBTOOL) --tag=D \
 	$(unittest_static_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link \
 	$(GDC) $(AM_CFLAGS) $(CFLAGS) $(unittest_static_LDFLAGS) \
 	$(LDFLAGS) -o $@
 
-unittest_LINK = $(LIBTOOL) --tag=CC \
+unittest_LINK = $(LIBTOOL) --tag=D \
 	$(unittest_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link \
 	$(GDC) $(AM_CFLAGS) $(CFLAGS) $(unittest_LDFLAGS) \
+	$(LDFLAGS) -o $@
+
+
+# Also override library link commands: This is not strictly
+# required, but we want to record additional dependencies such
+# as pthread in the library
+libgdruntime_la_LINK = $(LIBTOOL) --tag=D $(AM_LIBTOOLFLAGS) \
+	$(LIBTOOLFLAGS) --mode=link $(GDC) $(AM_CFLAGS) $(CFLAGS) \
+	$(libgdruntime_la_LDFLAGS) $(LDFLAGS) -o $@
+
+libgdruntime_t_la_LINK = $(LIBTOOL) --tag=D $(AM_LIBTOOLFLAGS) \
+	$(LIBTOOLFLAGS) --mode=link $(GDC) $(AM_CFLAGS) $(CFLAGS) \
+	$(libgdruntime_t_la_LDFLAGS) $(LDFLAGS) -o $@
+
+libgphobos_la_LINK = $(LIBTOOL) --tag=D $(libgphobos_la_LIBTOOLFLAGS) \
+	$(LIBTOOLFLAGS) --mode=link $(GDC) $(AM_CFLAGS) $(CFLAGS) \
+	$(libgphobos_la_LDFLAGS) $(LDFLAGS) -o $@
+
+libgphobos_t_la_LINK = $(LIBTOOL) --tag=D \
+	$(libgphobos_t_la_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link \
+	$(GDC) $(AM_CFLAGS) $(CFLAGS) $(libgphobos_t_la_LDFLAGS) \
 	$(LDFLAGS) -o $@
 
 
@@ -467,13 +482,13 @@ PHOBOS_TEST_LOBJECTS = $(filter-out std/net/curl.t.lo std/base64.t.lo, \
 @ENABLE_SHARED_TRUE@check_LTLIBRARIES = libgphobos_t.la
 toolexeclib_LTLIBRARIES = libgphobos.la
 libgphobos_la_SOURCES = $(ALL_PHOBOS_SOURCES) $(ZLIB_SRC)
-libgphobos_la_LIBTOOLFLAGS = --tag=D
+libgphobos_la_LIBTOOLFLAGS = 
 libgphobos_la_LDFLAGS = -Xcompiler -nophoboslib $(PHOBOS_VER_FLAG)
 libgphobos_la_LIBADD = ../libdruntime/libgdruntime.la $(ZLIB_LIB)
 
 # For static unittest, link objects directly
 unittest_static_SOURCES = ../libdruntime/test_runner.d $(ZLIB_SRC)
-unittest_static_LIBTOOLFLAGS = --tag=D
+unittest_static_LIBTOOLFLAGS = 
 unittest_static_LDFLAGS = -Xcompiler -nophoboslib -static-libtool-libs
 unittest_static_LDADD = $(PHOBOS_TEST_OBJECTS) $(ZLIB_LIB) \
     ../libdruntime/libgdruntime.la
@@ -482,7 +497,7 @@ EXTRA_unittest_static_DEPENDENCIES = $(PHOBOS_TEST_OBJECTS)
 
 # For unittest with dynamic library
 libgphobos_t_la_SOURCES = $(ZLIB_SRC)
-libgphobos_t_la_LIBTOOLFLAGS = --tag=D
+libgphobos_t_la_LIBTOOLFLAGS = 
 libgphobos_t_la_LDFLAGS = -Xcompiler -nophoboslib -rpath /foo -shared
 libgphobos_t_la_LIBADD = $(PHOBOS_TEST_LOBJECTS) $(ZLIB_LIB) \
     ../libdruntime/libgdruntime.la
@@ -491,7 +506,7 @@ EXTRA_libgphobos_t_la_DEPENDENCIES = $(PHOBOS_TEST_LOBJECTS)
 
 # For unittest
 unittest_SOURCES = ../libdruntime/test_runner.d
-unittest_LIBTOOLFLAGS = --tag=D
+unittest_LIBTOOLFLAGS = 
 unittest_LDFLAGS = -Xcompiler -nophoboslib -shared
 unittest_LDADD = libgphobos_t.la ../libdruntime/libgdruntime.la
 


### PR DESCRIPTION
Fixes https://bugzilla.gdcproject.org/show_bug.cgi?id=244

The `.d.lo`: rule is already responsible for compiling D sources. The  `LIBTOOLFLAGS=--tag=D` is only required to make libtool link using gdc. This is useful to record the library dependencies (pthread,...) into the shared libraries. But instead of using the tag which then  also applies to the sources we can also just provide a custom link command. We can remove all those custom link commands if we properly configure all dependencies (i.e. pull 240).

Note: We have to keep the empty `LIBTOOLFLAGS` to avoid these error messages:

```
src/Makefile.am: object `inflate.$(OBJEXT)' created both with libtool and without
```

BTW: The best error message ever:

```
xgcc: error: unrecognized command line option '-nophoboslib'; did you mean '-nophoboslib'?
```
