### PR TITLE
Add fast path for returning true from d_types_same.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,7 @@
+2016-10-15  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-codegen.h (d_types_same): Return early if types are identical.
+
 2016-10-03  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-objfile.cc (VarDeclaration::toObjFile): Always generate

--- a/gcc/d/d-codegen.h
+++ b/gcc/d/d-codegen.h
@@ -200,9 +200,15 @@ extern bool empty_aggregate_p(tree type);
 inline bool
 d_types_same (Type *t1, Type *t2)
 {
-  Type *tb1 = t1->toBasetype()->immutableOf();
-  Type *tb2 = t2->toBasetype()->immutableOf();
-  return tb1->equals (tb2);
+  if (t1 == t2)
+    return true;
+
+  Type *tb1 = t1->toBasetype();
+  Type *tb2 = t2->toBasetype();
+  if (tb1 == tb2)
+    return true;
+
+  return tb1->immutableOf ()->equals (tb2->immutableOf ());
 }
 
 // Returns D frontend type 'Object' which all classes are derived from.


### PR DESCRIPTION
Taken from #236.  Used as one part of fixing an ICE in:

```
void crash()
{
  enum E;
  E *e;
}
```

But actually applies to type comparisons of synthetic structs too, where calling immutableOf would trigger bogus forward reference errors.
