### PR TITLE
Bug 235: Fix ICE with array slice assign.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,9 @@
+2016-10-27  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* expr.cc (ExprVisitor::visit(AssignExp)): Don't set TREE_ADDRESSABLE.
+	* d-codegen.cc (build_assign): Handle setting up INIT_EXPR from a
+	value returning via NRVO here instead.
+
 2016-10-26  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-codegen.cc (d_build_call): Only convert CALL_EXPRs into a

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,10 @@
+2016-10-26  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-codegen.cc (d_build_call): Only convert CALL_EXPRs into a
+	TARGET_EXPR if return type is TREE_ADDRESSABLE.
+	(build_assign): Use TARGET_EXPR accessors.
+	(compound_expr): Likewise.
+
 2016-10-15  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-codegen.h (d_types_same): Return early if types are identical.

--- a/gcc/d/expr.cc
+++ b/gcc/d/expr.cc
@@ -992,9 +992,6 @@ public:
 	tree t2 = convert_for_assignment(build_expr(e->e2),
 					 e->e2->type, e->e1->type);
 
-	if (e->op == TOKconstruct && e->e2->op == TOKcall)
-	  d_mark_addressable(t1);
-
 	if (e->e2->op == TOKint64)
 	  {
 	    // Use memset to fill struct.
@@ -1046,9 +1043,6 @@ public:
 	    tree t1 = build_expr(e->e1);
 	    tree t2 = convert_for_assignment(build_expr(e->e2),
 					     e->e2->type, e->e1->type);
-
-	    if (e->op == TOKconstruct && e->e2->op == TOKcall)
-	      d_mark_addressable(t1);
 
 	    this->result_ = build_assign(modifycode, t1, t2);
 	  }


### PR DESCRIPTION
I've been thinking of every angle to tackle this.  But actually, the best way not to fall into a myriad of edge cases is just to not return every static array or aggregate in a `TARGET_EXPR`.

There may be an opportunity to move this to `d_save_expr`, but for now I'm just going with the conservative choice.
