### PR TITLE
Improvements to debug information on opaque types.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,10 @@
+2016-10-29  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-codegen.cc (layout_aggregate_type): Continue searching based on
+	aggregate members, not just fields.
+	* types.cc (TypeVisitor::visit(TypeEnum)): Use void for opaque enums.
+	(TypeVisitor::visit(TypeStruct)): Don't give opaque structs a size.
+
 2016-10-27  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* expr.cc (ExprVisitor::visit(AssignExp)): Don't set TREE_ADDRESSABLE.

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -4600,11 +4600,11 @@ layout_aggregate_members(Dsymbols *members, tree context, bool inherited_p)
       AttribDeclaration *attrib = sym->isAttribDeclaration();
       if (attrib != NULL)
 	{
-	  Dsymbols *decl = attrib->include(NULL, NULL);
+	  Dsymbols *decls = attrib->include(NULL, NULL);
 
-	  if (decl != NULL)
+	  if (decls != NULL)
 	    {
-	      fields += layout_aggregate_members(decl, context, inherited_p);
+	      fields += layout_aggregate_members(decls, context, inherited_p);
 	      continue;
 	    }
 	}
@@ -4663,7 +4663,7 @@ layout_aggregate_type(AggregateDeclaration *decl, tree type, AggregateDeclaratio
 	}
     }
 
-  if (base->fields.dim)
+  if (base->members)
     {
       size_t fields = layout_aggregate_members(base->members, type, inherited_p);
       gcc_assert(fields == base->fields.dim);

--- a/gcc/d/types.cc
+++ b/gcc/d/types.cc
@@ -398,9 +398,10 @@ public:
 
   void visit (TypeEnum *t)
   {
-    tree basetype = build_ctype (t->sym->memtype);
+    tree basetype = (t->sym->memtype) ?
+      build_ctype (t->sym->memtype) : void_type_node;
 
-    if (!t->sym->memtype->isintegral () || t->sym->memtype->ty == Tbool)
+    if (!INTEGRAL_TYPE_P (basetype) || TREE_CODE (basetype) == BOOLEAN_TYPE)
       {
 	/* Enums in D2 can have a base type that is not necessarily integral.
 	   For these, we simplify this a little by using the base type directly
@@ -478,22 +479,25 @@ public:
 
     TYPE_LANG_SPECIFIC (t->ctype) = build_lang_type (t);
 
-    /* Must set up the overall size and alignment before determining
-       the context or laying out fields as those types may make
-       recursive references to this type.  */
-    unsigned structsize = t->sym->structsize;
-    unsigned alignsize = t->sym->alignsize;
+    if (t->sym->members)
+      {
+	/* Must set up the overall size and alignment before determining
+	   the context or laying out fields as those types may make
+	   recursive references to this type.  */
+	unsigned structsize = t->sym->structsize;
+	unsigned alignsize = t->sym->alignsize;
 
-    TYPE_SIZE (t->ctype) = bitsize_int (structsize * BITS_PER_UNIT);
-    TYPE_SIZE_UNIT (t->ctype) = size_int (structsize);
-    SET_TYPE_ALIGN (t->ctype, alignsize * BITS_PER_UNIT);
-    TYPE_PACKED (t->ctype) = (alignsize == 1);
-    compute_record_mode (t->ctype);
+	TYPE_SIZE (t->ctype) = bitsize_int (structsize * BITS_PER_UNIT);
+	TYPE_SIZE_UNIT (t->ctype) = size_int (structsize);
+	SET_TYPE_ALIGN (t->ctype, alignsize * BITS_PER_UNIT);
+	TYPE_PACKED (t->ctype) = (alignsize == 1);
+	compute_record_mode (t->ctype);
 
-    /* Put out all fields.  */
-    layout_aggregate_type (t->sym, t->ctype, t->sym);
-    finish_aggregate_type (structsize, alignsize, t->ctype,
-			   t->sym->userAttribDecl);
+	/* Put out all fields.  */
+	layout_aggregate_type (t->sym, t->ctype, t->sym);
+	finish_aggregate_type (structsize, alignsize, t->ctype,
+			       t->sym->userAttribDecl);
+      }
 
     TYPE_CONTEXT (t->ctype) = d_decl_context (t->sym);
     build_type_decl (t->ctype, t->sym);


### PR DESCRIPTION
Fixes segfault when using opaque enums, where sym->memtype is a null pointer.
Improves debug generation of opaque structs by omitting size, alignment, and type mode (there are none).

Pull out of #236, to separately apply before updating GCC.
