### PR TITLE
Improve interaction with the binding_level system.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,34 @@
 2016-10-29  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-decls.cc (ClassReferenceExp::toSymbol): Use class record type for
+	static symbol.
+	* d-lang.cc (global_context): New static variable.
+	(global_declarations): New static variable.
+	(d_nametype): Pass built-in types to debug_hooks::type_decl.
+	(d_add_global_declaration): Remove function, update all callers.
+	(get_global_context): New function.
+	(d_pushdecl): Push decls to global, or bindings list here.
+	(StructDeclaration::toObjFile): Send type decl to d_pushdecl.
+	(ClassDeclaration::toObjFile): Likewise.
+	(InterfaceDeclaration::toObjFile): Likewise.
+	(EnumDeclaration::toObjFile): Likewise.
+	(FuncDeclaration::toObjFile): Send finished decl to d_pushdecl.
+	(d_finish_symbol): Likewise.
+	(emit_modref_hooks): Likewise.
+	(d_comdat_linkage): Don't set DECL_COMDAT on non-public decls.
+	(setup_symbol_storage): Don't set DECL_ABSTRACT_P on templates.
+	(d_finish_compilation): Remove check for type decls.
+	(build_type_decl): Don't add to global decl list, just call
+	rest_of_decl_compilation.
+	* expr.cc (ExprVisitor::visit(ArrayLiteralExp)): Send finished decl to
+	d_pushdecl.
+	* toir.cc (IRVisitor::visit(SwitchStatement)): Likewise.
+	(IRVisitor::end_scope): Mark bind expr as having side effects.
+	* typeinfo.cc (TypeInfoVisitor::visit(TypeInfoTupleDeclaration)): Send
+	finished decl to d_pushdecl.
+
+2016-10-29  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* d-codegen.cc (layout_aggregate_type): Continue searching based on
 	aggregate members, not just fields.
 	* types.cc (TypeVisitor::visit(TypeEnum)): Use void for opaque enums.

--- a/gcc/d/d-decls.cc
+++ b/gcc/d/d-decls.cc
@@ -648,7 +648,8 @@ ClassReferenceExp::toSymbol()
       value->sym = new Symbol();
 
       // Build reference symbol.
-      tree decl = build_artificial_decl(unknown_type_node, NULL_TREE, "C");
+      tree ctype = build_ctype(value->stype);
+      tree decl = build_artificial_decl(TREE_TYPE (ctype), NULL_TREE, "C");
       set_decl_location(decl, loc);
 
       value->sym->Stree = decl;

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -146,6 +146,12 @@ static bool std_inc = true;
 struct binding_level *current_binding_level;
 struct binding_level *global_binding_level;
 
+/* The context to be used for global declarations.  */
+static GTY(()) tree global_context;
+
+/* Array of all global declarations to pass back to the middle-end.  */
+static GTY(()) vec<tree, va_gc> *global_declarations;
+
 /* Common initialization before calling option handlers.  */
 static void
 d_init_options(unsigned int, cl_decoded_option *decoded_options)
@@ -782,7 +788,7 @@ d_nametype (Type *t)
   tree ident = get_identifier (t->toChars());
   tree decl = build_decl (BUILTINS_LOCATION, TYPE_DECL, ident, type);
   TYPE_NAME (type) = decl;
-  rest_of_decl_compilation (decl, 1, 0);
+  debug_hooks->type_decl (decl, 0);
 }
 
 // Generate C main() in response to seeing D main().
@@ -882,15 +888,6 @@ deps_write (Module *m)
   }
 
   ob->writenl();
-}
-
-// Array of all global declarations to pass back to the middle-end.
-static GTY(()) vec<tree, va_gc> *global_declarations;
-
-void
-d_add_global_declaration(tree decl)
-{
-  vec_safe_push(global_declarations, decl);
 }
 
 void
@@ -1406,17 +1403,47 @@ d_global_bindings_p()
   return !global_binding_level;
 }
 
+/* Return global_context, but create it first if need be.  */
+
+static tree
+get_global_context (void)
+{
+  if (!global_context)
+    {
+      global_context = build_translation_unit_decl (NULL_TREE);
+      debug_hooks->register_main_translation_unit (global_context);
+    }
+
+  return global_context;
+}
+
+/* Record DECL as belonging to the current lexical scope.  */
+
 tree
 d_pushdecl (tree decl)
 {
-  // Should only be for variables OR, should also use TRANSLATION_UNIT for toplevel...
-  // current_function_decl could be NULL_TREE (top level)...
-  if (DECL_CONTEXT (decl) == NULL_TREE)
-    DECL_CONTEXT (decl) = current_function_decl;
+  /* Set the context of the decl.  If current_function_decl did not help in
+     determining the context, use global scope.  */
+  if (!DECL_CONTEXT (decl))
+    {
+      if (current_function_decl)
+	DECL_CONTEXT (decl) = current_function_decl;
+      else
+	DECL_CONTEXT (decl) = get_global_context ();
+    }
 
-  // Put decls on list in reverse order.
-  TREE_CHAIN (decl) = current_binding_level->names;
-  current_binding_level->names = decl;
+  /* If template is not needed, don't send it to backend.  */
+  if (D_DECL_IS_TEMPLATE (decl) && !flag_emit_templates)
+    return decl;
+
+  /* Put decls on list in reverse order.  */
+  if (TREE_STATIC (decl) || d_global_bindings_p ())
+    vec_safe_push(global_declarations, decl);
+  else
+    {
+      TREE_CHAIN (decl) = current_binding_level->names;
+      current_binding_level->names = decl;
+    }
 
   return decl;
 }

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -238,6 +238,11 @@ StructDeclaration::toObjFile()
       return;
     }
 
+  /* Add this decl to the current binding level.  */
+  tree ctype = build_ctype(type);
+  if (TYPE_NAME (ctype))
+    d_pushdecl(TYPE_NAME (ctype));
+
   // Anonymous structs/unions only exist as part of others,
   // do not output forward referenced structs's
   if (isAnonymous() || !members)
@@ -604,6 +609,11 @@ Lhaspointers:
   vtblsym->Sdt = dt;
   vtblsym->Sreadonly = true;
   d_finish_symbol (vtblsym);
+
+  /* Add this decl to the current binding level.  */
+  tree ctype = TREE_TYPE (build_ctype(type));
+  if (TYPE_NAME (ctype))
+    d_pushdecl(TYPE_NAME (ctype));
 }
 
 // Get offset of base class's vtbl[] initialiser from start of csym.
@@ -771,6 +781,11 @@ InterfaceDeclaration::toObjFile()
   csym->Sdt = dt;
   csym->Sreadonly = true;
   d_finish_symbol (csym);
+
+  /* Add this decl to the current binding level.  */
+  tree ctype = TREE_TYPE (build_ctype(type));
+  if (TYPE_NAME (ctype))
+    d_pushdecl(TYPE_NAME (ctype));
 }
 
 void
@@ -798,6 +813,11 @@ EnumDeclaration::toObjFile()
       toInitializer();
       DECL_INITIAL (sinit->Stree) = build_expr(tc->sym->defaultval, true);
       d_finish_symbol (sinit);
+
+      /* Add this decl to the current binding level.  */
+      tree ctype = build_ctype(type);
+      if (TREE_CODE (ctype) == ENUMERAL_TYPE && TYPE_NAME (ctype))
+	d_pushdecl(TYPE_NAME (ctype));
     }
 
   semanticRun = PASSobj;
@@ -1198,6 +1218,9 @@ FuncDeclaration::toObjFile()
       rest_of_decl_compilation (fndecl, 1, 0);
       return;
     }
+
+  /* Add this decl to the current binding level.  */
+  d_pushdecl(fndecl);
 
   // Start generating code for this function.
   gcc_assert(this->semanticRun == PASSsemantic3done);
@@ -1693,7 +1716,8 @@ d_comdat_linkage(tree decl)
     // Fallback, cannot have multiple copies.
     DECL_COMMON (decl) = 1;
 
-  DECL_COMDAT (decl) = 1;
+  if (TREE_PUBLIC (decl))
+    DECL_COMDAT (decl) = 1;
 }
 
 
@@ -1739,7 +1763,6 @@ setup_symbol_storage(Dsymbol *dsym, tree decl, bool public_p)
 	{
 	  D_DECL_ONE_ONLY (decl) = 1;
 	  D_DECL_IS_TEMPLATE (decl) = 1;
-	  DECL_ABSTRACT_P (decl) = !flag_emit_templates;
 	}
 
       VarDeclaration *vd = rd ? rd->isVarDeclaration() : NULL;
@@ -1873,8 +1896,6 @@ d_finish_symbol (Symbol *sym)
       DECL_USER_ALIGN (decl) = 1;
     }
 
-  d_add_global_declaration (decl);
-
   // %% FIXME: DECL_COMMON so the symbol goes in .tcommon
   if (DECL_THREAD_LOCAL_P (decl)
       && DECL_ASSEMBLER_NAME (decl) == get_identifier ("_tlsend"))
@@ -1882,6 +1903,9 @@ d_finish_symbol (Symbol *sym)
       DECL_INITIAL (decl) = NULL_TREE;
       DECL_COMMON (decl) = 1;
     }
+
+  /* Add this decl to the current binding level.  */
+  d_pushdecl (decl);
 
   rest_of_decl_compilation (decl, 1, 0);
 }
@@ -1893,10 +1917,6 @@ d_finish_function(FuncDeclaration *fd)
   tree decl = s->Stree;
 
   gcc_assert(TREE_CODE (decl) == FUNCTION_DECL);
-
-  // If function is not needed, don't send it to backend.
-  if (DECL_ABSTRACT_P (decl))
-    return;
 
   // If we generated the function, but it's really extern.
   // Such as external inlinable functions or thunk aliases.
@@ -1926,7 +1946,6 @@ d_finish_function(FuncDeclaration *fd)
 	static_dtor_list.safe_push(fd);
     }
 
-  d_add_global_declaration(decl);
   cgraph_node::finalize_function(decl, true);
 }
 
@@ -1949,11 +1968,6 @@ d_finish_compilation(tree *vec, int len)
       if ((VAR_P (decl) && TREE_STATIC (decl))
 	  || TREE_CODE (decl) == FUNCTION_DECL)
 	mark_needed(decl);
-      else if (TREE_CODE (decl) == TYPE_DECL)
-	{
-	  bool toplevel = !DECL_CONTEXT (decl);
-	  rest_of_decl_compilation(decl, toplevel, 0);
-	}
     }
 }
 
@@ -1979,7 +1993,6 @@ build_artificial_decl(tree type, tree init, const char *prefix)
   DECL_ARTIFICIAL (decl) = 1;
 
   DECL_INITIAL (decl) = init;
-  d_add_global_declaration(decl);
 
   return decl;
 }
@@ -1996,6 +2009,7 @@ build_type_decl (tree type, Dsymbol *dsym)
 
   tree decl = build_decl(UNKNOWN_LOCATION, TYPE_DECL,
 			 get_identifier(dsym->ident->string), type);
+  DECL_ARTIFICIAL (decl) = 1;
 
   DECL_CONTEXT (decl) = d_decl_context(dsym);
   set_decl_location(decl, dsym);
@@ -2003,16 +2017,12 @@ build_type_decl (tree type, Dsymbol *dsym)
   TYPE_CONTEXT (type) = DECL_CONTEXT (decl);
   TYPE_NAME (type) = decl;
 
-  if (TREE_CODE (type) == ENUMERAL_TYPE || TREE_CODE (type) == RECORD_TYPE
-      || TREE_CODE (type) == UNION_TYPE)
-    {
-      /* Not sure if there is a need for separate TYPE_DECLs in
-	 TYPE_NAME and TYPE_STUB_DECL. */
-      TYPE_STUB_DECL (type) = decl;
-      DECL_ARTIFICIAL (decl) = 1;
-    }
+  /* Not sure if there is a need for separate TYPE_DECLs in
+     TYPE_NAME and TYPE_STUB_DECL. */
+  if (TREE_CODE (type) == ENUMERAL_TYPE || RECORD_OR_UNION_TYPE_P (type))
+    TYPE_STUB_DECL (type) = decl;
 
-  d_add_global_declaration(decl);
+  rest_of_decl_compilation(decl, SCOPE_FILE_SCOPE_P (decl), 0);
 }
 
 // Can't output thunks while a function is being compiled.
@@ -2614,6 +2624,7 @@ emit_modref_hooks(Symbol *sym, Dsymbol *mref)
 
   DECL_INITIAL (modref) = build_constructor (tmodref, ce);
   TREE_STATIC (DECL_INITIAL (modref)) = 1;
+  d_pushdecl (modref);
   rest_of_decl_compilation (modref, 1, 0);
 
   // Generate:

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -314,7 +314,6 @@ extern tree build_return_dtor (Expression *, Type *, TypeFunction *);
 extern void add_import_paths (const char *, const char *, bool);
 
 // In d-lang.cc.
-extern void d_add_global_declaration (tree);
 extern Module *d_gcc_get_output_module (void);
 extern struct lang_type *build_lang_type (Type *);
 extern struct lang_decl *build_lang_decl (Declaration *);

--- a/gcc/d/expr.cc
+++ b/gcc/d/expr.cc
@@ -32,6 +32,7 @@
 #include "diagnostic.h"
 #include "tm.h"
 #include "function.h"
+#include "toplev.h"
 #include "varasm.h"
 #include "stor-layout.h"
 
@@ -2493,10 +2494,13 @@ public:
 	// static symbol, and then refer to it.
 	if (tb->ty != Tsarray)
 	  {
-	    ctor = build_artificial_decl(TREE_TYPE (ctor), ctor, "A");
-	    ctor = build_address(ctor);
+	    tree decl = build_artificial_decl(TREE_TYPE (ctor), ctor, "A");
+	    ctor = build_address(decl);
 	    if (tb->ty == Tarray)
 	      ctor = d_array_value(type, size_int(e->elements->dim), ctor);
+
+	    d_pushdecl(decl);
+	    rest_of_decl_compilation(decl, 1, 0);
 	  }
 
 	// If the array literal is readonly or static.

--- a/gcc/d/toir.cc
+++ b/gcc/d/toir.cc
@@ -84,8 +84,10 @@ public:
     if (! BLOCK_VARS (block))
       return body;
 
-    return build3(BIND_EXPR, void_type_node,
-		  BLOCK_VARS (block), body, block);
+    tree bind = build3(BIND_EXPR, void_type_node,
+		       BLOCK_VARS (block), body, block);
+    TREE_SIDE_EFFECTS (bind) = 1;
+    return bind;
   }
 
   // Like end_scope, but also push it into the outer statement-tree.
@@ -452,6 +454,7 @@ public:
 	tree ctor = build_constructor(build_ctype(satype), elms);
 	tree decl = build_artificial_decl(TREE_TYPE (ctor), ctor);
 	TREE_READONLY (decl) = 1;
+	d_pushdecl(decl);
 	rest_of_decl_compilation(decl, 1, 0);
 
 	tree args[2];

--- a/gcc/d/typeinfo.cc
+++ b/gcc/d/typeinfo.cc
@@ -32,6 +32,7 @@
 #include "fold-const.h"
 #include "diagnostic.h"
 #include "stringpool.h"
+#include "toplev.h"
 
 #include "d-tree.h"
 #include "d-codegen.h"
@@ -510,11 +511,15 @@ public:
 	CONSTRUCTOR_APPEND_ELT (elms, size_int(i), build_address(s->Stree));
       }
     tree ctor = build_constructor(build_ctype(satype), elms);
+    tree decl = build_artificial_decl(TREE_TYPE (ctor), ctor);
 
     tree type = build_ctype(Type::tvoid->arrayOf());
     tree length = size_int(ti->arguments->dim);
-    tree ptr = build_address(build_artificial_decl(TREE_TYPE (ctor), ctor));
+    tree ptr = build_address(decl);
     this->set_field("elements", d_array_value(type, length, ptr));
+
+    d_pushdecl(decl);
+    rest_of_decl_compilation(decl, 1, 0);
   }
 };
 


### PR DESCRIPTION
Helps at least the debug generator to keep track of the correct hierachy and references of all var, function, and type declarations.

Also a step in the direction to improve hints for the backend to remove unreferenced nested symbols entirely.  But for now we add anything that is marked TREE_STATIC.

Another change separated from #236, testing before updating GCC version.
