### PR TITLE
Backport fix for DMD 16116

### DIFF
--- a/gcc/d/dfrontend/cast.c
+++ b/gcc/d/dfrontend/cast.c
@@ -3136,6 +3136,8 @@ Lcc:
     {
         if (t1->ty != t2->ty)
         {
+            if (t1->ty == Tvector || t2->ty == Tvector)
+                goto Lincompatible;
             e1 = integralPromotions(e1, sc);
             e2 = integralPromotions(e2, sc);
             t1 = e1->type;

--- a/gcc/testsuite/gdc.test/fail_compilation/test16116.d
+++ b/gcc/testsuite/gdc.test/fail_compilation/test16116.d
@@ -1,0 +1,16 @@
+/*
+REQUIRED_ARGS: -m64
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+fail_compilation/test16116.d(15): Error: incompatible types for ((v) * (i)): '__vector(short[8])' and 'int'
+---
+*/
+
+// https://issues.dlang.org/show_bug.cgi?id=16116
+
+void foo() {
+    __vector(short[8]) v;
+    int i;
+    v = v * i;
+}


### PR DESCRIPTION
Trivial, and because I have a vested interest in SIMD-related frontend bugs being fixed. ;-)

This is safe to add, as I have no intention of supporting any of the front-end releases between 2.069, through to whenever we decide to switch over.  We'll need to backport C++/D co-operability fixes (ie: `CTFloat`) anyway.  So any other backports are welcome.