### PR TITLE
Use needsCodegen rather than isRoot for determining the static/extern of a template symbol.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2016-12-04  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-decls.cc (get_symbol_decl): Use needsCodegen to determine whether
+	template instance is extern or not.
+
 2016-12-02  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-glue.cc (escapePath): Move to dfrontend.

--- a/gcc/d/d-decls.cc
+++ b/gcc/d/d-decls.cc
@@ -351,8 +351,7 @@ get_symbol_decl (Declaration *decl)
 	  D_DECL_ONE_ONLY (decl->csym) = 1;
 	  D_DECL_IS_TEMPLATE (decl->csym) = 1;
 
-	  if (!DECL_EXTERNAL (decl->csym)
-	      && ti->minst && ti->minst->isRoot())
+	  if (!DECL_EXTERNAL (decl->csym) && ti->needsCodegen ())
 	    TREE_STATIC (decl->csym) = 1;
 	  else
 	    DECL_EXTERNAL (decl->csym) = 1;


### PR DESCRIPTION
This is noticed when building with --enable-default-pie, where calls to extern functions should be marked `@PLT`.  When this doesn't happen (and building with -shared-libphobos) the result is bad relocation errors in the linker.

See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=845377#32
