### PR TITLE
Updates and fixes for gdc driver

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,6 +1,6 @@
 2016-12-06  Iain Buclaw  <ibuclaw@gdcproject.org>
 
-	* d-spec.c (lang_specific_driver): Update.
+	* d-spec.c (lang_specific_driver): Remove 'added' variable.
 
 2016-12-04  Iain Buclaw  <ibuclaw@gdcproject.org>
 

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,7 @@
+2016-12-06  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-spec.c (lang_specific_driver): Update.
+
 2016-12-04  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-decls.cc (get_symbol_decl): Use needsCodegen to determine whether

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2016-12-07  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-spec.c (lang_specific_driver): Remove error handling.
+	* d-lang.cc (d_parse_file): Don't error twice.
+
 2016-12-06  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-spec.c (lang_specific_driver): Remove 'added' variable.

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -919,13 +919,8 @@ d_parse_file()
 
   // In this mode, the first file name is supposed to be a duplicate
   // of one of the input files.
-  if (fonly_arg)
-    {
-      if (strcmp(fonly_arg, main_input_filename))
-	error("-fonly= argument is different from main input file name");
-      if (strcmp(fonly_arg, in_fnames[0]))
-	error("-fonly= argument is different from first input file name");
-    }
+  if (fonly_arg && strcmp(fonly_arg, in_fnames[0]))
+    error("-fonly= argument is different from first input file name");
 
   for (size_t i = 0; i < num_in_fnames; i++)
     {

--- a/gcc/d/d-spec.c
+++ b/gcc/d/d-spec.c
@@ -97,11 +97,6 @@ lang_specific_driver (cl_decoded_option **in_decoded_options,
      3  means libgphobos is needed and should be linked dynamically. */
   int library = 0;
 
-  /* The number of arguments being added to what's in argv, other than
-     libraries.  We use this to track the number of times we've inserted
-     -xd/-xnone.  */
-  int added = 0;
-
   /* The new argument list will be contained in this.  */
   cl_decoded_option *new_decoded_options;
 
@@ -185,13 +180,11 @@ lang_specific_driver (cl_decoded_option **in_decoded_options,
 	  break;
 
 	case OPT_nophoboslib:
-	  added = 1;
 	  need_phobos = false;
 	  args[i] |= SKIPOPT;
 	  break;
 
 	case OPT_defaultlib_:
-	  added = 1;
 	  need_phobos = false;
 	  args[i] |= SKIPOPT;
 	  if (defaultlib != NULL)
@@ -206,7 +199,6 @@ lang_specific_driver (cl_decoded_option **in_decoded_options,
 	  break;
 
 	case OPT_debuglib_:
-	  added = 1;
 	  need_phobos = false;
 	  args[i] |= SKIPOPT;
 	  if (debuglib != NULL)
@@ -359,13 +351,6 @@ lang_specific_driver (cl_decoded_option **in_decoded_options,
 	}
     }
 
-  /* If we know we don't have to do anything, bail now.  */
-  if (!added && library <= 0 && !only_source_option)
-    {
-      free (args);
-      return;
-    }
-
   /* There's no point adding -shared-libgcc if we don't have a shared
      libgcc.  */
 #ifndef ENABLE_SHARED_LIBGCC
@@ -373,10 +358,7 @@ lang_specific_driver (cl_decoded_option **in_decoded_options,
 #endif
 
   /* Make sure to have room for the trailing NULL argument.  */
-  /* There is one extra argument added here for the runtime
-     library: -lgphobos.  The -pthread argument is added by
-     setting need_thread. */
-  num_args = argc + added + need_math + shared_libgcc + (library > 0) * 5 + 2;
+  num_args = argc + need_math + shared_libgcc + (library > 0) * 5 + 2;
   new_decoded_options = XNEWVEC (cl_decoded_option, num_args);
 
   i = 0;

--- a/gcc/d/d-spec.c
+++ b/gcc/d/d-spec.c
@@ -21,8 +21,6 @@ along with GCC; see the file COPYING3.  If not see
 #include "system.h"
 #include "coretypes.h"
 #include "tm.h"
-
-#include "gcc.h"
 #include "opts.h"
 
 /* This bit is set if the arguments is a D source file. */
@@ -185,28 +183,24 @@ lang_specific_driver (cl_decoded_option **in_decoded_options,
 	  break;
 
 	case OPT_defaultlib_:
-	  need_phobos = false;
-	  args[i] |= SKIPOPT;
 	  if (defaultlib != NULL)
 	    free (CONST_CAST (char *, defaultlib));
-	  if (arg == NULL)
-	    error ("missing argument to 'defaultlib=' option");
-	  else
+	  if (arg != NULL)
 	    {
+	      need_phobos = false;
+	      args[i] |= SKIPOPT;
 	      defaultlib = XNEWVEC (char, strlen (arg));
 	      strcpy (CONST_CAST (char *, defaultlib), arg);
 	    }
 	  break;
 
 	case OPT_debuglib_:
-	  need_phobos = false;
-	  args[i] |= SKIPOPT;
 	  if (debuglib != NULL)
 	    free (CONST_CAST (char *, debuglib));
-	  if (arg == NULL)
-	    error ("missing argument to 'debuglib=' option");
-	  else
+	  if (arg != NULL)
 	    {
+	      need_phobos = false;
+	      args[i] |= SKIPOPT;
 	      debuglib = XNEWVEC (char, strlen (arg));
 	      strcpy (CONST_CAST (char *, debuglib), arg);
 	    }


### PR DESCRIPTION
- Replace int with bool, initialize on declaration.
- Remove added variable and logic. Fixes the following bogus error:
```
gdc: error: unrecognized command line option ‘-shared-libphobos’; did you mean ‘-shared-libphobos’?
```
- Move error handling out of lang_specific_driver.