### PR TITLE
Move check for generic builtins to build_dtype

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2016-12-11  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-builtins.cc (build_dtype): Don't build generic function types.
+	(d_build_builtins_module): Remove check.
+
 2016-12-10  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-codegen.cc (build_vindex_ref): Move saving of object to callers.


### PR DESCRIPTION
Despite the check, generic builtins were being pushed into the builtins module anyway.

This fixes that (diff attached):
```
@@ -258,7 +258,6 @@ extern (C)
 	extern pure nothrow @nogc @trusted double __builtin_scalbn(in double, in int);
 	extern pure nothrow @nogc @trusted float __builtin_scalbnf(in float, in int);
 	extern pure nothrow @nogc @trusted real __builtin_scalbnl(in real, in int);
-	extern pure nothrow @nogc @trusted int __builtin_signbit();
 	extern pure nothrow @nogc @trusted int __builtin_signbitf(in float);
 	extern pure nothrow @nogc @trusted int __builtin_signbitl(in real);
 	extern pure nothrow @nogc @trusted int __builtin_signbitd32(in float);
@@ -460,12 +459,6 @@ extern (C)
 	extern pure nothrow @nogc @trusted int __builtin_iswxdigit(in uint);
 	extern pure nothrow @nogc @trusted uint __builtin_towlower(in uint);
 	extern pure nothrow @nogc @trusted uint __builtin_towupper(in uint);
-	extern pure nothrow @nogc @safe bool __builtin_add_overflow();
-	extern pure nothrow @nogc @safe bool __builtin_sub_overflow();
-	extern pure nothrow @nogc @safe bool __builtin_mul_overflow();
-	extern pure nothrow @nogc @safe bool __builtin_add_overflow_p();
-	extern pure nothrow @nogc @safe bool __builtin_sub_overflow_p();
-	extern pure nothrow @nogc @safe bool __builtin_mul_overflow_p();
 	extern pure nothrow @nogc @safe bool __builtin_sadd_overflow(in int, in int, in int*);
 	extern pure nothrow @nogc @safe bool __builtin_saddl_overflow(in long, in long, in long*);
 	extern pure nothrow @nogc @safe bool __builtin_saddll_overflow(in long, in long, in long*);
@@ -486,21 +479,16 @@ extern (C)
 	extern pure nothrow @nogc @safe bool __builtin_umulll_overflow(in ulong, in ulong, in ulong*);
 	extern nothrow @nogc @trusted void __builtin_abort();
 	extern pure nothrow @nogc @trusted int __builtin_abs(in int);
-	extern pure nothrow @nogc @safe void* __builtin_aggregate_incoming_address();
 	extern nothrow @nogc @trusted void* __builtin_alloca(in ulong);
-	extern pure nothrow @nogc @safe void* __builtin_apply(in void function(), in void*, in ulong);
-	extern pure nothrow @nogc @safe void* __builtin_apply_args();
 	extern pure nothrow @nogc @safe ushort __builtin_bswap16(in ushort);
 	extern pure nothrow @nogc @safe uint __builtin_bswap32(in uint);
 	extern pure nothrow @nogc @safe ulong __builtin_bswap64(in ulong);
 	extern nothrow @nogc @trusted void __builtin___clear_cache(in void*, in void*);
 	extern nothrow @nogc @trusted void* __builtin_calloc(in ulong, in ulong);
-	extern pure nothrow @nogc @safe int __builtin_classify_type();
 	extern pure nothrow @nogc @safe int __builtin_clz(in uint);
 	extern pure nothrow @nogc @safe int __builtin_clzimax(in ulong);
 	extern pure nothrow @nogc @safe int __builtin_clzl(in ulong);
 	extern pure nothrow @nogc @safe int __builtin_clzll(in ulong);
-	extern pure nothrow @nogc @safe int __builtin_constant_p();
 	extern pure nothrow @nogc @safe int __builtin_ctz(in uint);
 	extern pure nothrow @nogc @safe int __builtin_ctzimax(in ulong);
 	extern pure nothrow @nogc @safe int __builtin_ctzl(in ulong);
@@ -544,32 +532,20 @@ extern (C)
 	extern pure nothrow @nogc @trusted int __builtin_finited64(in double);
 	extern pure nothrow @nogc @trusted int __builtin_finited128(in real);
 	extern pure nothrow @nogc @safe int __builtin_fpclassify(in int, in int, in int, in int, in int, ...);
-	extern pure nothrow @nogc @safe int __builtin_isfinite();
-	extern pure nothrow @nogc @safe int __builtin_isinf_sign();
-	extern pure nothrow @nogc @trusted int __builtin_isinf();
 	extern pure nothrow @nogc @trusted int __builtin_isinff(in float);
 	extern pure nothrow @nogc @trusted int __builtin_isinfl(in real);
 	extern pure nothrow @nogc @trusted int __builtin_isinfd32(in float);
 	extern pure nothrow @nogc @trusted int __builtin_isinfd64(in double);
 	extern pure nothrow @nogc @trusted int __builtin_isinfd128(in real);
-	extern pure nothrow @nogc @trusted int __builtin_isnan();
 	extern pure nothrow @nogc @trusted int __builtin_isnanf(in float);
 	extern pure nothrow @nogc @trusted int __builtin_isnanl(in real);
 	extern pure nothrow @nogc @trusted int __builtin_isnand32(in float);
 	extern pure nothrow @nogc @trusted int __builtin_isnand64(in double);
 	extern pure nothrow @nogc @trusted int __builtin_isnand128(in real);
-	extern pure nothrow @nogc @safe int __builtin_isnormal();
-	extern pure nothrow @nogc @safe int __builtin_isgreater();
-	extern pure nothrow @nogc @safe int __builtin_isgreaterequal();
-	extern pure nothrow @nogc @safe int __builtin_isless();
-	extern pure nothrow @nogc @safe int __builtin_islessequal();
-	extern pure nothrow @nogc @safe int __builtin_islessgreater();
-	extern pure nothrow @nogc @safe int __builtin_isunordered();
 	extern pure nothrow @nogc @trusted long __builtin_labs(in long);
 	extern pure nothrow @nogc @trusted long __builtin_llabs(in long);
 	extern pure nothrow @nogc @safe void __builtin_longjmp(in void*, in int);
 	extern nothrow @nogc @trusted void* __builtin_malloc(in ulong);
-	extern pure nothrow @nogc @safe void* __builtin_next_arg();
 	extern pure nothrow @nogc @safe int __builtin_parity(in uint);
 	extern pure nothrow @nogc @safe int __builtin_parityimax(in ulong);
 	extern pure nothrow @nogc @safe int __builtin_parityl(in ulong);
@@ -583,7 +559,6 @@ extern (C)
 	extern nothrow @nogc @trusted void* __builtin_realloc(in void*, in ulong);
 	extern pure nothrow @nogc @safe void __builtin_return(in void*);
 	extern pure nothrow @nogc @safe void* __builtin_return_address(in uint);
-	extern pure nothrow @nogc @safe void* __builtin_saveregs();
 	extern pure nothrow @nogc @safe int __builtin_setjmp(in void*);
 	extern nothrow @nogc @trusted long __builtin_strfmon(in char*, in ulong, in char*, ...);
 	extern nothrow @nogc @trusted ulong __builtin_strftime(in char*, in ulong, in char*, in void*);
@@ -624,82 +599,66 @@ extern (C)
 	extern pure nothrow @nogc @safe char* __builtin_FILE();
 	extern pure nothrow @nogc @safe char* __builtin_FUNCTION();
 	extern pure nothrow @nogc @safe int __builtin_LINE();
-	extern pure nothrow @nogc @safe void __sync_fetch_and_add();
 	extern pure nothrow @nogc @safe ubyte __sync_fetch_and_add_1(in void*, in ubyte);
 	extern pure nothrow @nogc @safe ushort __sync_fetch_and_add_2(in void*, in ushort);
 	extern pure nothrow @nogc @safe uint __sync_fetch_and_add_4(in void*, in uint);
 	extern pure nothrow @nogc @safe ulong __sync_fetch_and_add_8(in void*, in ulong);
-	extern pure nothrow @nogc @safe void __sync_fetch_and_sub();
 	extern pure nothrow @nogc @safe ubyte __sync_fetch_and_sub_1(in void*, in ubyte);
 	extern pure nothrow @nogc @safe ushort __sync_fetch_and_sub_2(in void*, in ushort);
 	extern pure nothrow @nogc @safe uint __sync_fetch_and_sub_4(in void*, in uint);
 	extern pure nothrow @nogc @safe ulong __sync_fetch_and_sub_8(in void*, in ulong);
-	extern pure nothrow @nogc @safe void __sync_fetch_and_or();
 	extern pure nothrow @nogc @safe ubyte __sync_fetch_and_or_1(in void*, in ubyte);
 	extern pure nothrow @nogc @safe ushort __sync_fetch_and_or_2(in void*, in ushort);
 	extern pure nothrow @nogc @safe uint __sync_fetch_and_or_4(in void*, in uint);
 	extern pure nothrow @nogc @safe ulong __sync_fetch_and_or_8(in void*, in ulong);
-	extern pure nothrow @nogc @safe void __sync_fetch_and_and();
 	extern pure nothrow @nogc @safe ubyte __sync_fetch_and_and_1(in void*, in ubyte);
 	extern pure nothrow @nogc @safe ushort __sync_fetch_and_and_2(in void*, in ushort);
 	extern pure nothrow @nogc @safe uint __sync_fetch_and_and_4(in void*, in uint);
 	extern pure nothrow @nogc @safe ulong __sync_fetch_and_and_8(in void*, in ulong);
-	extern pure nothrow @nogc @safe void __sync_fetch_and_xor();
 	extern pure nothrow @nogc @safe ubyte __sync_fetch_and_xor_1(in void*, in ubyte);
 	extern pure nothrow @nogc @safe ushort __sync_fetch_and_xor_2(in void*, in ushort);
 	extern pure nothrow @nogc @safe uint __sync_fetch_and_xor_4(in void*, in uint);
 	extern pure nothrow @nogc @safe ulong __sync_fetch_and_xor_8(in void*, in ulong);
-	extern pure nothrow @nogc @safe void __sync_fetch_and_nand();
 	extern pure nothrow @nogc @safe ubyte __sync_fetch_and_nand_1(in void*, in ubyte);
 	extern pure nothrow @nogc @safe ushort __sync_fetch_and_nand_2(in void*, in ushort);
 	extern pure nothrow @nogc @safe uint __sync_fetch_and_nand_4(in void*, in uint);
 	extern pure nothrow @nogc @safe ulong __sync_fetch_and_nand_8(in void*, in ulong);
-	extern pure nothrow @nogc @safe void __sync_add_and_fetch();
 	extern pure nothrow @nogc @safe ubyte __sync_add_and_fetch_1(in void*, in ubyte);
 	extern pure nothrow @nogc @safe ushort __sync_add_and_fetch_2(in void*, in ushort);
 	extern pure nothrow @nogc @safe uint __sync_add_and_fetch_4(in void*, in uint);
 	extern pure nothrow @nogc @safe ulong __sync_add_and_fetch_8(in void*, in ulong);
-	extern pure nothrow @nogc @safe void __sync_sub_and_fetch();
 	extern pure nothrow @nogc @safe ubyte __sync_sub_and_fetch_1(in void*, in ubyte);
 	extern pure nothrow @nogc @safe ushort __sync_sub_and_fetch_2(in void*, in ushort);
 	extern pure nothrow @nogc @safe uint __sync_sub_and_fetch_4(in void*, in uint);
 	extern pure nothrow @nogc @safe ulong __sync_sub_and_fetch_8(in void*, in ulong);
-	extern pure nothrow @nogc @safe void __sync_or_and_fetch();
 	extern pure nothrow @nogc @safe ubyte __sync_or_and_fetch_1(in void*, in ubyte);
 	extern pure nothrow @nogc @safe ushort __sync_or_and_fetch_2(in void*, in ushort);
 	extern pure nothrow @nogc @safe uint __sync_or_and_fetch_4(in void*, in uint);
 	extern pure nothrow @nogc @safe ulong __sync_or_and_fetch_8(in void*, in ulong);
-	extern pure nothrow @nogc @safe void __sync_and_and_fetch();
 	extern pure nothrow @nogc @safe ubyte __sync_and_and_fetch_1(in void*, in ubyte);
 	extern pure nothrow @nogc @safe ushort __sync_and_and_fetch_2(in void*, in ushort);
 	extern pure nothrow @nogc @safe uint __sync_and_and_fetch_4(in void*, in uint);
 	extern pure nothrow @nogc @safe ulong __sync_and_and_fetch_8(in void*, in ulong);
-	extern pure nothrow @nogc @safe void __sync_xor_and_fetch();
 	extern pure nothrow @nogc @safe ubyte __sync_xor_and_fetch_1(in void*, in ubyte);
 	extern pure nothrow @nogc @safe ushort __sync_xor_and_fetch_2(in void*, in ushort);
 	extern pure nothrow @nogc @safe uint __sync_xor_and_fetch_4(in void*, in uint);
 	extern pure nothrow @nogc @safe ulong __sync_xor_and_fetch_8(in void*, in ulong);
-	extern pure nothrow @nogc @safe void __sync_nand_and_fetch();
 	extern pure nothrow @nogc @safe ubyte __sync_nand_and_fetch_1(in void*, in ubyte);
 	extern pure nothrow @nogc @safe ushort __sync_nand_and_fetch_2(in void*, in ushort);
 	extern pure nothrow @nogc @safe uint __sync_nand_and_fetch_4(in void*, in uint);
 	extern pure nothrow @nogc @safe ulong __sync_nand_and_fetch_8(in void*, in ulong);
-	extern pure nothrow @nogc @safe void __sync_bool_compare_and_swap();
 	extern pure nothrow @nogc @safe bool __sync_bool_compare_and_swap_1(in void*, in ubyte, in ubyte);
 	extern pure nothrow @nogc @safe bool __sync_bool_compare_and_swap_2(in void*, in ushort, in ushort);
 	extern pure nothrow @nogc @safe bool __sync_bool_compare_and_swap_4(in void*, in uint, in uint);
 	extern pure nothrow @nogc @safe bool __sync_bool_compare_and_swap_8(in void*, in ulong, in ulong);
-	extern pure nothrow @nogc @safe void __sync_val_compare_and_swap();
 	extern pure nothrow @nogc @safe ubyte __sync_val_compare_and_swap_1(in void*, in ubyte, in ubyte);
 	extern pure nothrow @nogc @safe ushort __sync_val_compare_and_swap_2(in void*, in ushort, in ushort);
 	extern pure nothrow @nogc @safe uint __sync_val_compare_and_swap_4(in void*, in uint, in uint);
 	extern pure nothrow @nogc @safe ulong __sync_val_compare_and_swap_8(in void*, in ulong, in ulong);
-	extern pure nothrow @nogc @safe void __sync_lock_test_and_set();
 	extern pure nothrow @nogc @safe ubyte __sync_lock_test_and_set_1(in void*, in ubyte);
 	extern pure nothrow @nogc @safe ushort __sync_lock_test_and_set_2(in void*, in ushort);
 	extern pure nothrow @nogc @safe uint __sync_lock_test_and_set_4(in void*, in uint);
 	extern pure nothrow @nogc @safe ulong __sync_lock_test_and_set_8(in void*, in ulong);
-	extern pure nothrow @nogc @safe void __sync_lock_release();
 	extern pure nothrow @nogc @safe void __sync_lock_release_1(in void*);
 	extern pure nothrow @nogc @safe void __sync_lock_release_2(in void*);
 	extern pure nothrow @nogc @safe void __sync_lock_release_4(in void*);
@@ -709,85 +668,69 @@ extern (C)
 	extern pure nothrow @nogc @safe bool __atomic_test_and_set(in void*, in int);
 	extern pure nothrow @nogc @safe void __atomic_clear(in void*, in int);
 	extern pure nothrow @nogc @safe void __atomic_exchange(in ulong, in void*, in void*, in void*, in int);
-	extern pure nothrow @nogc @safe void __atomic_exchange_n();
 	extern pure nothrow @nogc @safe ubyte __atomic_exchange_1(in void*, in ubyte, in int);
 	extern pure nothrow @nogc @safe ushort __atomic_exchange_2(in void*, in ushort, in int);
 	extern pure nothrow @nogc @safe uint __atomic_exchange_4(in void*, in uint, in int);
 	extern pure nothrow @nogc @safe ulong __atomic_exchange_8(in void*, in ulong, in int);
 	extern pure nothrow @nogc @safe void __atomic_load(in ulong, in void*, in void*, in int);
-	extern pure nothrow @nogc @safe void __atomic_load_n();
 	extern pure nothrow @nogc @safe ubyte __atomic_load_1(in void*, in int);
 	extern pure nothrow @nogc @safe ushort __atomic_load_2(in void*, in int);
 	extern pure nothrow @nogc @safe uint __atomic_load_4(in void*, in int);
 	extern pure nothrow @nogc @safe ulong __atomic_load_8(in void*, in int);
 	extern pure nothrow @nogc @safe bool __atomic_compare_exchange(in ulong, in void*, in void*, in void*, in int, in int);
-	extern pure nothrow @nogc @safe void __atomic_compare_exchange_n();
 	extern pure nothrow @nogc @safe bool __atomic_compare_exchange_1(in void*, in void*, in ubyte, in bool, in int, in int);
 	extern pure nothrow @nogc @safe bool __atomic_compare_exchange_2(in void*, in void*, in ushort, in bool, in int, in int);
 	extern pure nothrow @nogc @safe bool __atomic_compare_exchange_4(in void*, in void*, in uint, in bool, in int, in int);
 	extern pure nothrow @nogc @safe bool __atomic_compare_exchange_8(in void*, in void*, in ulong, in bool, in int, in int);
 	extern pure nothrow @nogc @safe void __atomic_store(in ulong, in void*, in void*, in int);
-	extern pure nothrow @nogc @safe void __atomic_store_n();
 	extern pure nothrow @nogc @safe void __atomic_store_1(in void*, in ubyte, in int);
 	extern pure nothrow @nogc @safe void __atomic_store_2(in void*, in ushort, in int);
 	extern pure nothrow @nogc @safe void __atomic_store_4(in void*, in uint, in int);
 	extern pure nothrow @nogc @safe void __atomic_store_8(in void*, in ulong, in int);
-	extern pure nothrow @nogc @safe void __atomic_add_fetch();
 	extern pure nothrow @nogc @safe ubyte __atomic_add_fetch_1(in void*, in ubyte, in int);
 	extern pure nothrow @nogc @safe ushort __atomic_add_fetch_2(in void*, in ushort, in int);
 	extern pure nothrow @nogc @safe uint __atomic_add_fetch_4(in void*, in uint, in int);
 	extern pure nothrow @nogc @safe ulong __atomic_add_fetch_8(in void*, in ulong, in int);
-	extern pure nothrow @nogc @safe void __atomic_sub_fetch();
 	extern pure nothrow @nogc @safe ubyte __atomic_sub_fetch_1(in void*, in ubyte, in int);
 	extern pure nothrow @nogc @safe ushort __atomic_sub_fetch_2(in void*, in ushort, in int);
 	extern pure nothrow @nogc @safe uint __atomic_sub_fetch_4(in void*, in uint, in int);
 	extern pure nothrow @nogc @safe ulong __atomic_sub_fetch_8(in void*, in ulong, in int);
-	extern pure nothrow @nogc @safe void __atomic_and_fetch();
 	extern pure nothrow @nogc @safe ubyte __atomic_and_fetch_1(in void*, in ubyte, in int);
 	extern pure nothrow @nogc @safe ushort __atomic_and_fetch_2(in void*, in ushort, in int);
 	extern pure nothrow @nogc @safe uint __atomic_and_fetch_4(in void*, in uint, in int);
 	extern pure nothrow @nogc @safe ulong __atomic_and_fetch_8(in void*, in ulong, in int);
-	extern pure nothrow @nogc @safe void __atomic_nand_fetch();
 	extern pure nothrow @nogc @safe ubyte __atomic_nand_fetch_1(in void*, in ubyte, in int);
 	extern pure nothrow @nogc @safe ushort __atomic_nand_fetch_2(in void*, in ushort, in int);
 	extern pure nothrow @nogc @safe uint __atomic_nand_fetch_4(in void*, in uint, in int);
 	extern pure nothrow @nogc @safe ulong __atomic_nand_fetch_8(in void*, in ulong, in int);
-	extern pure nothrow @nogc @safe void __atomic_xor_fetch();
 	extern pure nothrow @nogc @safe ubyte __atomic_xor_fetch_1(in void*, in ubyte, in int);
 	extern pure nothrow @nogc @safe ushort __atomic_xor_fetch_2(in void*, in ushort, in int);
 	extern pure nothrow @nogc @safe uint __atomic_xor_fetch_4(in void*, in uint, in int);
 	extern pure nothrow @nogc @safe ulong __atomic_xor_fetch_8(in void*, in ulong, in int);
-	extern pure nothrow @nogc @safe void __atomic_or_fetch();
 	extern pure nothrow @nogc @safe ubyte __atomic_or_fetch_1(in void*, in ubyte, in int);
 	extern pure nothrow @nogc @safe ushort __atomic_or_fetch_2(in void*, in ushort, in int);
 	extern pure nothrow @nogc @safe uint __atomic_or_fetch_4(in void*, in uint, in int);
 	extern pure nothrow @nogc @safe ulong __atomic_or_fetch_8(in void*, in ulong, in int);
-	extern pure nothrow @nogc @safe void __atomic_fetch_add();
 	extern pure nothrow @nogc @safe ubyte __atomic_fetch_add_1(in void*, in ubyte, in int);
 	extern pure nothrow @nogc @safe ushort __atomic_fetch_add_2(in void*, in ushort, in int);
 	extern pure nothrow @nogc @safe uint __atomic_fetch_add_4(in void*, in uint, in int);
 	extern pure nothrow @nogc @safe ulong __atomic_fetch_add_8(in void*, in ulong, in int);
-	extern pure nothrow @nogc @safe void __atomic_fetch_sub();
 	extern pure nothrow @nogc @safe ubyte __atomic_fetch_sub_1(in void*, in ubyte, in int);
 	extern pure nothrow @nogc @safe ushort __atomic_fetch_sub_2(in void*, in ushort, in int);
 	extern pure nothrow @nogc @safe uint __atomic_fetch_sub_4(in void*, in uint, in int);
 	extern pure nothrow @nogc @safe ulong __atomic_fetch_sub_8(in void*, in ulong, in int);
-	extern pure nothrow @nogc @safe void __atomic_fetch_and();
 	extern pure nothrow @nogc @safe ubyte __atomic_fetch_and_1(in void*, in ubyte, in int);
 	extern pure nothrow @nogc @safe ushort __atomic_fetch_and_2(in void*, in ushort, in int);
 	extern pure nothrow @nogc @safe uint __atomic_fetch_and_4(in void*, in uint, in int);
 	extern pure nothrow @nogc @safe ulong __atomic_fetch_and_8(in void*, in ulong, in int);
-	extern pure nothrow @nogc @safe void __atomic_fetch_nand();
 	extern pure nothrow @nogc @safe ubyte __atomic_fetch_nand_1(in void*, in ubyte, in int);
 	extern pure nothrow @nogc @safe ushort __atomic_fetch_nand_2(in void*, in ushort, in int);
 	extern pure nothrow @nogc @safe uint __atomic_fetch_nand_4(in void*, in uint, in int);
 	extern pure nothrow @nogc @safe ulong __atomic_fetch_nand_8(in void*, in ulong, in int);
-	extern pure nothrow @nogc @safe void __atomic_fetch_xor();
 	extern pure nothrow @nogc @safe ubyte __atomic_fetch_xor_1(in void*, in ubyte, in int);
 	extern pure nothrow @nogc @safe ushort __atomic_fetch_xor_2(in void*, in ushort, in int);
 	extern pure nothrow @nogc @safe uint __atomic_fetch_xor_4(in void*, in uint, in int);
 	extern pure nothrow @nogc @safe ulong __atomic_fetch_xor_8(in void*, in ulong, in int);
-	extern pure nothrow @nogc @safe void __atomic_fetch_or();
 	extern pure nothrow @nogc @safe ubyte __atomic_fetch_or_1(in void*, in ubyte, in int);
 	extern pure nothrow @nogc @safe ushort __atomic_fetch_or_2(in void*, in ushort, in int);
 	extern pure nothrow @nogc @safe uint __atomic_fetch_or_4(in void*, in uint, in int);
```