### PR TITLE
Build record types for ClassInfo and ModuleInfo

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,11 @@
+2016-12-12  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-decls.cc (add_moduleinfo_field): New function.
+	(layout_moduleinfo_fields): New function.
+	(get_moduleinfo_decl): Use record type for moduleinfo decl.
+	* d-objfile.cc (build_moduleinfo_symbol): Delay calling
+	get_moduleinfo_decl until after ModuleInfo type is validated.
+
 2016-12-11  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-decls.cc (copy_struct): New function.

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,11 @@
 2016-12-11  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-decls.cc (copy_struct): New function.
+	(layout_classinfo_interfaces): New function.
+	(get_classinfo_decl): Use record type for classinfo decl.
+
+2016-12-11  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* d-builtins.cc (build_dtype): Don't build generic function types.
 	(d_build_builtins_module): Remove check.
 

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -3,6 +3,8 @@
 	* d-decls.cc (copy_struct): New function.
 	(layout_classinfo_interfaces): New function.
 	(get_classinfo_decl): Use record type for classinfo decl.
+	* d-codegen.cc (create_field_decl): New function.
+	Use it instead of build_decl when creating a new FIELD_DECL.
 
 2016-12-11  Iain Buclaw  <ibuclaw@gdcproject.org>
 

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -5,6 +5,7 @@
 	(get_moduleinfo_decl): Use record type for moduleinfo decl.
 	* d-objfile.cc (build_moduleinfo_symbol): Delay calling
 	get_moduleinfo_decl until after ModuleInfo type is validated.
+	(d_finish_symbol): Remove check for unknown_type_node.
 
 2016-12-11  Iain Buclaw  <ibuclaw@gdcproject.org>
 

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -2110,16 +2110,13 @@ static tree
 build_alignment_field(HOST_WIDE_INT offset, HOST_WIDE_INT fieldpos)
 {
   tree type = d_array_type(Type::tuns8, fieldpos - offset);
-  tree field = build_decl(UNKNOWN_LOCATION, FIELD_DECL, NULL_TREE, type);
+  tree field = create_field_decl(type, NULL, 1, 1);
 
   SET_DECL_OFFSET_ALIGN (field, TYPE_ALIGN (type));
   DECL_FIELD_OFFSET (field) = size_int(offset);
   DECL_FIELD_BIT_OFFSET (field) = bitsize_zero_node;
 
   layout_decl(field, 0);
-
-  DECL_ARTIFICIAL (field) = 1;
-  DECL_IGNORED_P (field) = 1;
 
   return field;
 }
@@ -4610,11 +4607,9 @@ layout_aggregate_members(Dsymbols *members, tree context, bool inherited_p)
 	  // Insert the field declaration at it's given offset.
 	  if (var->isField())
 	    {
-	      tree ident = var->ident ? get_identifier(var->ident->string) : NULL_TREE;
-	      tree field = build_decl(UNKNOWN_LOCATION, FIELD_DECL, ident,
-				      declaration_type(var));
-	      DECL_ARTIFICIAL (field) = inherited_p;
-	      DECL_IGNORED_P (field) = inherited_p;
+	      tree field = create_field_decl(declaration_type(var),
+					     var->ident ? var->ident->string : NULL,
+					     inherited_p, inherited_p);
 	      insert_aggregate_field(var->loc, context, field, var->offset);
 
 	      // Because the front-end shares field decls across classes, don't
@@ -4667,7 +4662,7 @@ layout_aggregate_members(Dsymbols *members, tree context, bool inherited_p)
 	  finish_aggregate_type(ad->anonstructsize, ad->anonalignsize, type, NULL);
 
 	  // And make the corresponding data member.
-	  tree field = build_decl(UNKNOWN_LOCATION, FIELD_DECL, NULL, type);
+	  tree field = create_field_decl(type, NULL, 0, 0);
 	  insert_aggregate_field(ad->loc, context, field, ad->anonoffset);
 	  continue;
 	}
@@ -4719,21 +4714,15 @@ layout_aggregate_type(AggregateDeclaration *decl, tree type, AggregateDeclaratio
 	  tree objtype = TREE_TYPE (build_ctype(cd->type));
 
 	  // Add the virtual table pointer, and optionally the monitor fields.
-	  tree field = build_decl(UNKNOWN_LOCATION, FIELD_DECL,
-				  get_identifier("__vptr"), vtbl_ptr_type_node);
+	  tree field = create_field_decl(vtbl_ptr_type_node, "__vptr", 1, inherited_p);
 	  DECL_VIRTUAL_P (field) = 1;
 	  TYPE_VFIELD (type) = field;
 	  DECL_FCONTEXT (field) = objtype;
-	  DECL_ARTIFICIAL (field) = 1;
-	  DECL_IGNORED_P (field) = inherited_p;
 	  insert_aggregate_field(decl->loc, type, field, 0);
 
 	  if (!cd->cpp)
 	    {
-	      field = build_decl(UNKNOWN_LOCATION, FIELD_DECL,
-				 get_identifier("__monitor"), ptr_type_node);
-	      DECL_ARTIFICIAL (field) = 1;
-	      DECL_IGNORED_P (field) = inherited_p;
+	      field = create_field_decl(ptr_type_node, "__monitor", 1, inherited_p);
 	      insert_aggregate_field(decl->loc, type, field, Target::ptrsize);
 	    }
 	}
@@ -4760,10 +4749,8 @@ layout_aggregate_type(AggregateDeclaration *decl, tree type, AggregateDeclaratio
       for (size_t i = 0; i < cd->vtblInterfaces->dim; i++)
 	{
 	  BaseClass *bc = (*cd->vtblInterfaces)[i];
-	  tree field = build_decl(UNKNOWN_LOCATION, FIELD_DECL, NULL_TREE,
-				  build_ctype(Type::tvoidptr->pointerTo()));
-	  DECL_ARTIFICIAL (field) = 1;
-	  DECL_IGNORED_P (field) = 1;
+	  tree field = create_field_decl(build_ctype(Type::tvoidptr->pointerTo()),
+					 NULL, 1, 1);
 	  insert_aggregate_field(decl->loc, type, field, bc->offset);
 	}
     }
@@ -4825,6 +4812,20 @@ finish_aggregate_type(unsigned structsize, unsigned alignsize, tree type,
       TYPE_USER_ALIGN (t) = TYPE_USER_ALIGN (type);
       gcc_assert(TYPE_MODE (t) == TYPE_MODE (type));
     }
+}
+
+// Create a declaration for field NAME of a given TYPE, setting the flags
+// for whether the field is ARTIFICIAL and/or IGNORED.
+
+tree
+create_field_decl (tree type, const char *name, int artificial, int ignored)
+{
+  tree decl = build_decl (UNKNOWN_LOCATION, FIELD_DECL,
+			  name ? get_identifier (name) : NULL_TREE, type);
+  DECL_ARTIFICIAL (decl) = artificial;
+  DECL_IGNORED_P (decl) = ignored;
+
+  return decl;
 }
 
 // Find the field inside aggregate TYPE identified by IDENT at field OFFSET.

--- a/gcc/d/d-codegen.h
+++ b/gcc/d/d-codegen.h
@@ -180,6 +180,7 @@ extern tree expand_intrinsic (tree callexp);
 extern void layout_aggregate_type(AggregateDeclaration *decl, tree type, AggregateDeclaration *base);
 extern void insert_aggregate_field(const Loc& loc, tree type, tree field, size_t offset);
 extern void finish_aggregate_type(unsigned structsize, unsigned alignsize, tree type, UserAttributeDeclaration *declattrs);
+extern tree create_field_decl(tree type, const char *name, int artificial, int ignored);
 extern tree find_aggregate_field(tree type, tree ident, tree offset = NULL_TREE);
 
 extern bool empty_aggregate_p(tree type);

--- a/gcc/d/d-decls.cc
+++ b/gcc/d/d-decls.cc
@@ -124,8 +124,6 @@ get_symbol_decl (Declaration *decl)
 			      get_identifier (decl->ident->string), NULL_TREE);
 
       /* Set function type afterwards as there could be self references.  */
-      //gcc_assert (fd->tintro == NULL || fd->tintro == fd->type);
-      //TREE_TYPE (decl->csym) = build_ctype (fd->tintro ? fd->tintro : fd->type);
       TREE_TYPE (decl->csym) = build_ctype (fd->type);
 
       if (!fd->fbody)
@@ -743,11 +741,9 @@ layout_classinfo_interfaces (ClassDeclaration *decl, tree type)
 	 about the vtables that follow.  */
       if (Type::typeinterface)
 	{
-	  field = build_decl (UNKNOWN_LOCATION, FIELD_DECL, NULL_TREE,
-			      d_array_type (Type::typeinterface->type,
-					    decl->vtblInterfaces->dim));
-	  DECL_ARTIFICIAL (field) = 1;
-	  DECL_IGNORED_P (field) = 1;
+	  field = create_field_decl (d_array_type (Type::typeinterface->type,
+						   decl->vtblInterfaces->dim),
+				     NULL, 1, 1);
 	  insert_aggregate_field (decl->loc, type, field,
 				  Type::typeinfoclass->structsize);
 	}
@@ -761,10 +757,9 @@ layout_classinfo_interfaces (ClassDeclaration *decl, tree type)
 
 	  if (id->vtbl.dim && offset != ~0u)
 	    {
-	      field = build_decl (UNKNOWN_LOCATION, FIELD_DECL, NULL_TREE,
-				  d_array_type (Type::tvoidptr, id->vtbl.dim));
-	      DECL_ARTIFICIAL (field) = 1;
-	      DECL_IGNORED_P (field) = 1;
+	      field = create_field_decl (d_array_type (Type::tvoidptr,
+						       id->vtbl.dim),
+					 NULL, 1, 1);
 	      insert_aggregate_field (decl->loc, type, field, offset);
 	    }
 	}
@@ -781,15 +776,12 @@ layout_classinfo_interfaces (ClassDeclaration *decl, tree type)
 
 	  if (id->vtbl.dim && offset != ~0u)
 	    {
-	      tree field;
-
 	      if (type == orig_type)
 		type = copy_struct (type);
 
-	      field = build_decl (UNKNOWN_LOCATION, FIELD_DECL, NULL_TREE,
-				  d_array_type (Type::tvoidptr, id->vtbl.dim));
-	      DECL_ARTIFICIAL (field) = 1;
-	      DECL_IGNORED_P (field) = 1;
+	      tree field = create_field_decl (d_array_type (Type::tvoidptr,
+							    id->vtbl.dim),
+					      NULL, 1, 1);
 	      insert_aggregate_field (decl->loc, type, field, offset);
 	    }
 	}

--- a/gcc/d/d-decls.cc
+++ b/gcc/d/d-decls.cc
@@ -674,6 +674,100 @@ make_thunk (FuncDeclaration *decl, int offset)
   return thunk;
 }
 
+/* Return a copy of TYPE but safe to modify in any way.  */
+
+static tree
+copy_struct (tree type)
+{
+  tree newtype = build_distinct_type_copy (type);
+  TYPE_FIELDS (newtype) = copy_list (TYPE_FIELDS (type));
+
+  for (tree field = TYPE_FIELDS (newtype); field; field = DECL_CHAIN (field))
+    DECL_FIELD_CONTEXT (field) = newtype;
+
+  return newtype;
+}
+
+/* Convenience function for layout_moduleinfo_fields.  Adds a field of TYPE to
+   REC_TYPE at OFFSET, incrementing the offset to the next field position.  */
+
+static void
+add_moduleinfo_field (tree type, tree rec_type, size_t& offset)
+{
+  tree field = create_field_decl (type, NULL, 1, 1);
+  insert_aggregate_field (Module::moduleinfo->loc, rec_type, field, offset);
+  offset += int_size_in_bytes (type);
+}
+
+/* Layout fields that immediately come after the moduleinfo TYPE for DECL.
+   Data relating to the module is packed into the type on an as-needed
+   basis, this is done to keep its size to a minimum.  */
+
+tree
+layout_moduleinfo_fields (Module *decl, tree type)
+{
+  size_t offset = Module::moduleinfo->structsize;
+
+  type = copy_struct (type);
+
+  /* First fields added are all the function pointers.  */
+  if (decl->sctor)
+    add_moduleinfo_field (ptr_type_node, type, offset);
+  if (decl->sdtor)
+    add_moduleinfo_field (ptr_type_node, type, offset);
+  if (decl->ssharedctor)
+    add_moduleinfo_field (ptr_type_node, type, offset);
+  if (decl->sshareddtor)
+    add_moduleinfo_field (ptr_type_node, type, offset);
+  if (decl->findGetMembers ())
+    add_moduleinfo_field (ptr_type_node, type, offset);
+  if (decl->sictor)
+    add_moduleinfo_field (ptr_type_node, type, offset);
+  if (decl->stest)
+    add_moduleinfo_field (ptr_type_node, type, offset);
+
+  /* Array of module imports is layed out as a length field, followed by
+     a static array of ModuleInfo pointers.  */
+  size_t aimports_dim = decl->aimports.dim;
+  for (size_t i = 0; i < decl->aimports.dim; i++)
+    {
+      Module *mi = decl->aimports[i];
+      if (!mi->needmoduleinfo)
+	aimports_dim--;
+    }
+
+  if (aimports_dim)
+    {
+      Type *tn = Module::moduleinfo->type->pointerTo ();
+      add_moduleinfo_field (size_type_node, type, offset);
+      add_moduleinfo_field (d_array_type (tn, aimports_dim), type, offset);
+    }
+
+  /* Array of local ClassInfo decls are layed out in the same way.  */
+  ClassDeclarations aclasses;
+  for (size_t i = 0; i < decl->members->dim; i++)
+    {
+      Dsymbol *member = (*decl->members)[i];
+      member->addLocalClass (&aclasses);
+    }
+
+  if (aclasses.dim)
+    {
+      Type *tn = Type::typeinfoclass->type;
+      add_moduleinfo_field (size_type_node, type, offset);
+      add_moduleinfo_field (d_array_type (tn, aclasses.dim), type, offset);
+    }
+
+  /* Lastly, the name of the module is a static char array.  */
+  size_t namelen = strlen (decl->toPrettyChars ()) + 1;
+  add_moduleinfo_field (d_array_type (Type::tchar, namelen), type, offset);
+
+  TYPE_SIZE (type) = NULL_TREE;
+  layout_type (type);
+
+  return type;
+}
+
 /* Get the VAR_DECL of the ModuleInfo for DECL.  If this does not yet exist,
    create it.  The ModuleInfo decl is used to keep track of constructors,
    destructors, unittests, members, classes, and imports for the given module.
@@ -688,7 +782,8 @@ get_moduleinfo_decl (Module *decl)
   tree ident = make_internal_name (decl, "__ModuleInfo", "Z");
 
   decl->csym = build_decl (BUILTINS_LOCATION, VAR_DECL,
-			   IDENTIFIER_PRETTY_NAME (ident), unknown_type_node);
+			   IDENTIFIER_PRETTY_NAME (ident),
+			   build_ctype (Module::moduleinfo->type));
   set_decl_location (decl->csym, decl);
   DECL_LANG_SPECIFIC (decl->csym) = build_lang_decl (NULL);
   SET_DECL_ASSEMBLER_NAME (decl->csym, ident);
@@ -706,20 +801,6 @@ get_moduleinfo_decl (Module *decl)
   DECL_EXTERNAL (decl->csym) = 1;
 
   return decl->csym;
-}
-
-/* Return a copy of TYPE but safe to modify in any way.  */
-
-static tree
-copy_struct (tree type)
-{
-  tree newtype = build_distinct_type_copy (type);
-  TYPE_FIELDS (newtype) = copy_list (TYPE_FIELDS (type));
-
-  for (tree field = TYPE_FIELDS (newtype); field; field = DECL_CHAIN (field))
-    DECL_FIELD_CONTEXT (field) = newtype;
-
-  return newtype;
 }
 
 /* Layout fields that immediately come after the classinfo TYPE for DECL if

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -962,8 +962,6 @@ TypeInfoDeclaration::toObjFile()
 static tree
 build_moduleinfo_symbol(Module *m)
 {
-  tree msym = get_moduleinfo_decl (m);
-  tree dt = NULL_TREE;
   ClassDeclarations aclasses;
   FuncDeclaration *sgetmembers;
 
@@ -1010,10 +1008,15 @@ build_moduleinfo_symbol(Module *m)
 
   flags |= MIname;
 
+  tree msym = get_moduleinfo_decl (m);
+  TREE_TYPE (msym) = layout_moduleinfo_fields (m, TREE_TYPE (msym));
+
   /* Put out:
    *  uint flags;
    *  uint index;
    */
+  tree dt = NULL_TREE;
+
   dt_cons (&dt, build_integer_cst (flags, build_ctype(Type::tuns32)));
   dt_cons (&dt, build_integer_cst (0, build_ctype(Type::tuns32)));
 
@@ -1097,8 +1100,9 @@ build_moduleinfo_symbol(Module *m)
       dt_cons (&dt, strtree);
     }
 
-  DECL_LANG_INITIAL (m->csym) = dt;
-  d_finish_symbol (m->csym);
+  DECL_LANG_INITIAL (msym) = dt;
+  d_finish_symbol (msym);
+
   return msym;
 }
 

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -1698,11 +1698,6 @@ d_finish_symbol (tree decl)
       if (DECL_INITIAL (decl) == NULL_TREE)
 	{
 	  tree sinit = dtvector_to_tree (DECL_LANG_INITIAL (decl));
-	  if (TREE_TYPE (decl) == unknown_type_node)
-	    {
-	      TREE_TYPE (decl) = TREE_TYPE (sinit);
-	      TYPE_NAME (TREE_TYPE (decl)) = DECL_ASSEMBLER_NAME (decl);
-	    }
 
 	  // No gain setting DECL_INITIAL if the initialiser is all zeros.
 	  // Let the backend put the symbol in bss instead, if supported.

--- a/gcc/d/d-todt.cc
+++ b/gcc/d/d-todt.cc
@@ -80,15 +80,13 @@ dt_container(dt_t *dt)
 	  if (value == error_mark_node)
 	    return error_mark_node;
 
-	  tree field = build_decl(UNKNOWN_LOCATION, FIELD_DECL, NULL_TREE, TREE_TYPE(value));
+	  tree field = create_field_decl(TREE_TYPE(value), NULL, 1, 1);
 	  tree size = TYPE_SIZE_UNIT(TREE_TYPE(value));
 
 	  DECL_FIELD_CONTEXT(field) = aggtype;
 	  DECL_FIELD_OFFSET(field) = offset;
 	  DECL_FIELD_BIT_OFFSET(field) = bitsize_zero_node;
 	  SET_DECL_OFFSET_ALIGN(field, TYPE_ALIGN(TREE_TYPE(value)));
-	  DECL_ARTIFICIAL(field) = 1;
-	  DECL_IGNORED_P(field) = 1;
 
 	  layout_decl(field, 0);
 	  fields = chainon(fields, field);

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -408,6 +408,7 @@ extern tree d_truthvalue_conversion (tree);
 extern tree make_internal_name (Dsymbol *, const char *, const char *);
 extern tree get_symbol_decl (Declaration *);
 extern tree make_thunk (FuncDeclaration *, int);
+extern tree layout_moduleinfo_fields (Module *, tree);
 extern tree get_moduleinfo_decl (Module *);
 extern tree get_typeinfo_decl (TypeInfoDeclaration *);
 extern tree get_classinfo_decl (ClassDeclaration *);

--- a/gcc/d/dfrontend/aggregate.h
+++ b/gcc/d/dfrontend/aggregate.h
@@ -180,7 +180,7 @@ public:
     // For those, today TypeInfo_Struct is generated in COMDAT.
     bool requestTypeInfo;
 
-    StructDeclaration(Loc loc, Identifier *id);
+    StructDeclaration(Loc loc, Identifier *id, bool inObject = false);
     Dsymbol *syntaxCopy(Dsymbol *s);
     void semantic(Scope *sc);
     void semanticTypeInfoMembers();

--- a/gcc/d/dfrontend/idgen.c
+++ b/gcc/d/dfrontend/idgen.c
@@ -75,6 +75,7 @@ Msgtable msgtable[] =
     { "RTInfo" },
     { "Throwable" },
     { "Error" },
+    { "Interface" },
     { "withSym", "__withSym" },
     { "result", "__result" },
     { "returnLabel", "__returnLabel" },

--- a/gcc/d/dfrontend/mtype.c
+++ b/gcc/d/dfrontend/mtype.c
@@ -74,6 +74,9 @@ ClassDeclaration *Type::typeinfoinvariant;
 ClassDeclaration *Type::typeinfoshared;
 ClassDeclaration *Type::typeinfowild;
 
+#ifdef IN_GCC
+StructDeclaration *Type::typeinterface;
+#endif
 TemplateDeclaration *Type::rtinfo;
 
 Type *Type::tvoid;

--- a/gcc/d/dfrontend/mtype.h
+++ b/gcc/d/dfrontend/mtype.h
@@ -213,6 +213,9 @@ public:
     static ClassDeclaration *typeinfoshared;
     static ClassDeclaration *typeinfowild;
 
+#ifdef IN_GCC
+    static StructDeclaration *typeinterface;
+#endif
     static TemplateDeclaration *rtinfo;
 
     static Type *basic[TMAX];

--- a/gcc/d/dfrontend/parse.c
+++ b/gcc/d/dfrontend/parse.c
@@ -2257,7 +2257,10 @@ Dsymbol *Parser::parseAggregate()
 
         case TOKstruct:
             if (id)
-                a = new StructDeclaration(loc, id);
+            {
+                bool inObject = md && !md->packages && md->id == Id::object;
+                a = new StructDeclaration(loc, id, inObject);
+            }
             else
                 anon = 1;
             break;

--- a/gcc/d/dfrontend/struct.c
+++ b/gcc/d/dfrontend/struct.c
@@ -892,7 +892,7 @@ Dsymbol *AggregateDeclaration::searchCtor()
 
 /********************************* StructDeclaration ****************************/
 
-StructDeclaration::StructDeclaration(Loc loc, Identifier *id)
+StructDeclaration::StructDeclaration(Loc loc, Identifier *id, bool inObject)
     : AggregateDeclaration(loc, id)
 {
     zeroInit = 0;       // assume false until we do semantic processing
@@ -912,8 +912,11 @@ StructDeclaration::StructDeclaration(Loc loc, Identifier *id)
     // For forward references
     type = new TypeStruct(this);
 
-    if (id == Id::ModuleInfo && !Module::moduleinfo)
-        Module::moduleinfo = this;
+    if (inObject)
+    {
+        if (id == Id::ModuleInfo && !Module::moduleinfo)
+            Module::moduleinfo = this;
+    }
 }
 
 Dsymbol *StructDeclaration::syntaxCopy(Dsymbol *s)

--- a/gcc/d/dfrontend/struct.c
+++ b/gcc/d/dfrontend/struct.c
@@ -916,6 +916,10 @@ StructDeclaration::StructDeclaration(Loc loc, Identifier *id, bool inObject)
     {
         if (id == Id::ModuleInfo && !Module::moduleinfo)
             Module::moduleinfo = this;
+#ifdef IN_GCC
+        else if (id == Id::Interface && !Type::typeinterface)
+            Type::typeinterface = this;
+#endif
     }
 }
 


### PR DESCRIPTION
This is a real win for gdb.  Finally classinfo/moduleinfo can be viewed directly from the debugger.

(Hidden fields are still hidden though).

Both of these new layout functions exposed should probably be merged into the same routine that builds the static data for ClassInfo/ModuleInfo.  I have an idea to do that once these two data types have been converted away from the old `dt_t` generator.