### PR TITLE
Also copy TYPE_METHODS in copy_struct function

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,7 @@
+2016-12-17  Johannes Pfau  <johannespfau@gmail.com>
+
+	* d-decls.cc (copy_struct): Also copy and update TYPE_METHODS.
+
 2016-12-13  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-builtins.cc (build_dtype): Cache all allocated frontend types.

--- a/gcc/d/d-decls.cc
+++ b/gcc/d/d-decls.cc
@@ -681,9 +681,13 @@ copy_struct (tree type)
 {
   tree newtype = build_distinct_type_copy (type);
   TYPE_FIELDS (newtype) = copy_list (TYPE_FIELDS (type));
+  TYPE_METHODS (newtype) = copy_list (TYPE_METHODS (type));
 
   for (tree field = TYPE_FIELDS (newtype); field; field = DECL_CHAIN (field))
     DECL_FIELD_CONTEXT (field) = newtype;
+
+  for (tree method = TYPE_METHODS (newtype); method; method = DECL_CHAIN (method))
+    DECL_CONTEXT (method) = newtype;
 
   return newtype;
 }


### PR DESCRIPTION
GCC <= 5 does not clear the TYPE_METHODS list in build_distinct_type_copy which leads to methods with a wrong CONTEXT. This causes backend errors in the DWARF output module.

We could just clear the TYPE_METHODS for GCC <= 5 instead but providing copies of the methods should be better for debug info. OTOH these methods are likely never called as the frontend only uses the default `TypeInfo_Class` methods, so this may also lead to unnecessary bloat. @ibuclaw what do you think?