### PR TITLE
Use finish_aggregate_type to complete dynamically sized types.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,9 @@
+2016-12-18  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-decls.cc (layout_moduleinfo_fields): Use finish_aggregate_type
+	instead of layout_type.
+	(layout_classinfo_interfaces): Likewise.
+
 2016-12-17  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-builtins.cc (build_dtype): Use static create method for allocating


### PR DESCRIPTION
Using layout_type may adjust the field alignments, adding alignment holes. The desired behaviour is to keep all anonymous fields packed.