### PR TITLE
Use build_typeinfo instead of get_typeinfo_decl

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,10 @@
 2016-12-18  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* typeinfo.cc (TypeInfoVisitor): Use build_typeinfo instead of
+	get_typeinfo_decl.
+
+2016-12-18  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* d-decls.cc (layout_moduleinfo_fields): Use finish_aggregate_type
 	instead of layout_type.
 	(layout_classinfo_interfaces): Likewise.


### PR DESCRIPTION
Cleans up a little most parts of the TypeInfo visitor.