### PR TITLE
[FEATURE] Support extern(C++, class) and extern(C++, struct)

### DIFF
--- a/gcc/d/dfrontend/attrib.c
+++ b/gcc/d/dfrontend/attrib.c
@@ -71,12 +71,13 @@ int AttribDeclaration::apply(Dsymbol_apply_ft_t fp, void *param)
  * the scope after it used.
  */
 Scope *AttribDeclaration::createNewScope(Scope *sc,
-        StorageClass stc, LINK linkage, Prot protection, int explicitProtection,
-        structalign_t structalign, PINLINE inlining)
+        StorageClass stc, LINK linkage, CPPMANGLE cppmangle, Prot protection,
+        int explicitProtection, structalign_t structalign, PINLINE inlining)
 {
     Scope *sc2 = sc;
     if (stc != sc->stc ||
         linkage != sc->linkage ||
+        cppmangle != sc->cppmangle ||
         !protection.isSubsetOf(sc->protection) ||
         explicitProtection != sc->explicitProtection ||
         structalign != sc->structalign ||
@@ -86,6 +87,7 @@ Scope *AttribDeclaration::createNewScope(Scope *sc,
         sc2 = sc->copy();
         sc2->stc = stc;
         sc2->linkage = linkage;
+        sc2->cppmangle = cppmangle;
         sc2->protection = protection;
         sc2->explicitProtection = explicitProtection;
         sc2->structalign = structalign;
@@ -391,7 +393,7 @@ Scope *StorageClassDeclaration::newScope(Scope *sc)
     scstc |= stc;
     //printf("scstc = x%llx\n", scstc);
 
-    return createNewScope(sc, scstc, sc->linkage, sc->protection, sc->explicitProtection, sc->structalign, sc->inlining);
+    return createNewScope(sc, scstc, sc->linkage, sc->cppmangle, sc->protection, sc->explicitProtection, sc->structalign, sc->inlining);
 }
 
 /*************************************************
@@ -530,10 +532,35 @@ Dsymbol *LinkDeclaration::syntaxCopy(Dsymbol *s)
 
 Scope *LinkDeclaration::newScope(Scope *sc)
 {
-    return createNewScope(sc, sc->stc, this->linkage, sc->protection, sc->explicitProtection, sc->structalign, sc->inlining);
+    return createNewScope(sc, sc->stc, this->linkage, sc->cppmangle, sc->protection, sc->explicitProtection, sc->structalign, sc->inlining);
 }
 
 const char *LinkDeclaration::toChars()
+{
+    return (char *)"extern ()";
+}
+
+/********************************* CPPMangleDeclaration ****************************/
+
+CPPMangleDeclaration::CPPMangleDeclaration(CPPMANGLE p, Dsymbols *decl)
+        : AttribDeclaration(decl)
+{
+    //printf("CPPMangleDeclaration(cppmangle = %d, decl = %p)\n", p, decl);
+    cppmangle = p;
+}
+
+Dsymbol *CPPMangleDeclaration::syntaxCopy(Dsymbol *s)
+{
+    assert(!s);
+    return new CPPMangleDeclaration(cppmangle, Dsymbol::arraySyntaxCopy(decl));
+}
+
+Scope *CPPMangleDeclaration::newScope(Scope *sc)
+{
+    return createNewScope(sc, sc->stc, LINKcpp, this->cppmangle, sc->protection, sc->explicitProtection, sc->structalign, sc->inlining);
+}
+
+const char *CPPMangleDeclaration::toChars()
 {
     return (char *)"extern ()";
 }
@@ -583,7 +610,7 @@ Scope *ProtDeclaration::newScope(Scope *sc)
 {
     if (pkg_identifiers)
         semantic(sc);
-    return createNewScope(sc, sc->stc, sc->linkage, this->protection, 1, sc->structalign, sc->inlining);
+    return createNewScope(sc, sc->stc, sc->linkage, sc->cppmangle, this->protection, 1, sc->structalign, sc->inlining);
 }
 
 void ProtDeclaration::addMember(Scope *sc, ScopeDsymbol *sds)
@@ -640,7 +667,7 @@ Dsymbol *AlignDeclaration::syntaxCopy(Dsymbol *s)
 
 Scope *AlignDeclaration::newScope(Scope *sc)
 {
-    return createNewScope(sc, sc->stc, sc->linkage, sc->protection, sc->explicitProtection, this->salign, sc->inlining);
+    return createNewScope(sc, sc->stc, sc->linkage, sc->cppmangle, sc->protection, sc->explicitProtection, this->salign, sc->inlining);
 }
 
 /********************************* AnonDeclaration ****************************/
@@ -842,7 +869,7 @@ Scope *PragmaDeclaration::newScope(Scope *sc)
                 inlining = PINLINEnever;
         }
 
-        return createNewScope(sc, sc->stc, sc->linkage, sc->protection, sc->explicitProtection, sc->structalign, inlining);
+        return createNewScope(sc, sc->stc, sc->linkage, sc->cppmangle, sc->protection, sc->explicitProtection, sc->structalign, inlining);
     }
     return sc;
 }

--- a/gcc/d/dfrontend/attrib.h
+++ b/gcc/d/dfrontend/attrib.h
@@ -36,8 +36,8 @@ public:
     virtual Dsymbols *include(Scope *sc, ScopeDsymbol *sds);
     int apply(Dsymbol_apply_ft_t fp, void *param);
     static Scope *createNewScope(Scope *sc,
-        StorageClass newstc, LINK linkage, Prot protection, int explictProtection,
-        structalign_t structalign, PINLINE inlining);
+        StorageClass newstc, LINK linkage, CPPMANGLE cppmangle, Prot protection,
+        int explictProtection, structalign_t structalign, PINLINE inlining);
     virtual Scope *newScope(Scope *sc);
     void addMember(Scope *sc, ScopeDsymbol *sds);
     void setScope(Scope *sc);
@@ -93,6 +93,18 @@ public:
     LINK linkage;
 
     LinkDeclaration(LINK p, Dsymbols *decl);
+    Dsymbol *syntaxCopy(Dsymbol *s);
+    Scope *newScope(Scope *sc);
+    const char *toChars();
+    void accept(Visitor *v) { v->visit(this); }
+};
+
+class CPPMangleDeclaration : public AttribDeclaration
+{
+public:
+    CPPMANGLE cppmangle;
+
+    CPPMangleDeclaration(CPPMANGLE p, Dsymbols *decl);
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     const char *toChars();

--- a/gcc/d/dfrontend/cppmangle.c
+++ b/gcc/d/dfrontend/cppmangle.c
@@ -1208,7 +1208,7 @@ public:
             if (type->sym->isUnionDeclaration())
                 buf.writeByte('T');
             else
-                buf.writeByte('U');
+                buf.writeByte(type->cppmangle == CPPMANGLEclass ? 'V' : 'U');
             mangleIdent(type->sym);
         }
         flags &= ~IS_NOT_TOP_TYPE;
@@ -1281,7 +1281,7 @@ public:
         flags |= IS_NOT_TOP_TYPE;
         mangleModifier(type);
 
-        buf.writeByte('V');
+        buf.writeByte(type->cppmangle == CPPMANGLEstruct ? 'U' : 'V');
 
         mangleIdent(type->sym);
         flags &= ~IS_NOT_TOP_TYPE;
@@ -1611,7 +1611,12 @@ private:
             name = sym->ident->toChars();
         }
         assert(name);
-        if (!is_dmc_template)
+        if (is_dmc_template)
+        {
+            if (checkAndSaveIdent(name))
+                return;
+        }
+        else
         {
             if (dont_use_back_reference)
             {

--- a/gcc/d/dfrontend/globals.h
+++ b/gcc/d/dfrontend/globals.h
@@ -285,6 +285,13 @@ enum LINK
     LINKpascal,
 };
 
+enum CPPMANGLE
+{
+    CPPMANGLEdefault,
+    CPPMANGLEstruct,
+    CPPMANGLEclass,
+};
+
 enum DYNCAST
 {
     DYNCAST_OBJECT,

--- a/gcc/d/dfrontend/hdrgen.c
+++ b/gcc/d/dfrontend/hdrgen.c
@@ -1286,6 +1286,24 @@ public:
         visit((AttribDeclaration *)d);
     }
 
+    void visit(CPPMangleDeclaration *d)
+    {
+        const char *p;
+
+        switch (d->cppmangle)
+        {
+            case CPPMANGLEclass:    p = "class";            break;
+            case CPPMANGLEstruct:   p = "struct";           break;
+            default:
+                assert(0);
+                break;
+        }
+        buf->writestring("extern (C++, ");
+        buf->writestring(p);
+        buf->writestring(") ");
+        visit((AttribDeclaration *)d);
+    }
+
     void visit(ProtDeclaration *d)
     {
         protectionToBuffer(buf, d->protection);

--- a/gcc/d/dfrontend/mtype.c
+++ b/gcc/d/dfrontend/mtype.c
@@ -7609,6 +7609,7 @@ TypeStruct::TypeStruct(StructDeclaration *sym)
 {
     this->sym = sym;
     this->att = RECfwdref;
+    this->cppmangle = CPPMANGLEdefault;
 }
 
 const char *TypeStruct::kind()
@@ -7624,6 +7625,8 @@ Type *TypeStruct::syntaxCopy()
 Type *TypeStruct::semantic(Loc loc, Scope *sc)
 {
     //printf("TypeStruct::semantic('%s')\n", sym->toChars());
+    if (deco)
+        return this;
 
     /* Don't semantic for sym because it should be deferred until
      * sizeof needed or its members accessed.
@@ -7633,6 +7636,7 @@ Type *TypeStruct::semantic(Loc loc, Scope *sc)
 
     if (sym->type->ty == Terror)
         return Type::terror;
+    this->cppmangle = sc->cppmangle;
     return merge();
 }
 
@@ -8162,6 +8166,7 @@ TypeClass::TypeClass(ClassDeclaration *sym)
 {
     this->sym = sym;
     this->att = RECfwdref;
+    this->cppmangle = CPPMANGLEdefault;
 }
 
 const char *TypeClass::kind()
@@ -8177,6 +8182,8 @@ Type *TypeClass::syntaxCopy()
 Type *TypeClass::semantic(Loc loc, Scope *sc)
 {
     //printf("TypeClass::semantic(%s)\n", sym->toChars());
+    if (deco)
+        return this;
 
     /* Don't semantic for sym because it should be deferred until
      * sizeof needed or its members accessed.
@@ -8186,6 +8193,7 @@ Type *TypeClass::semantic(Loc loc, Scope *sc)
 
     if (sym->type->ty == Terror)
         return Type::terror;
+    this->cppmangle = sc->cppmangle;
     return merge();
 }
 

--- a/gcc/d/dfrontend/mtype.h
+++ b/gcc/d/dfrontend/mtype.h
@@ -766,6 +766,7 @@ class TypeStruct : public Type
 public:
     StructDeclaration *sym;
     AliasThisRec att;
+    CPPMANGLE cppmangle;
 
     TypeStruct(StructDeclaration *sym);
     const char *kind();
@@ -834,6 +835,7 @@ class TypeClass : public Type
 public:
     ClassDeclaration *sym;
     AliasThisRec att;
+    CPPMANGLE cppmangle;
 
     TypeClass(ClassDeclaration *sym);
     const char *kind();

--- a/gcc/d/dfrontend/parse.c
+++ b/gcc/d/dfrontend/parse.c
@@ -1333,7 +1333,10 @@ LINK Parser::parseLinkage(Identifiers **pidents, CPPMANGLE *pcppmangle)
                                 }
                             }
                             else
+                            {
                                 error("identifier expected for C++ namespace");
+                                idents = NULL;  // error occurred, invalidate list of elements.
+                            }
                             break;
                         }
                     }

--- a/gcc/d/dfrontend/parse.c
+++ b/gcc/d/dfrontend/parse.c
@@ -683,7 +683,8 @@ Dsymbols *Parser::parseDeclDefs(int once, Dsymbol **pLastDecl, PrefixAttributes 
 
                 Loc linkLoc = token.loc;
                 Identifiers *idents = NULL;
-                LINK link = parseLinkage(&idents);
+                CPPMANGLE cppmangle = CPPMANGLEdefault;
+                LINK link = parseLinkage(&idents, &cppmangle);
                 if (pAttrs->link != LINKdefault)
                 {
                     if (pAttrs->link != link)
@@ -722,6 +723,11 @@ Dsymbols *Parser::parseDeclDefs(int once, Dsymbol **pLastDecl, PrefixAttributes 
                 {
                     s = new LinkDeclaration(pAttrs->link, a);
                     pAttrs->link = LINKdefault;
+                }
+                else if (cppmangle != CPPMANGLEdefault)
+                {
+                    assert(link == LINKcpp);
+                    s = new CPPMangleDeclaration(cppmangle, a);
                 }
                 break;
             }
@@ -1277,9 +1283,10 @@ Type *Parser::parseVector()
  * The parser is on the 'extern' token.
  */
 
-LINK Parser::parseLinkage(Identifiers **pidents)
+LINK Parser::parseLinkage(Identifiers **pidents, CPPMANGLE *pcppmangle)
 {
     Identifiers *idents = NULL;
+    CPPMANGLE cppmangle = CPPMANGLEdefault;
     LINK link = LINKdefault;
     nextToken();
     assert(token.value == TOKlparen);
@@ -1301,26 +1308,34 @@ LINK Parser::parseLinkage(Identifiers **pidents)
             {
                 link = LINKcpp;
                 nextToken();
-                if (token.value == TOKcomma)    // , namespaces
+                if (token.value == TOKcomma)    // , namespaces or class or struct
                 {
-                    idents = new Identifiers();
                     nextToken();
-                    while (1)
+                    if (token.value == TOKclass || token.value == TOKstruct)
                     {
-                        if (token.value == TOKidentifier)
+                        cppmangle = token.value == TOKclass ? CPPMANGLEclass : CPPMANGLEstruct;
+                        nextToken();
+                    }
+                    else
+                    {
+                        idents = new Identifiers();
+                        while (1)
                         {
-                            Identifier *idn = token.ident;
-                            idents->push(idn);
-                            nextToken();
-                            if (token.value == TOKdot)
+                            if (token.value == TOKidentifier)
                             {
+                                Identifier *idn = token.ident;
+                                idents->push(idn);
                                 nextToken();
-                                continue;
+                                if (token.value == TOKdot)
+                                {
+                                    nextToken();
+                                    continue;
+                                }
                             }
+                            else
+                                error("identifier expected for C++ namespace");
+                            break;
                         }
-                        else
-                            error("identifier expected for C++ namespace");
-                        break;
                     }
                 }
             }
@@ -1341,6 +1356,7 @@ LINK Parser::parseLinkage(Identifiers **pidents)
     }
     check(TOKrparen);
     *pidents = idents;
+    *pcppmangle = cppmangle;
     return link;
 }
 
@@ -3614,11 +3630,16 @@ void Parser::parseStorageClasses(StorageClass &storage_class, LINK &link, unsign
                     error("redundant linkage declaration");
                 sawLinkage = true;
                 Identifiers *idents = NULL;
-                link = parseLinkage(&idents);
+                CPPMANGLE cppmangle = CPPMANGLEdefault;
+                link = parseLinkage(&idents, &cppmangle);
                 if (idents)
                 {
                     error("C++ name spaces not allowed here");
                     delete idents;
+                }
+                if (cppmangle != CPPMANGLEdefault)
+                {
+                     error("C++ mangle declaration not allowed here");
                 }
                 continue;
             }

--- a/gcc/d/dfrontend/parse.h
+++ b/gcc/d/dfrontend/parse.h
@@ -68,6 +68,7 @@ public:
     Module *mod;
     ModuleDeclaration *md;
     LINK linkage;
+    CPPMANGLE cppmangle;
     Loc endloc;                 // set to location of last right curly
     int inBrackets;             // inside [] of array index or slice
     Loc lookingForElse;         // location of lonely if looking for an else
@@ -93,7 +94,7 @@ public:
     StaticAssert *parseStaticAssert();
     TypeQualified *parseTypeof();
     Type *parseVector();
-    LINK parseLinkage(Identifiers **);
+    LINK parseLinkage(Identifiers **, CPPMANGLE *);
     Identifiers *parseQualifiedIdentifier(const char *entity);
     Condition *parseDebugCondition();
     Condition *parseVersionCondition();

--- a/gcc/d/dfrontend/scope.c
+++ b/gcc/d/dfrontend/scope.c
@@ -70,6 +70,7 @@ Scope::Scope()
     this->func = NULL;
     this->slabel = NULL;
     this->linkage = LINKd;
+    this->cppmangle = CPPMANGLEdefault;
     this->inlining = PINLINEdefault;
     this->protection = Prot(PROTpublic);
     this->explicitProtection = 0;

--- a/gcc/d/dfrontend/scope.h
+++ b/gcc/d/dfrontend/scope.h
@@ -107,6 +107,7 @@ struct Scope
 
     structalign_t structalign;  // alignment for struct members
     LINK linkage;               // linkage for external functions
+    CPPMANGLE cppmangle;        // C++ mangle type
     PINLINE inlining;            // inlining strategy for functions
 
     Prot protection;            // protection for class members

--- a/gcc/d/dfrontend/visitor.h
+++ b/gcc/d/dfrontend/visitor.h
@@ -98,6 +98,7 @@ class AttribDeclaration;
 class StorageClassDeclaration;
 class DeprecatedDeclaration;
 class LinkDeclaration;
+class CPPMangleDeclaration;
 class ProtDeclaration;
 class AlignDeclaration;
 class AnonDeclaration;
@@ -389,6 +390,7 @@ public:
     virtual void visit(StorageClassDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(DeprecatedDeclaration *s) { visit((StorageClassDeclaration *)s); }
     virtual void visit(LinkDeclaration *s) { visit((AttribDeclaration *)s); }
+    virtual void visit(CPPMangleDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(ProtDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(AlignDeclaration *s) { visit((AttribDeclaration *)s); }
     virtual void visit(AnonDeclaration *s) { visit((AttribDeclaration *)s); }

--- a/gcc/testsuite/gdc.test/fail_compilation/ice17074.d
+++ b/gcc/testsuite/gdc.test/fail_compilation/ice17074.d
@@ -1,0 +1,39 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice17074.d(9): Error: identifier expected for C++ namespace
+fail_compilation/ice17074.d(9): Error: found 'cast' when expecting ')'
+fail_compilation/ice17074.d(9): Error: declaration expected, not ')'
+---
+*/
+extern(C++, cast) void ice_keyword();
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice17074.d(19): Error: identifier expected for C++ namespace
+fail_compilation/ice17074.d(19): Error: found '__overloadset' when expecting ')'
+fail_compilation/ice17074.d(19): Error: declaration expected, not ')'
+---
+*/
+extern(C++, std.__overloadset) void ice_std_keyword();
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice17074.d(29): Error: identifier expected for C++ namespace
+fail_compilation/ice17074.d(29): Error: found '...' when expecting ')'
+fail_compilation/ice17074.d(29): Error: declaration expected, not ')'
+---
+*/
+extern(C++, ...) void ice_token();
+
+/*
+TEST_OUTPUT:
+---
+fail_compilation/ice17074.d(39): Error: identifier expected for C++ namespace
+fail_compilation/ice17074.d(39): Error: found '*' when expecting ')'
+fail_compilation/ice17074.d(39): Error: declaration expected, not ')'
+---
+*/
+extern(C++, std.*) void ice_std_token();

--- a/gcc/testsuite/gdc.test/runnable/externmangle.d
+++ b/gcc/testsuite/gdc.test/runnable/externmangle.d
@@ -169,6 +169,62 @@ interface Test38
      public static void dispose(ref Test38);
 }
 
+extern(C++, class)
+struct S1
+{
+    private int val;
+    static S1* init(int);
+    int value();
+}
+
+extern(C++, class)
+struct S2(T)
+{
+    private T val;
+    static S2!T* init(int);
+    T value();
+}
+
+extern(C++, struct)
+class C1
+{
+    const(char)* data;
+
+    static C1 init(const(char)* p);
+    const(char)* getDataCPP();
+    extern(C++) const(char)* getDataD()
+    {
+        return data;
+    }
+}
+
+extern(C++, struct)
+class C2(T)
+{
+    const(T)* data;
+
+    static C2!T init(const(T)* p);
+    const(T)* getData();
+}
+
+extern(C++) int test39cpp(C2!char, S2!(int)*);
+
+void test39()
+{
+    S1* s1 = S1.init(42);
+    assert(s1.value == 42);
+    assert(S2!int.init(43).value == 43);
+    const(char)* ptr = "test".ptr;
+    C1 c1 = C1.init(ptr);
+    assert(c1.getDataCPP() == ptr);
+    assert(c1.getDataD() == ptr);
+    C2!char c2 = C2!char.init(ptr);
+    assert(c2.getData() == ptr);
+    auto result = test39cpp(c2, S2!int.init(43));
+    assert(result == 0);
+}
+
+
 void main()
 {
     test1(Foo!int());
@@ -254,4 +310,5 @@ void main()
     auto t38 = Test38.create();
     assert(t38.test(1, 2, 3) == 1);
     Test38.dispose(t38);
+    test39();
 }

--- a/gcc/testsuite/gdc.test/runnable/extra-files/externmangle.cpp
+++ b/gcc/testsuite/gdc.test/runnable/extra-files/externmangle.cpp
@@ -304,3 +304,101 @@ void Test38::dispose(Test38 *&t)
         delete t;
     t = 0;
 }
+
+class S1
+{
+    int val;
+public:
+    static S1* init(int);
+    S1(int v) : val(v) {}
+    int value();
+};
+
+S1* S1::init(int x)
+{
+    return new S1(x);
+}
+
+int S1::value()
+{
+    return val;
+}
+
+template<class T>
+class S2
+{
+    T val;
+public:
+    static S2<T>* init(T);
+    S2(T v) : val(v) {}
+    T value();
+};
+
+template<>
+S2<int>* S2<int>::init(int x)
+{
+    return new S2<int>(x);
+}
+
+template<>
+int S2<int>::value()
+{
+    return val;
+}
+
+struct C1
+{
+    const char *data;
+
+    static C1* init(const char *p);
+
+    C1(const char* p) : data(p) { }
+
+    virtual const char* getDataCPP();
+    virtual const char* getDataD();
+};
+
+C1* C1::init(const char *p)
+{
+    return new C1(p);
+}
+
+const char* C1::getDataCPP()
+{
+    return data;
+}
+
+template<class T>
+struct C2
+{
+    const T *data;
+
+    static C2* init(const T *p);
+
+    C2(const T* p) : data(p) { }
+
+    virtual const T* getData();
+};
+
+template<>
+C2<char>* C2<char>::init(const char *p)
+{
+    return new C2<char>(p);
+}
+
+template<>
+const char* C2<char>::getData()
+{
+    return data;
+}
+
+int test39cpp(C2<char>* c2, S2<int>* s2)
+{
+    C2<char>* otherC2 = C2<char>::init(c2->getData());
+    if (c2->getData() != otherC2->getData())
+        return 1;
+    S2<int>* otherS2 = S2<int>::init(s2->value());
+    if (s2->value() != otherS2->value())
+        return 2;
+    return 0;
+}


### PR DESCRIPTION
Also backported https://github.com/dlang/dmd/pull/6415

Because it is such an obvious/trivial way to crash the compiler, it's simply embarrassing.