### PR TITLE
More vector-related fixes

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -15,6 +15,10 @@
 
 2017-12-28  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* expr.cc (ExprVisitor::visit(VarExp)): Remove type forced conversion.
+
+2017-12-28  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* d-lang.cc (d_handle_option): Handle -ftransition=safe.
 	* lang.opt (ftransition=safe): Add compiler option.
 
@@ -31,6 +35,12 @@
 2017-12-27  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-lang.cc (d_parse_file): Run runDeferredSemantic2 after semantic2.
+
+2017-12-26  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* expr.cc (ExprVisitor::visit(ArrayLiteralExp)): Use getElement to
+	index elements array.
+	(ExprVisitor::visit(VectorExp)): Likewise.
 
 2017-12-25  Iain Buclaw  <ibuclaw@gdcproject.org>
 

--- a/gcc/d/d-target.cc
+++ b/gcc/d/d-target.cc
@@ -279,7 +279,8 @@ Target::loadModule (Module *m)
     }
 }
 
-/* Check whether the given Type is a supported for this target.  */
+/* Checks whether the target supports a vector type with total size SZ
+   (in bytes) and element type TYPE.  */
 
 int
 Target::checkVectorType (int sz, Type *type)

--- a/gcc/d/dfrontend/expression.c
+++ b/gcc/d/dfrontend/expression.c
@@ -10147,6 +10147,15 @@ Expression *VectorExp::syntaxCopy()
     return new VectorExp(loc, e1->syntaxCopy(), to->syntaxCopy());
 }
 
+static bool checkVectorElem(Expression *e, Expression *elem)
+{
+    if (elem->isConst() == 1)
+        return false;
+
+    e->error("constant expression expected, not %s", elem->toChars());
+    return true;
+}
+
 Expression *VectorExp::semantic(Scope *sc)
 {
 #if LOGSEMANTIC
@@ -10166,7 +10175,23 @@ Expression *VectorExp::semantic(Scope *sc)
     Type *te = tv->elementType();
     dim = (int)(tv->size(loc) / te->size(loc));
 
-    return this;
+    e1 = e1->optimize(WANTvalue);
+    bool result = false;
+    if (e1->op == TOKarrayliteral)
+    {
+        for (size_t i = 0; i < dim; i++)
+        {
+            // Do not stop on first error - check all AST nodes even if error found
+            result |= checkVectorElem(this, ((ArrayLiteralExp *)e1)->getElement(i));
+        }
+    }
+    else
+        result = checkVectorElem(this, e1);
+
+    Expression *e = this;
+    if (result)
+        e = new ErrorExp();
+    return e;
 }
 
 /************************************************************/

--- a/gcc/d/expr.cc
+++ b/gcc/d/expr.cc
@@ -2096,14 +2096,6 @@ public:
 	if (declaration_reference_p(e->var))
 	  result = indirect_ref(build_ctype(e->var->type), result);
 
-	// The frontend sometimes emits different types for the expression
-	// and var declaration.  So we must force convert to the expressions
-	// type, but don't convert FuncDeclaration as underlying ctype
-	// sometimes isn't the correct type for functions!
-	if (!e->var->isFuncDeclaration()
-	    && !d_types_same(e->var->type, e->type))
-	  result = build1(VIEW_CONVERT_EXPR, build_ctype(e->type), result);
-
 	this->result_ = result;
       }
   }

--- a/gcc/testsuite/gdc.test/runnable/testxmm.d
+++ b/gcc/testsuite/gdc.test/runnable/testxmm.d
@@ -1380,6 +1380,15 @@ void test12776()
 }
 
 /*****************************************/
+// https://issues.dlang.org/show_bug.cgi?id=13927
+
+void test13927(ulong2 a)
+{
+    ulong2 b = [long.min, long.min];
+    auto tmp = a - b;
+}
+
+/*****************************************/
 
 void foo13988(double[] arr)
 {
@@ -1393,6 +1402,125 @@ void test13988()
 {
     double[] arr = [3.0];
     foo13988(arr);
+}
+
+/*****************************************/
+// 15123
+
+void test15123()
+{
+    alias Vector16s = TypeTuple!(
+        void16,  byte16,  short8,  int4,  long2,
+                ubyte16, ushort8, uint4, ulong2, float4, double2);
+    foreach (V; Vector16s)
+    {
+        auto x = V.init;
+    }
+}
+
+/*****************************************/
+
+// https://issues.dlang.org/show_bug.cgi?id=16488
+
+void foo_byte16(byte t, byte s)
+{
+    byte16 f = s;
+    auto p = cast(byte*)&f;
+    foreach (i; 0 .. 16)
+        assert(p[i] == s);
+}
+
+void foo_ubyte16(ubyte t, ubyte s)
+{
+    ubyte16 f = s;
+    auto p = cast(ubyte*)&f;
+    foreach (i; 0 .. 16)
+        assert(p[i] == s);
+}
+
+
+void foo_short8(short t, short s)
+{
+    short8 f = s;
+    auto p = cast(short*)&f;
+    foreach (i; 0 .. 4)
+        assert(p[i] == s);
+}
+
+void foo_ushort8(ushort t, ushort s)
+{
+    ushort8 f = s;
+    auto p = cast(ushort*)&f;
+    foreach (i; 0 .. 4)
+        assert(p[i] == s);
+}
+
+
+void foo_int4(int t, int s)
+{
+    int4 f = s;
+    auto p = cast(int*)&f;
+    foreach (i; 0 .. 4)
+        assert(p[i] == s);
+}
+
+void foo_uint4(uint t, uint s, uint u)
+{
+    uint4 f = s;
+    auto p = cast(uint*)&f;
+    foreach (i; 0 .. 4)
+        assert(p[i] == s);
+}
+
+void foo_long2(long t, long s, long u)
+{
+    long2 f = s;
+    auto p = cast(long*)&f;
+    foreach (i; 0 .. 2)
+        assert(p[i] == s);
+}
+
+void foo_ulong2(ulong t, ulong s)
+{
+    ulong2 f = s;
+    auto p = cast(ulong*)&f;
+    foreach (i; 0 .. 2)
+        assert(p[i] == s);
+}
+
+void foo_float4(float t, float s)
+{
+    float4 f = s;
+    auto p = cast(float*)&f;
+    foreach (i; 0 .. 4)
+        assert(p[i] == s);
+}
+
+void foo_double2(double t, double s, double u)
+{
+    double2 f = s;
+    auto p = cast(double*)&f;
+    foreach (i; 0 .. 2)
+        assert(p[i] == s);
+}
+
+
+void test16448()
+{
+    foo_byte16(5, -10);
+    foo_ubyte16(5, 11);
+
+    foo_short8(5, -6);
+    foo_short8(5, 7);
+
+    foo_int4(5, -6);
+    foo_uint4(5, 0x12345678, 22);
+
+    foo_long2(5, -6, 1);
+    foo_ulong2(5, 0x12345678_87654321L);
+
+    foo_float4(5, -6);
+    foo_double2(5, -6, 2);
 }
 
 /*****************************************/
@@ -1428,6 +1556,7 @@ int main()
     test9449();
     test9449_2();
     test13988();
+    test16448();
 
     return 0;
 }


### PR DESCRIPTION
All backend bugs were discovered because `testxmm.d` was actually never tested due to `version (D_SIMD)`.