### PR TITLE
Issue 14858 - spurious "Error: overload alias foo is not a variable"

### DIFF
--- a/gcc/d/dfrontend/expression.c
+++ b/gcc/d/dfrontend/expression.c
@@ -3483,6 +3483,12 @@ Lagain:
         fd->type = f->type;
         return new VarExp(loc, fd, hasOverloads);
     }
+    if (OverDeclaration *od = s->isOverDeclaration())
+    {
+        e = new VarExp(loc, od, 1);
+        e->type = Type::tvoid;
+        return e;
+    }
     if (OverloadSet *o = s->isOverloadSet())
     {
         //printf("'%s' is an overload set\n", o->toChars());

--- a/gcc/testsuite/gdc.test/runnable/overload.d
+++ b/gcc/testsuite/gdc.test/runnable/overload.d
@@ -1067,6 +1067,21 @@ void test13783()
 }
 
 /***************************************************/
+// 14858
+
+int foo14858()() { return 1; }
+int bar14858(int) { return 2; }
+
+alias foobar14858 = foo14858;
+alias foobar14858 = bar14858;
+
+void test14858()
+{
+    assert(foobar14858() == 1);
+    assert(foobar14858(1) == 2); // OK <- NG
+}
+
+/***************************************************/
 
 int main()
 {
@@ -1100,6 +1115,7 @@ int main()
     test11915();
     test11916();
     test13783();
+    test14858();
 
     printf("Success\n");
     return 0;


### PR DESCRIPTION
Error happens when overloading template and non-template via aliases