### PR TITLE
Revert change to handle void initialized fields.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,9 @@
+2017-01-13  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-codegen.cc (build_class_instance): Don't check for void
+	initialized fields.
+	* expr.cc (ExprVisitor::visit(StructLiteralExp)): Likewise.
+
 2017-01-11  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* typeinfo.cc (layout_classinfo): Use placement new to initialize

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -2282,9 +2282,6 @@ build_class_instance (ClassReferenceExp *exp)
 	  if (!value)
 	    continue;
 
-	  if (vfield->_init && vfield->_init->isVoidInitializer ())
-	    continue;
-
 	  // Use find_aggregate_field to get the overridden field decl,
 	  // instead of the field associated with the base class.
 	  tree field = get_symbol_decl (bcd->fields[i]);

--- a/gcc/d/expr.cc
+++ b/gcc/d/expr.cc
@@ -2636,9 +2636,6 @@ public:
 	  continue;
 
 	VarDeclaration *field = e->sd->fields[i];
-	if (field->_init && field->_init->isVoidInitializer())
-	  continue;
-
 	Type *type = exp->type->toBasetype();
 	Type *ftype = field->type->toBasetype();
 	tree value = NULL_TREE;

--- a/gcc/testsuite/gdc.test/runnable/test17073.d
+++ b/gcc/testsuite/gdc.test/runnable/test17073.d
@@ -1,0 +1,13 @@
+struct S0
+{
+    int x = void;
+}
+struct S1
+{
+    S0  x = S0(42);
+}
+void main()
+{
+    S1  x;
+    assert(x.x.x == 42);
+}


### PR DESCRIPTION
Checked both additions, and the field initializer is never used directly.  So the check is meaningless.