### PR TITLE
Issue 15579 - extern(C++) interfaces/multiple-inheritance

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -34,6 +34,15 @@
 	(make_internal_name): Update.
 	(get_symbol_decl): Update.
 
+2017-12-24  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-codegen.cc (convert_expr): Allow upcasting C++ classes.
+	(build_class_instance): Generate initial values of vtable interfaces
+	before class fields.
+	(layout_aggregate_type): Layout vtable interfaces before class fields.
+	* d-decls.cc (get_symbol_decl): Build DECL_ARGUMENTS for functions
+	that have no body.
+
 2017-12-22  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-target.cc (Target::cppExceptions): New variable.

--- a/gcc/d/d-decls.cc
+++ b/gcc/d/d-decls.cc
@@ -319,6 +319,27 @@ get_symbol_decl (Declaration *decl)
       if (decl->storage_class & STCfinal)
 	DECL_FINAL_P (decl->csym) = 1;
 
+      /* Declare stub parameters for functions that have no body.  */
+      if (!fd->fbody)
+	{
+	  tree param_list = NULL_TREE;
+	  fntype = TREE_TYPE (decl->csym);
+
+	  for (tree t = TYPE_ARG_TYPES (fntype); t; t = TREE_CHAIN (t))
+	    {
+	      if (t == void_list_node)
+		break;
+
+	      tree param = build_decl (DECL_SOURCE_LOCATION (decl->csym),
+				       PARM_DECL, NULL_TREE, TREE_VALUE (t));
+	      DECL_ARG_TYPE (param) = TREE_TYPE (param);
+	      param_list = chainon (param_list, param);
+	    }
+
+	  DECL_ARGUMENTS (decl->csym) = param_list;
+	}
+
+      /* Check whether this function is expanded by the frontend.  */
       maybe_set_intrinsic (fd);
     }
 

--- a/gcc/d/dfrontend/class.c
+++ b/gcc/d/dfrontend/class.c
@@ -994,6 +994,9 @@ void ClassDeclaration::finalizeSize(Scope *sc)
             structsize = Target::ptrsize * 2;   // allow room for __vptr and __monitor
     }
 
+    // Add vptr's for any interfaces implemented by this class
+    structsize += setBaseInterfaceOffsets(structsize);
+
     unsigned offset = structsize;
     for (size_t i = 0; i < members->dim; i++)
     {
@@ -1003,8 +1006,6 @@ void ClassDeclaration::finalizeSize(Scope *sc)
     if (sizeok == SIZEOKfwd)
         return;
 
-    // Add vptr's for any interfaces implemented by this class
-    structsize += setBaseInterfaceOffsets(structsize);
     sizeok = SIZEOKdone;
 
     // Calculate fields[i]->overlapped
@@ -1843,9 +1844,9 @@ bool BaseClass::fillVtbl(ClassDeclaration *cd, FuncDeclarations *vtbl, int newin
                 fd->error("linkage doesn't match interface function");
 
             // Check that it is current
-            if (newinstance &&
-                fd->toParent() != cd &&
-                ifd->toParent() == sym)
+            //printf("newinstance = %d fd->toParent() = %s ifd->toParent() = %s\n",
+                //newinstance, fd->toParent()->toChars(), ifd->toParent()->toChars());
+            if (newinstance && fd->toParent() != cd && ifd->toParent() == sym)
                 cd->error("interface function '%s' is not implemented", ifd->toFullSignature());
 
             if (fd->toParent() == cd)
@@ -1853,7 +1854,7 @@ bool BaseClass::fillVtbl(ClassDeclaration *cd, FuncDeclarations *vtbl, int newin
         }
         else
         {
-            //printf("            not found\n");
+            //printf("            not found %p\n", fd);
             // BUG: should mark this class as abstract?
             if (!cd->isAbstract())
                 cd->error("interface function '%s' is not implemented", ifd->toFullSignature());

--- a/gcc/d/dfrontend/cppmangle.c
+++ b/gcc/d/dfrontend/cppmangle.c
@@ -1318,7 +1318,7 @@ private:
         if (d->needThis()) // <flags> ::= <virtual/protection flag> <const/volatile flag> <calling convention flag>
         {
             // Pivate methods always non-virtual in D and it should be mangled as non-virtual in C++
-            if (d->isVirtual() && d->vtblIndex != -1)
+            if (d->isVirtual() && (d->vtblIndex != -1 || d.interfaceVirtual))
             {
                 switch (d->protection.kind)
                 {

--- a/gcc/d/dfrontend/declaration.h
+++ b/gcc/d/dfrontend/declaration.h
@@ -550,6 +550,7 @@ public:
     // true if errors in semantic3 this function's frame ptr
     bool semantic3Errors;
     ForeachStatement *fes;              // if foreach body, this is the foreach
+    BaseClass* interfaceVirtual;        // if virtual, but only appears in interface vtbl[]
     bool introducing;                   // true if 'introducing' function
     // if !=NULL, then this is the type
     // of the 'introducing' function

--- a/gcc/d/dfrontend/expression.c
+++ b/gcc/d/dfrontend/expression.c
@@ -8402,6 +8402,37 @@ Expression *CallExp::syntaxCopy()
     return new CallExp(loc, e1->syntaxCopy(), arraySyntaxCopy(arguments));
 }
 
+static FuncDeclaration *resolveOverloadSet(Loc loc, Scope *sc,
+    OverloadSet *os, Objects* tiargs, Type *tthis, Expressions *arguments)
+{
+    FuncDeclaration *f = NULL;
+    for (size_t i = 0; i < os->a.dim; i++)
+    {
+        Dsymbol *s = os->a[i];
+        if (tiargs && s->isFuncDeclaration())
+            continue;
+        if (FuncDeclaration *f2 = resolveFuncCall(loc, sc, s, tiargs, tthis, arguments, 1))
+        {
+            if (f2->errors)
+                return NULL;
+            if (f)
+            {
+                /* Error if match in more than one overload set,
+                 * even if one is a 'better' match than the other.
+                 */
+                ScopeDsymbol::multiplyDefined(loc, f, f2);
+            }
+            else
+                f = f2;
+        }
+    }
+    if (!f)
+        ::error(loc, "no overload matches for %s", os->toChars());
+    else if (f->errors)
+        f = NULL;
+    return f;
+}
+
 Expression *CallExp::semantic(Scope *sc)
 {
 #if LOGSEMANTIC
@@ -8799,7 +8830,20 @@ Lagain:
         f = resolveFuncCall(loc, sc, s, tiargs, ue1 ? ue1->type : NULL, arguments);
         if (!f || f->errors || f->type->ty == Terror)
             return new ErrorExp();
-
+        if (f->interfaceVirtual)
+        {
+            /* Cast 'this' to the type of the interface, and replace f with the interface's equivalent
+             */
+            BaseClass *b = f->interfaceVirtual;
+            ClassDeclaration *ad2 = b->sym;
+            ue->e1 = ue->e1->castTo(sc, ad2->type->addMod(ue->e1->type->mod));
+            ue->e1 = ue->e1->semantic(sc);
+            ue1 = ue->e1;
+            int vi = f->findVtblIndex((Dsymbols*)&ad2->vtbl, (int)ad2->vtbl.dim);
+            assert(vi >= 0);
+            f = ad2->vtbl[vi]->isFuncDeclaration();
+            assert(f);
+        }
         if (f->needThis())
         {
             AggregateDeclaration *ad = f->toParent2()->isAggregateDeclaration();
@@ -8888,10 +8932,8 @@ Lagain:
     else if (e1->op == TOKsuper)
     {
         // Base class constructor call
-        ClassDeclaration *cd = NULL;
-
-        if (sc->func && sc->func->isThis())
-            cd = sc->func->isThis()->isClassDeclaration();
+        AggregateDeclaration *ad = sc->func ? sc->func->isThis() : NULL;
+        ClassDeclaration *cd = ad ? ad->isClassDeclaration() : NULL;
         if (!cd || !cd->baseClass || !sc->func->isCtorDeclaration())
         {
             error("super class constructor call must be in a constructor");
@@ -8915,7 +8957,10 @@ Lagain:
         }
 
         tthis = cd->type->addMod(sc->func->type->mod);
-        f = resolveFuncCall(loc, sc, cd->baseClass->ctor, NULL, tthis, arguments, 0);
+        if (OverloadSet *os = cd->baseClass->ctor->isOverloadSet())
+            f = resolveOverloadSet(loc, sc, os, NULL, tthis, arguments);
+        else
+            f = resolveFuncCall(loc, sc, cd->baseClass->ctor, NULL, tthis, arguments, 0);
         if (!f || f->errors)
             return new ErrorExp();
         checkDeprecated(sc, f);
@@ -8931,11 +8976,8 @@ Lagain:
     else if (e1->op == TOKthis)
     {
         // same class constructor call
-        AggregateDeclaration *cd = NULL;
-
-        if (sc->func && sc->func->isThis())
-            cd = sc->func->isThis()->isAggregateDeclaration();
-        if (!cd || !sc->func->isCtorDeclaration())
+        AggregateDeclaration *ad = sc->func ? sc->func->isThis() : NULL;
+        if (!ad || !sc->func->isCtorDeclaration())
         {
             error("constructor call must be in a constructor");
             return new ErrorExp();
@@ -8952,8 +8994,11 @@ Lagain:
             sc->callSuper |= CSXany_ctor | CSXthis_ctor;
         }
 
-        tthis = cd->type->addMod(sc->func->type->mod);
-        f = resolveFuncCall(loc, sc, cd->ctor, NULL, tthis, arguments, 0);
+        tthis = ad->type->addMod(sc->func->type->mod);
+        if (OverloadSet *os = ad->ctor->isOverloadSet())
+            f = resolveOverloadSet(loc, sc, os, NULL, tthis, arguments);
+        else
+            f = resolveFuncCall(loc, sc, ad->ctor, NULL, tthis, arguments, 0);
         if (!f || f->errors)
             return new ErrorExp();
         checkDeprecated(sc, f);
@@ -8976,37 +9021,10 @@ Lagain:
     }
     else if (e1->op == TOKoverloadset)
     {
-        OverExp *eo = (OverExp *)e1;
-        FuncDeclaration *f = NULL;
-        Dsymbol *s = NULL;
-        for (size_t i = 0; i < eo->vars->a.dim; i++)
-        {
-            s = eo->vars->a[i];
-            if (tiargs && s->isFuncDeclaration())
-                continue;
-            FuncDeclaration *f2 = resolveFuncCall(loc, sc, s, tiargs, tthis, arguments, 1);
-            if (f2)
-            {
-                if (f2->errors)
-                    return new ErrorExp();
-                if (f)
-                {
-                    /* Error if match in more than one overload set,
-                     * even if one is a 'better' match than the other.
-                     */
-                    ScopeDsymbol::multiplyDefined(loc, f, f2);
-                }
-                else
-                    f = f2;
-            }
-        }
+        OverloadSet *os = ((OverExp *)e1)->vars;
+        f = resolveOverloadSet(loc, sc, os, tiargs, tthis, arguments);
         if (!f)
-        {
-            /* No overload matches
-             */
-            error("no overload matches for %s", s->toChars());
             return new ErrorExp();
-        }
         if (ethis)
             e1 = new DotVarExp(loc, ethis, f);
         else

--- a/gcc/d/dfrontend/func.c
+++ b/gcc/d/dfrontend/func.c
@@ -323,6 +323,7 @@ FuncDeclaration::FuncDeclaration(Loc loc, Loc endloc, Identifier *id, StorageCla
     isArrayOp = 0;
     semantic3Errors = false;
     fes = NULL;
+    interfaceVirtual = NULL;
     introducing = 0;
     tintro = NULL;
     /* The type given for "infer the return type" is a TypeFunction with
@@ -806,7 +807,26 @@ void FuncDeclaration::semantic(Scope *sc)
                 }
                 else
                 {
-                    //printf("\tintroducing function\n");
+                    if (global.params.mscoff && cd->cpp)
+                    {
+                        /* if overriding an interface function, then this is not
+                         * introducing and don't put it in the class vtbl[]
+                         */
+                        for (size_t i = 0; i < cd->interfaces_dim; i++)
+                        {
+                            BaseClass* b = cd->interfaces[i];
+                            int v = findVtblIndex((Dsymbols*)&b->sym->vtbl, (int)b->sym->vtbl.dim);
+                            if (v >= 0)
+                            {
+                                //printf("\tinterface function %s\n", toChars());
+                                cd->vtblFinal.push(this);
+                                interfaceVirtual = b;
+                                goto Linterfaces;
+                            }
+                        }
+                    }
+
+                    //printf("\tintroducing function %s\n", toChars());
                     introducing = 1;
                     if (cd->cpp && Target::reverseCppOverloads)
                     {
@@ -929,6 +949,7 @@ void FuncDeclaration::semantic(Scope *sc)
          * If this function is covariant with any members of those interface
          * functions, set the tintro.
          */
+    Linterfaces:
         for (size_t i = 0; i < cd->interfaces_dim; i++)
         {
             BaseClass *b = cd->interfaces[i];

--- a/gcc/testsuite/gdc.test/compilable/test15784.d
+++ b/gcc/testsuite/gdc.test/compilable/test15784.d
@@ -1,0 +1,47 @@
+// PERMUTE_ARGS:
+
+template AddField(T)
+{
+    T b;
+    this(Args...)(T b, auto ref Args args)
+    {
+        this.b = b;
+        this(args);
+    }
+}
+
+template construcotrs()
+{
+    int a;
+    this(int a)
+    {
+        this.a = a;
+    }
+}
+
+class B
+{
+    mixin construcotrs;
+    mixin AddField!(string);
+}
+
+class C : B
+{
+    this(A...)(A args)
+    {
+        // The called super ctor is an overload set.
+        super(args);
+    }
+}
+
+struct S
+{
+    mixin construcotrs;
+    mixin AddField!(string);
+}
+
+void main()
+{
+    auto s = S("bar", 15);
+    auto c = new C("bar", 15);
+}

--- a/gcc/testsuite/gdc.test/runnable/cppa.d
+++ b/gcc/testsuite/gdc.test/runnable/cppa.d
@@ -764,6 +764,71 @@ void test14200()
 }
 
 /****************************************/
+// 15579
+
+extern (C++)
+{
+    class Base
+    {
+        //~this() {}
+        void based() { }
+        ubyte x = 4;
+    }
+
+    interface Interface
+    {
+        int MethodCPP();
+        int MethodD();
+    }
+
+    class Derived : Base, Interface
+    {
+        short y = 5;
+        int MethodCPP();
+        int MethodD() {
+            printf("Derived.MethodD(): this = %p, x = %d, y = %d\n", this, x, y);
+            Derived p = this;
+            //p = cast(Derived)(cast(void*)p - 16);
+            assert(p.x == 4 || p.x == 7);
+            assert(p.y == 5 || p.y == 8);
+            return 3;
+        }
+        int Method() { return 6; }
+    }
+
+    Derived cppfoo(Derived);
+    Interface cppfooi(Interface);
+}
+
+void test15579()
+{
+    Derived d = new Derived();
+    printf("d = %p\n", d);
+    assert(d.x == 4);
+    assert(d.y == 5);
+    assert((cast(Interface)d).MethodCPP() == 30);
+    assert((cast(Interface)d).MethodD() == 3);
+    assert(d.MethodCPP() == 30);
+    assert(d.MethodD() == 3);
+    assert(d.Method() == 6);
+
+    d = cppfoo(d);
+    assert(d.x == 7);
+    assert(d.y == 8);
+
+    printf("d2 = %p\n", d);
+    assert((cast(Interface)d).MethodD() == 3);
+    assert((cast(Interface)d).MethodCPP() == 30);
+    assert(d.Method() == 6);
+
+    printf("d = %p, i = %p\n", d, cast(Interface)d);
+    Interface i = cppfooi(d);
+    printf("i2: %p\n", i);
+    assert(i.MethodD() == 3);
+    assert(i.MethodCPP() == 30);
+}
+
+/****************************************/
 
 void main()
 {
@@ -794,6 +859,7 @@ void main()
     foo13337(S13337());
     test14195();
     test14200();
+    test15579();
 
     printf("Success\n");
 }

--- a/gcc/testsuite/gdc.test/runnable/extra-files/cppb.cpp
+++ b/gcc/testsuite/gdc.test/runnable/extra-files/cppb.cpp
@@ -512,3 +512,78 @@ void test14200a(int a) {};
 void test14200b(float a, int b, double c) {};
 
 /******************************************/
+// 15579
+
+class Base
+{
+public:
+    //virtual ~Base() {}
+    virtual void base();
+    unsigned char x;
+};
+
+class Interface
+{
+public:
+    virtual int MethodCPP() = 0;
+    virtual int MethodD() = 0;
+};
+
+class Derived : public Base, public Interface
+{
+public:
+    Derived();
+    short y;
+    int MethodCPP();
+#if _WIN32 || _WIN64
+    int MethodD();
+    virtual int Method();
+#else
+    int MethodD() { return 3; }  // need def or vtbl[] is not generated
+    virtual int Method()  { return 6; }  // need def or vtbl[] is not generated
+#endif
+};
+
+void Base::base() { }
+int Derived::MethodCPP() {
+    printf("Derived::MethodCPP() this = %p, x = %d, y = %d\n", this, x, y);
+    assert(x == 4 || x == 7);
+    assert(y == 5 || y == 8);
+    return 30;
+}
+Derived::Derived() { }
+
+
+Derived *cppfoo(Derived *d)
+{
+    printf("cppfoo(): d = %p\n", d);
+    assert(d->x == 4);
+    assert(d->y == 5);
+    assert(d->MethodD() == 3);
+    assert(d->MethodCPP() == 30);
+    assert(d->Method() == 6);
+
+    d = new Derived();
+    d->x = 7;
+    d->y = 8;
+    assert(d->MethodD() == 3);
+    assert(d->MethodCPP() == 30);
+    assert(d->Method() == 6);
+    printf("d1 = %p\n", d);
+    return d;
+}
+
+Interface *cppfooi(Interface *i)
+{
+    printf("cppfooi(): i = %p\n", i);
+    assert(i->MethodD() == 3);
+    assert(i->MethodCPP() == 30);
+
+    Derived *d = new Derived();
+    d->x = 7;
+    d->y = 8;
+    printf("d = %p, i = %p\n", d, (Interface *)d);
+    return d;
+}
+
+/******************************************/


### PR DESCRIPTION
There's a lot going on here, mostly it's to support an ABI change in class layouts to match C++ MI classes.  That is - writing out vtbl interfaces before fields.

Another change is a fix an ICE in thunk generation code for extern, body-less functions with named parameters.  Because `DECL_ARGUMENTS` is never generated for functions that don't pass through `FuncDeclaration::toObjFile`, the thunk doesn't have them setup either (see comment: `Set up cloned argument trees for the thunk`), then`cgraph_node::expand_thunk` can't generate the generic thunk code - infact, it segfaults because it tries to dereference the null `DECL_ARGUMENTS`.

I intend to thumb through this again to make sure it's in shape.  The backend bit was adapted in haste just to get all new tests working.  Can't comment on regressions at this point in time - not sure...