### PR TITLE
Merge finalizeSize()s, remove now unused code

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -21,6 +21,11 @@
 
 2017-12-27  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-codegen.cc (layout_aggregate_type): Adjust layout of D interfaces.
+	Only add a __vptr field if no base interfaces, don't add __monitor.
+
+2017-12-27  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* d-lang.cc (d_parse_file): Run runDeferredSemantic2 after semantic2.
 
 2017-12-25  Iain Buclaw  <ibuclaw@gdcproject.org>

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -4711,28 +4711,33 @@ layout_aggregate_type(AggregateDeclaration *decl, tree type, AggregateDeclaratio
 	  tree objtype = TREE_TYPE (build_ctype(cd->type));
 
 	  // Add the virtual table pointer, and optionally the monitor fields.
-	  tree field = create_field_decl(vtbl_ptr_type_node, "__vptr", 1, inherited_p);
-	  DECL_VIRTUAL_P (field) = 1;
-	  TYPE_VFIELD (type) = field;
-	  DECL_FCONTEXT (field) = objtype;
-	  insert_aggregate_field(decl->loc, type, field, 0);
-
-	  if (!cd->cpp)
+	  InterfaceDeclaration *id = cd->isInterfaceDeclaration ();
+	  if (!id || id->vtblInterfaces->dim == 0)
 	    {
-	      field = create_field_decl(ptr_type_node, "__monitor", 1, inherited_p);
-	      insert_aggregate_field(decl->loc, type, field, Target::ptrsize);
+	      tree field = create_field_decl (vtbl_ptr_type_node, "__vptr", 1,
+					      inherited_p);
+	      DECL_VIRTUAL_P (field) = 1;
+	      TYPE_VFIELD (type) = field;
+	      DECL_FCONTEXT (field) = objtype;
+	      insert_aggregate_field (decl->loc, type, field, 0);
+	    }
+
+	  if (!id && !cd->cpp)
+	    {
+	      tree field = create_field_decl (ptr_type_node, "__monitor", 1,
+					      inherited_p);
+	      insert_aggregate_field (decl->loc, type, field, Target::ptrsize);
 	    }
 	}
-    }
 
-  if (cd && cd->vtblInterfaces)
-    {
-      for (size_t i = 0; i < cd->vtblInterfaces->dim; i++)
+      if (cd->vtblInterfaces)
 	{
-	  BaseClass *bc = (*cd->vtblInterfaces)[i];
-	  tree field = create_field_decl (build_ctype (Type::tvoidptr->pointerTo ()),
-					  NULL, 1, 1);
-	  insert_aggregate_field (decl->loc, type, field, bc->offset);
+	  for (size_t i = 0; i < cd->vtblInterfaces->dim; i++)
+	    {
+	      BaseClass *bc = (*cd->vtblInterfaces)[i];
+	      tree field = create_field_decl (vtbl_ptr_type_node, NULL, 1, 1);
+	      insert_aggregate_field (decl->loc, type, field, bc->offset);
+	    }
 	}
     }
 

--- a/gcc/d/dfrontend/aggregate.h
+++ b/gcc/d/dfrontend/aggregate.h
@@ -127,7 +127,7 @@ public:
     void semantic2(Scope *sc);
     void semantic3(Scope *sc);
     unsigned size(Loc loc);
-    virtual void finalizeSize(Scope *sc) = 0;
+    virtual void finalizeSize() = 0;
     bool checkOverlappedFields();
     bool fill(Loc loc, Expressions *elements, bool ctorinit);
     static void alignmember(structalign_t salign, unsigned size, unsigned *poffset);
@@ -196,7 +196,7 @@ public:
     void semanticTypeInfoMembers();
     Dsymbol *search(Loc, Identifier *ident, int flags = IgnoreNone);
     const char *kind();
-    void finalizeSize(Scope *sc);
+    void finalizeSize();
     bool fit(Loc loc, Scope *sc, Expressions *elements, Type *stype);
     bool isPOD();
 
@@ -302,12 +302,11 @@ public:
 
     bool isBaseInfoComplete();
     Dsymbol *search(Loc, Identifier *ident, int flags = IgnoreNone);
-    ClassDeclaration *searchBase(Loc, Identifier *ident);
-    void finalizeSize(Scope *sc);
+    ClassDeclaration *searchBase(Identifier *ident);
+    void finalizeSize();
     bool isFuncHidden(FuncDeclaration *fd);
     FuncDeclaration *findFunc(Identifier *ident, TypeFunction *tf);
     void interfaceSemantic(Scope *sc);
-    unsigned setBaseInterfaceOffsets(unsigned baseOffset);
     bool isCOMclass() const;
     virtual bool isCOMinterface() const;
     bool isCPPclass() const;
@@ -337,7 +336,6 @@ public:
     Dsymbol *syntaxCopy(Dsymbol *s);
     Scope *newScope(Scope *sc);
     void semantic(Scope *sc);
-    void finalizeSize(Scope *sc);
     bool isBaseOf(ClassDeclaration *cd, int *poffset);
     bool isBaseOf(BaseClass *bc, int *poffset);
     const char *kind();

--- a/gcc/d/dfrontend/mtype.c
+++ b/gcc/d/dfrontend/mtype.c
@@ -8329,7 +8329,7 @@ L1:
                 return Type::getProperty(e->loc, ident, 0);
             return new DotTypeExp(e->loc, e, sym);
         }
-        if (ClassDeclaration *cbase = sym->searchBase(e->loc, ident))
+        if (ClassDeclaration *cbase = sym->searchBase(ident))
         {
             if (e->op == TOKtype)
                 return Type::getProperty(e->loc, ident, 0);

--- a/gcc/d/dfrontend/struct.c
+++ b/gcc/d/dfrontend/struct.c
@@ -398,7 +398,7 @@ unsigned AggregateDeclaration::size(Loc loc)
             if (s->apply(&SV::func, &sv))
                 goto L1;
         }
-        finalizeSize(NULL);
+        finalizeSize();
 
       L1: ;
     }
@@ -969,7 +969,7 @@ void StructDeclaration::semantic(Scope *sc)
         Dsymbol *s = (*members)[i];
         s->semantic(sc2);
     }
-    finalizeSize(sc2);
+    finalizeSize();
 
     if (sizeok == SIZEOKfwd)
     {
@@ -1131,7 +1131,7 @@ Dsymbol *StructDeclaration::search(Loc loc, Identifier *ident, int flags)
     return ScopeDsymbol::search(loc, ident, flags);
 }
 
-void StructDeclaration::finalizeSize(Scope *sc)
+void StructDeclaration::finalizeSize()
 {
     //printf("StructDeclaration::finalizeSize() %s\n", toChars());
     if (sizeok != SIZEOKnone)


### PR DESCRIPTION
Follow-up from #359, it is now expected of us to *not* insert a `__monitor` field for D interfaces.

Also, only add the `__vptr` field for interfaces if there are no base interfaces.