### PR TITLE
Missing a 'break' statement on debug case.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,7 @@
+2017-01-15  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-spec.cc (lang_specific_driver): Add missing break.
+
 2017-01-13  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-codegen.cc (build_class_instance): Don't check for void

--- a/gcc/d/d-spec.c
+++ b/gcc/d/d-spec.c
@@ -182,6 +182,7 @@ lang_specific_driver (cl_decoded_option **in_decoded_options,
 
 	case OPT_g:
 	  saw_debug_flag = true;
+	  break;
 
 	case OPT_v:
 	  /* If they only gave us `-v', don't try to link in libphobos.  */


### PR DESCRIPTION
Thankfully it was a harmless fall-through, but need to silence the warnings anyway.