### PR TITLE
Bug 251: ICE: in dwarf2out_imported_module_or_decl_1, at dwarf2out.c:23802

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,11 @@
+2017-01-25  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* imports.cc (ImportVisitor::visit(EnumDeclaration)): New function.
+	(ImportVisitor::visit(AggregateDeclaration)): New function.
+	(ImportVisitor::visit(ClassDeclaration)): New function.
+	(ImportVisitor::make_import): New function.
+	(ImportVisitor::visit(AliasDeclaration)): Get decl for type alias.
+
 2017-01-22  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* expr.cc (ExprVisitor::visit(EqualExp)): Don't use memcmp on arrays

--- a/gcc/d/imports.cc
+++ b/gcc/d/imports.cc
@@ -1,20 +1,19 @@
-// imports.cc -- D frontend for GCC.
-// Copyright (C) 2016 Free Software Foundation, Inc.
+/* imports.cc -- Build imported modules/declarations.
+   Copyright (C) 2011-2017 Free Software Foundation, Inc.
 
-// GCC is free software; you can redistribute it and/or modify it under
-// the terms of the GNU General Public License as published by the Free
-// Software Foundation; either version 3, or (at your option) any later
-// version.
+GCC is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3, or (at your option)
+any later version.
 
-// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or
-// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
-// for more details.
+GCC is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
-// You should have received a copy of the GNU General Public License
-// along with GCC; see the file COPYING3.  If not see
-// <http://www.gnu.org/licenses/>.
-
+You should have received a copy of the GNU General Public License
+along with GCC; see the file COPYING3.  If not see
+<http://www.gnu.org/licenses/>.  */
 
 #include "config.h"
 #include "system.h"
@@ -32,125 +31,140 @@
 #include "d-tree.h"
 #include "d-objfile.h"
 
-// Implements the visitor interface to build debug trees for all module and
-// import declarations, where ISYM holds the cached backend representation
-// to be returned.
-
+/* Implements the visitor interface to build debug trees for all
+   module and import declarations, where ISYM holds the cached
+   backend representation to be returned.  */
 class ImportVisitor : public Visitor
 {
-public:
-  ImportVisitor() {}
-
-  // This should be overridden by each symbol class.
-  void visit(Dsymbol *)
+  /* Build the declaration DECL as an imported symbol.  */
+  tree make_import (tree decl)
   {
-    gcc_unreachable();
+    tree import = make_node (IMPORTED_DECL);
+    TREE_TYPE (import) = void_type_node;
+
+    gcc_assert (decl != NULL_TREE);
+    IMPORTED_DECL_ASSOCIATED_DECL (import) = decl;
+    d_keep (import);
+
+    return import;
   }
 
-  // Build the module namespace, this is considered toplevel, regardless
-  // of whether there are any parent packages in the module system.
-  void visit(Module *m)
+public:
+  ImportVisitor (void) {}
+
+  /* This should be overridden by each symbol class.  */
+  void visit (Dsymbol *)
   {
-    m->isym = build_decl(UNKNOWN_LOCATION, NAMESPACE_DECL,
-			 get_identifier(m->toPrettyChars()),
-			 void_type_node);
-    d_keep(m->isym);
+    gcc_unreachable ();
+  }
+
+  /* Build the module decl for M, this is considered toplevel, regardless
+     of whether there are any parent packages in the module system.  */
+  void visit (Module *m)
+  {
+    m->isym = build_decl (UNKNOWN_LOCATION, NAMESPACE_DECL,
+			  get_identifier (m->toPrettyChars ()),
+			  void_type_node);
+    d_keep (m->isym);
 
     Loc loc = (m->md != NULL) ? m->md->loc
-      : Loc(m->srcfile->toChars(), 1, 0);
-    set_decl_location(m->isym, loc);
+      : Loc (m->srcfile->toChars (), 1, 0);
+    set_decl_location (m->isym, loc);
 
-    if (!m->isRoot())
+    if (!m->isRoot ())
       DECL_EXTERNAL (m->isym) = 1;
 
     TREE_PUBLIC (m->isym) = 1;
     DECL_CONTEXT (m->isym) = NULL_TREE;
   }
 
-  //
-  void visit(ScopeDsymbol *d)
+  /* Build an import for any kind of user defined type.
+     Use the TYPE_DECL associated with the type symbol.  */
+  void visit (EnumDeclaration *d)
   {
-    tree type = NULL_TREE;
-
-    if (d->isEnumDeclaration())
-      type = build_ctype(((EnumDeclaration *) d)->type);
-    if (d->isAggregateDeclaration())
-      type = build_ctype(((AggregateDeclaration *) d)->type);
-
-    if (type != NULL_TREE)
-      {
-	d->isym = make_node(IMPORTED_DECL);
-	TREE_TYPE (d->isym) = void_type_node;
-	IMPORTED_DECL_ASSOCIATED_DECL (d->isym) = TYPE_STUB_DECL (type);
-	d_keep(d->isym);
-      }
-
-    // For now, ignore importing other kinds of dsymbols.
-    return;
+    tree type = build_ctype (d->type);
+    /* Not all kinds of D enums create a TYPE_DECL.  */
+    if (TREE_CODE (type) == ENUMERAL_TYPE)
+      d->isym = this->make_import (TYPE_STUB_DECL (type));
   }
 
-  // Alias symbols aren't imported, but their targets are.
-  void visit(AliasDeclaration *d)
+  void visit (AggregateDeclaration *d)
   {
-    Dsymbol *dsym = d->toAlias();
+    tree type = build_ctype (d->type);
+    d->isym = this->make_import (TYPE_STUB_DECL (type));
+  }
 
-    // This symbol is really an alias for another, visit the other.
+  void visit (ClassDeclaration *d)
+  {
+    /* Want the RECORD_TYPE, not POINTER_TYPE.  */
+    tree type = TREE_TYPE (build_ctype (d->type));
+    d->isym = this->make_import (TYPE_STUB_DECL (type));
+  }
+
+  /* For now, ignore importing other kinds of dsymbols.  */
+  void visit (ScopeDsymbol *)
+  {
+  }
+
+  /* Alias symbols aren't imported, but their targets are.  */
+  void visit (AliasDeclaration *d)
+  {
+    Dsymbol *dsym = d->toAlias ();
+
+    if (dsym == d)
+      {
+	Type *type = d->getType ();
+
+	/* Type imports should really be part of their own visit method.  */
+	if (type != NULL)
+	  {
+	    if (type->ty == Tenum)
+	      dsym = ((TypeEnum *) type)->sym;
+	    else if (type->ty == Tstruct)
+	      dsym = ((TypeStruct *) type)->sym;
+	    else if (type->ty == Tclass)
+	      dsym = ((TypeClass *) type)->sym;
+	  }
+      }
+
+    /* This symbol is really an alias for another, visit the other.  */
     if (dsym != d)
       {
-	dsym->accept(this);
+	dsym->accept (this);
 	d->isym = dsym->isym;
-	return;
-      }
-
-    // Type imports should really be part of their own visit method.
-    if (d->type != NULL)
-      {
-	tree type = build_ctype(d->type);
-
-	if (!TYPE_STUB_DECL (type))
-	  return;
-
-	d->isym = make_node(IMPORTED_DECL);
-	TREE_TYPE (d->isym) = void_type_node;
-	IMPORTED_DECL_ASSOCIATED_DECL (d->isym) = TYPE_STUB_DECL (type);
-	d_keep(d->isym);
       }
   }
 
-  // Skip over importing templates and tuples.
-  void visit(TemplateDeclaration *)
+  /* Skip over importing templates and tuples.  */
+  void visit (TemplateDeclaration *)
   {
   }
 
-  void visit(TupleDeclaration *)
+  void visit (TupleDeclaration *)
   {
   }
 
-  // Import any other kind of declaration.  If the class does not implement
-  // symbol generation routines, the compiler will throw an error.
-  void visit(Declaration *d)
+  /* Import any other kind of declaration.  If the class does not implement
+     symbol generation routines, the compiler will throw an error.  */
+  void visit (Declaration *d)
   {
-    d->isym = make_node(IMPORTED_DECL);
-    TREE_TYPE (d->isym) = void_type_node;
-    IMPORTED_DECL_ASSOCIATED_DECL (d->isym) = get_symbol_decl (d);
-    d_keep(d->isym);
+    d->isym = this->make_import (get_symbol_decl (d));
   }
 };
 
 
-// Build a declaration for the symbol D that can be used for the debug_hook
-// imported_module_or_decl.
-
+/* Build a declaration for the symbol D that can be used for the
+   debug_hook imported_module_or_decl.  */
 tree
-build_import_decl(Dsymbol *d)
+build_import_decl (Dsymbol *d)
 {
   if (!d->isym)
     {
       ImportVisitor v;
-      d->accept(&v);
+      d->accept (&v);
     }
 
-  // Not all visitors set 'isym'.
+  /* Not all visitors set 'isym'.  */
   return d->isym ? d->isym : NULL_TREE;
 }
 

--- a/gcc/testsuite/gdc.test/compilable/gdc251.d
+++ b/gcc/testsuite/gdc.test/compilable/gdc251.d
@@ -1,0 +1,4 @@
+module gdc251;
+
+import imports.gdc251a;
+import imports.gdc251b : C251;

--- a/gcc/testsuite/gdc.test/compilable/imports/gdc251a.d
+++ b/gcc/testsuite/gdc.test/compilable/imports/gdc251a.d
@@ -1,0 +1,6 @@
+module imports.gdc251a;
+
+import imports.gdc251b;
+import gdc251;
+
+C251 config;

--- a/gcc/testsuite/gdc.test/compilable/imports/gdc251b.d
+++ b/gcc/testsuite/gdc.test/compilable/imports/gdc251b.d
@@ -1,0 +1,3 @@
+module imports.gdc251b;
+
+class C251 { }


### PR DESCRIPTION
This occurred in complex cases of selectively importing a class declaration symbol.  The problem being that the TYPE_STUB_DECL is only set for the underlying RECORD_TYPE, not the reference type.

In the simple case, this wasn't happening because the ImportVisitor never built an imported decl for straightforward class imports.  This has also been fixed, which in turn improves gdb usability.

Source file has been reformatted also, with copyright years updated as it is a relatively manageable size.