### PR TITLE
Use internal hash instead of custom one.

### DIFF
--- a/gcc/d/dfrontend/template.h
+++ b/gcc/d/dfrontend/template.h
@@ -68,8 +68,7 @@ public:
     Expression *constraint;
 
     // Hash table to look up TemplateInstance's of this TemplateDeclaration
-    Array<TemplateInstances *> buckets;
-    size_t numinstances;                // number of instances in the hash table
+    void *instances;
 
     TemplateDeclaration *overnext;      // next overloaded TemplateDeclaration
     TemplateDeclaration *overroot;      // first in overnext list


### PR DESCRIPTION
Upstream uses D's built-in hash, we don't have that luxury, but this at least it's compatible.