### PR TITLE
Better overflow detection and type size handling

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2017-02-11  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-objfile.cc (VarDeclaration::toObjFile): Error if a variable covers
+	more than half the address space.
+
 2017-02-04  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-objfile.cc (Module::genmoduleinfo): Ignore symbol visibility when

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -518,7 +518,14 @@ VarDeclaration::toObjFile()
 	  mi->tlsVars.safe_push (this);
 	}
 
-      size_t sz = type->size();
+      /* How big a symbol can be should depend on backend.  */
+      tree size = build_integer_cst (this->type->size (this->loc),
+				      build_ctype (Type::tsize_t));
+      if (!valid_constant_size_p (size))
+	{
+	  this->error("size is too large");
+	  return;
+	}
 
       if (this->_init && !this->_init->isVoidInitializer())
 	{
@@ -547,7 +554,7 @@ VarDeclaration::toObjFile()
 	}
 
       // Frontend should have already caught this.
-      gcc_assert (sz || type->toBasetype()->ty == Tsarray);
+      gcc_assert (!integer_zerop (size) || type->toBasetype()->ty == Tsarray);
       d_finish_symbol (s);
     }
   else

--- a/gcc/d/dfrontend/aggregate.h
+++ b/gcc/d/dfrontend/aggregate.h
@@ -123,12 +123,13 @@ public:
 
     AggregateDeclaration(Loc loc, Identifier *id);
     virtual Scope *newScope(Scope *sc);
+    void setScope(Scope *sc);
     void semantic2(Scope *sc);
     void semantic3(Scope *sc);
     bool determineFields();
     bool determineSize(Loc loc);
     virtual void finalizeSize() = 0;
-    unsigned size(Loc loc);
+    d_uns64 size(Loc loc);
     bool checkOverlappedFields();
     bool fill(Loc loc, Expressions *elements, bool ctorinit);
     static void alignmember(structalign_t salign, unsigned size, unsigned *poffset);

--- a/gcc/d/dfrontend/argtypes.c
+++ b/gcc/d/dfrontend/argtypes.c
@@ -215,8 +215,9 @@ TypeTuple *toArgTypes(Type *t)
             if (!t2)
                 return t1;
 
-            unsigned sz1 = (unsigned)t1->size(Loc());
-            unsigned sz2 = (unsigned)t2->size(Loc());
+            const d_uns64 sz1 = t1->size(Loc());
+            const d_uns64 sz2 = t2->size(Loc());
+            assert(sz1 != SIZE_INVALID && sz2 != SIZE_INVALID);
 
             if (t1->ty != t2->ty &&
                 (t1->ty == Tfloat80 || t2->ty == Tfloat80))
@@ -244,6 +245,7 @@ TypeTuple *toArgTypes(Type *t)
                 t = t1;
 
             // If t2 does not lie within t1, need to increase the size of t to enclose both
+            assert(sz2 < UINT64_MAX - UINT32_MAX);
             if (offset2 && sz1 < offset2 + sz2)
             {
                 switch (offset2 + sz2)
@@ -318,7 +320,7 @@ TypeTuple *toArgTypes(Type *t)
             }
             Type *t1 = NULL;
             Type *t2 = NULL;
-            d_uns64 sz = t->size(Loc());
+            const d_uns64 sz = t->size(Loc());
             assert(sz < 0xFFFFFFFF);
             switch ((unsigned)sz)
             {
@@ -398,7 +400,8 @@ TypeTuple *toArgTypes(Type *t)
                             goto Lmemory;
 
                         // Fields that overlap the 8byte boundary goto Lmemory
-                        d_uns64 fieldsz = f->type->size(Loc());
+                        const d_uns64 fieldsz = f->type->size(Loc());
+                        assert(fieldsz != SIZE_INVALID && fieldsz < UINT64_MAX - UINT32_MAX);
                         if (f->offset < 8 && (f->offset + fieldsz) > 8)
                             goto Lmemory;
                     }

--- a/gcc/d/dfrontend/declaration.h
+++ b/gcc/d/dfrontend/declaration.h
@@ -127,7 +127,7 @@ public:
     Declaration(Identifier *id);
     void semantic(Scope *sc);
     const char *kind();
-    unsigned size(Loc loc);
+    d_uns64 size(Loc loc);
     int checkModify(Loc loc, Scope *sc, Type *t, Expression *e1, int flag);
 
     Dsymbol *search(Loc loc, Identifier *ident, int flags = SearchLocalsOnly);

--- a/gcc/d/dfrontend/dsymbol.c
+++ b/gcc/d/dfrontend/dsymbol.c
@@ -580,10 +580,10 @@ bool Dsymbol::overloadInsert(Dsymbol *s)
     return false;
 }
 
-unsigned Dsymbol::size(Loc loc)
+d_uns64 Dsymbol::size(Loc loc)
 {
     error("Dsymbol '%s' has no size", toChars());
-    return 0;
+    return SIZE_INVALID;
 }
 
 bool Dsymbol::isforwardRef()

--- a/gcc/d/dfrontend/dsymbol.h
+++ b/gcc/d/dfrontend/dsymbol.h
@@ -216,7 +216,7 @@ public:
     Dsymbol *search_correct(Identifier *id);
     Dsymbol *searchX(Loc loc, Scope *sc, RootObject *id);
     virtual bool overloadInsert(Dsymbol *s);
-    virtual unsigned size(Loc loc);
+    virtual d_uns64 size(Loc loc);
     virtual bool isforwardRef();
     virtual AggregateDeclaration *isThis();     // is a 'this' required to access the member
     virtual bool isExport();                    // is Dsymbol exported?

--- a/gcc/d/dfrontend/hdrgen.c
+++ b/gcc/d/dfrontend/hdrgen.c
@@ -1070,7 +1070,7 @@ public:
     {
         // Bugzilla 13776: Don't use ti->toAlias() to avoid forward reference error
         // while printing messages.
-        TemplateInstance *ti = t->sym->parent->isTemplateInstance();
+        TemplateInstance *ti = t->sym->parent ? t->sym->parent->isTemplateInstance() : NULL;
         if (ti && ti->aliasdecl == t->sym)
             buf->writestring(hgs->fullQual ? ti->toPrettyChars() : ti->toChars());
         else

--- a/gcc/d/dfrontend/init.h
+++ b/gcc/d/dfrontend/init.h
@@ -120,7 +120,7 @@ class ArrayInitializer : public Initializer
 public:
     Expressions index;  // indices
     Initializers value; // of Initializer *'s
-    size_t dim;         // length of array being initialized
+    unsigned dim;       // length of array being initialized
     Type *type;         // type that array will be used to initialize
     bool sem;           // true if semantic() is run
 

--- a/gcc/d/dfrontend/mtype.c
+++ b/gcc/d/dfrontend/mtype.c
@@ -3917,8 +3917,9 @@ Type *TypeSArray::syntaxCopy()
 }
 
 d_uns64 TypeSArray::size(Loc loc)
-{   dinteger_t sz;
-
+{
+    //printf("TypeSArray::size()\n");
+    dinteger_t sz;
     if (!dim)
         return Type::size(loc);
     sz = dim->toInteger();
@@ -3930,10 +3931,12 @@ d_uns64 TypeSArray::size(Loc loc)
         if (overflow)
             goto Loverflow;
     }
+    if (sz > UINT32_MAX)
+        goto Loverflow;
     return sz;
 
 Loverflow:
-    error(loc, "index %lld overflow for static array", (long long)sz);
+    error(loc, "static array %s size overflowed to %lld", toChars(), (long long)sz);
     return SIZE_INVALID;
 }
 

--- a/gcc/d/dfrontend/statementsem.c
+++ b/gcc/d/dfrontend/statementsem.c
@@ -1302,8 +1302,11 @@ public:
 
                         Expressions *exps = new Expressions();
                         exps->push(fs->aggr);
-                        size_t keysize = (size_t)taa->index->size();
-                        keysize = (keysize + ((size_t)Target::ptrsize-1)) & ~((size_t)Target::ptrsize-1);
+                        d_uns64 keysize = taa->index->size();
+                        if (keysize == SIZE_INVALID)
+                            goto Lerror2;
+                        assert(keysize < UINT64_MAX - Target::ptrsize);
+                        keysize = (keysize + (Target::ptrsize- 1)) & ~(Target::ptrsize - 1);
                         // paint delegate argument to the type runtime expects
                         if (!fldeTy[i]->equals(flde->type))
                         {

--- a/gcc/d/dfrontend/struct.c
+++ b/gcc/d/dfrontend/struct.c
@@ -232,6 +232,16 @@ Scope *AggregateDeclaration::newScope(Scope *sc)
     return sc2;
 }
 
+void AggregateDeclaration::setScope(Scope *sc)
+{
+    // Might need a scope to resolve forward references. The check for
+    // semanticRun prevents unnecessary setting of _scope during deferred
+    // setScope phases for aggregates which already finished semantic().
+    // Also see https://issues.dlang.org/show_bug.cgi?id=16607
+    if (semanticRun < PASSsemanticdone)
+        ScopeDsymbol::setScope(sc);
+}
+
 void AggregateDeclaration::semantic2(Scope *sc)
 {
     //printf("AggregateDeclaration::semantic2(%s) type = %s, errors = %d\n", toChars(), type->toChars(), errors);
@@ -504,12 +514,12 @@ void StructDeclaration::semanticTypeInfoMembers()
     }
 }
 
-unsigned AggregateDeclaration::size(Loc loc)
+d_uns64 AggregateDeclaration::size(Loc loc)
 {
     //printf("+AggregateDeclaration::size() %s, scope = %p, sizeok = %d\n", toChars(), _scope, sizeok);
-    determineSize(loc);
+    bool ok = determineSize(loc);
     //printf("-AggregateDeclaration::size() %s, scope = %p, sizeok = %d\n", toChars(), _scope, sizeok);
-    return structsize;
+    return ok ? structsize : SIZE_INVALID;
 }
 
 Type *AggregateDeclaration::getType()

--- a/gcc/testsuite/gdc.test/compilable/test16607.d
+++ b/gcc/testsuite/gdc.test/compilable/test16607.d
@@ -1,0 +1,15 @@
+struct A(T)
+{
+    T t; // causes A to be SIZEOKfwd b/c B (passed as T) isn't yet done
+
+     // On the 2nd semantic pass through A, _scope of C got set again,
+     // even though the struct was already done.
+    struct C
+    {
+    }
+}
+
+struct B
+{
+    A!B* a; // causes instantiation of A!B, but can finish semantic with A!B still being fwdref
+}

--- a/gcc/testsuite/gdc.test/fail_compilation/fail229.d
+++ b/gcc/testsuite/gdc.test/fail_compilation/fail229.d
@@ -1,7 +1,8 @@
 /*
 TEST_OUTPUT:
 ---
-fail_compilation/fail229.d(10): Error: array dimension overflow
+fail_compilation/fail229.d(11): Error: array index 18446744073709551615 overflow
+fail_compilation/fail229.d(11): Error: array dimension overflow
 ---
 */
 

--- a/gcc/testsuite/gdc.test/fail_compilation/staticarrayoverflow.d
+++ b/gcc/testsuite/gdc.test/fail_compilation/staticarrayoverflow.d
@@ -1,0 +1,24 @@
+/*
+REQUIRED_ARGS: -m64
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+fail_compilation/staticarrayoverflow.d(21): Error: static array S[1879048192] size overflowed to 7516192768000
+fail_compilation/staticarrayoverflow.d(21): Error: variable staticarrayoverflow.y size overflow
+fail_compilation/staticarrayoverflow.d(22): Error: variable staticarrayoverflow.z size of x1000ae0 exceeds max allowed size 0x100_0000
+fail_compilation/staticarrayoverflow.d(23): Error: static array S[8070450532247928832] size overflowed to 0
+fail_compilation/staticarrayoverflow.d(23): Error: variable staticarrayoverflow.a size overflow
+---
+*/
+
+
+
+struct S
+{
+    int[1000] x;
+}
+
+S[0x7000_0000] y;
+S[0x100_0000/(4*1000 - 1)] z;
+S[0x7000_0000_0000_0000] a;
+


### PR DESCRIPTION
DMD defines the maximum size of a variable to be `0x100_000`.  I've just gone with not exceeding half of the address space.