### PR TITLE
testsuite/gdc.test: Use simple regexp for matching -I, -J and -version

### DIFF
--- a/gcc/testsuite/gdc.test/d_do_test.exp
+++ b/gcc/testsuite/gdc.test/d_do_test.exp
@@ -24,7 +24,13 @@ proc gdc-convert-args { args } {
 
     foreach arg [split [lindex $args 0] " "] {
         # List of switches kept in ASCII collated order.
-        if [string match "-allinst" $arg] {
+        if { [regexp -- {^-I([\w+/-]+)} $arg pattern path] } {
+            lappend out "-I$path"
+
+        } elseif { [regexp -- {^-J([\w+/-]+)} $arg pattern path] } {
+            lappend out "-J$path"
+
+        } elseif [string match "-allinst" $arg] {
             lappend out "-femit-templates"
 
         } elseif { [string match "-boundscheck" $arg]
@@ -83,6 +89,9 @@ proc gdc-convert-args { args } {
         } elseif [regexp -- {^-verrors=(\d+)} $arg pattern num] {
             lappend out "-fmax-errors=$num"
 
+        } elseif [regexp -- {^-version=(\w+)} $arg pattern value] {
+            lappend out "-fversion=$value"
+
         } elseif [string match "-w" $arg] {
             lappend out "-Wall"
             lappend out "-Werror"
@@ -94,27 +103,6 @@ proc gdc-convert-args { args } {
         } else {
             # print "Unhandled Argument: $arg"
         }
-    }
-
-    set i 0
-    while { [regexp -start $i -indices -- {-I([\w/-]+)} $args i j] } {
-        set i [lindex $j 0]
-        set j [lindex $j 1]
-        lappend out "-I[string range $args $i $j]"
-    }
-
-    set i 0
-    while { [regexp -start $i -indices -- {-J([\w/-]+)} $args i j] } {
-        set i [lindex $j 0]
-        set j [lindex $j 1]
-        lappend out "-J[string range $args $i $j]"
-    }
-
-    set i 0
-    while { [regexp -start $i -indices -- {-version=([\w]+)} $args i j] } {
-        set i [lindex $j 0]
-        set j [lindex $j 1]
-        lappend out "-fversion=[string range $args $i $j]"
     }
 
     return $out


### PR DESCRIPTION
I can't see any benefit of doing it the former way.