### PR TITLE
Include checkedint.h where stdint limit macros are used

### DIFF
--- a/gcc/d/dfrontend/argtypes.c
+++ b/gcc/d/dfrontend/argtypes.c
@@ -12,6 +12,8 @@
 #include <stdio.h>
 #include <assert.h>
 
+#include "checkedint.h"
+
 #include "mars.h"
 #include "dsymbol.h"
 #include "mtype.h"

--- a/gcc/d/dfrontend/declaration.c
+++ b/gcc/d/dfrontend/declaration.c
@@ -12,6 +12,8 @@
 #include <stdio.h>
 #include <assert.h>
 
+#include "checkedint.h"
+
 #include "init.h"
 #include "declaration.h"
 #include "attrib.h"

--- a/gcc/d/dfrontend/statementsem.c
+++ b/gcc/d/dfrontend/statementsem.c
@@ -14,6 +14,7 @@
 
 #include "rmem.h"
 #include "target.h"
+#include "checkedint.h"
 
 #include "statement.h"
 #include "expression.h"

--- a/gcc/d/dfrontend/traits.c
+++ b/gcc/d/dfrontend/traits.c
@@ -17,6 +17,7 @@
 
 #include "rmem.h"
 #include "aav.h"
+#include "checkedint.h"
 
 //#include "port.h"
 #include "mtype.h"


### PR DESCRIPTION
@jpf91 - Should fix builds using older glibc versions.