### PR TITLE
Encapsulate GDC compiler-specific options away from the frontend.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,16 @@
+2017-02-19  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-lang.cc (iprefix_dir): Remove.
+	(imultilib_dir): Remove.
+	(std_inc): Remove.
+	(d_option_data): New struct.
+	(d_option): Declare.
+	(d_init_options): Initialize d_option.
+	(d_init): Update to use d_option.
+	(d_handle_option): Likewise.
+	(d_parse_file): Likewise.
+	(deps_write): Update signature.
+
 2017-02-11  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-objfile.cc (VarDeclaration::toObjFile): Error if a variable covers

--- a/gcc/d/dfrontend/globals.h
+++ b/gcc/d/dfrontend/globals.h
@@ -133,13 +133,6 @@ struct Param
     const char *moduleDepsFile; // filename for deps output
     OutBuffer *moduleDeps;      // contents to be written to deps file
 
-#ifdef IN_GCC
-    const char *makeDepsFile;   // filename for make deps output
-    OutBuffer *makeDeps;        // contents to be written to make deps file
-    char makeDepsStyle;         // 0: include system header files
-                                // 1: ignore system header files
-#endif
-
     // Hidden debug switches
     bool debugb;
     bool debugc;


### PR DESCRIPTION
Cleans up `Params`, and consolidates a bunch of static data that is not used anywhere else apart from d-lang.c.