### PR TITLE
Always import stdint.h through checkedint.h

### DIFF
--- a/gcc/d/dfrontend/mtype.c
+++ b/gcc/d/dfrontend/mtype.c
@@ -24,10 +24,10 @@
 #include <malloc.h>
 #endif
 
+#include "checkedint.h"
 #include "rmem.h"
 #include "port.h"
 #include "target.h"
-#include "checkedint.h"
 
 #include "dsymbol.h"
 #include "mtype.h"

--- a/gcc/d/dfrontend/statementsem.c
+++ b/gcc/d/dfrontend/statementsem.c
@@ -13,8 +13,8 @@
 #include <assert.h>
 
 #include "rmem.h"
-#include "target.h"
 #include "checkedint.h"
+#include "target.h"
 
 #include "statement.h"
 #include "expression.h"


### PR DESCRIPTION
@ibuclaw followup for https://github.com/D-Programming-GDC/GDC/pull/394

There are some cases (mtype.c AFAIR) where target.h or port.h import stdint.h before checkedint.h is imported explicitly.

I've simply replaced all stdint.h imports. We could leave the imports in the .c files unchanged as long as these don't use the limit macros, but it seems safer to just change all imports. The .h files have to be changed in any case.