### PR TITLE
Issue 119: Some way towards removing unfortunately named command-line options.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -43,6 +43,11 @@
 
 2017-02-18  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-objfile.cc (PragmaDeclaration::toObjFile): Warn about unknown
+	pragmas only if -Wunknown-pragmas.
+
+2017-02-18  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* d-glue.cc (Global::init): Initialize errorLimit to flag_max_errors.
 	(verror): Don't halt program after invocation limit.
 	* d-lang.cc (d_handle_option): Remove handling -fmax-error-messages.

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -41,6 +41,13 @@
 	(d_parse_file): Likewise.
 	(deps_write): Update signature.
 
+2017-02-18  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* lang.opt (fassert): Update help text.
+	(fin): Likewise.
+	(finvariants): Likewise.
+	(fout): Likewise.
+
 2017-02-11  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-objfile.cc (VarDeclaration::toObjFile): Error if a variable covers

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -5,6 +5,15 @@
 
 2017-02-21  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-lang.cc (d_handle_option): Handle -X and -Xf options.
+	(d_parse_file): Update.
+	* lang-specs.h: Add rules for -X style options.
+	* lang.opt (X): Declare.
+	(Xf): Declare.
+	(fXf=): Make alias for -Xf.
+
+2017-02-21  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* lang.opt (fd-vgc): Comment out help test.
 	(fd-verbose): Likewise.
 	(fd-vtls): Likewise.

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -43,6 +43,19 @@
 
 2017-02-18  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-lang.cc (d_handle_option): Replace -fin with -fpreconditions;
+	-fout with -fpostconditions.  Handle -fswitch-errors.
+	(d_post_options): Move setting of release code flags here.
+	* lang.opt (fassert): Declare flag_assert.
+	(fin): Make alias for -fpreconditions.
+	(finvariants): Declare flag_invariants.
+	(fout): Make alias for -fpostconditions.
+	(fpostconditions): Declare.
+	(fpreconditions): Declare.
+	(fswitch-errors): Declare.
+
+2017-02-18  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* d-objfile.cc (PragmaDeclaration::toObjFile): Warn about unknown
 	pragmas only if -Wunknown-pragmas.
 

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -43,6 +43,19 @@
 
 2017-02-18  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-decls.cc (get_symbol_decl): Handle -Wtemplates.
+	* d-lang.cc (d_init_options): Remove setting flag_emit_templates.
+	(d_handle_option): Replace handling -femit-templates with
+	-fall-instantiations.
+	(d_pushdecl): Remove checking for flag_emit_templates.
+	* d-tree.h (D_DECL_IS_TEMPLATE): Remove macro.
+	* lang.opt (flag_emit_templates): Remove variable.
+	(fall-instantiations): Declare.
+	(femit-templates): Make alias for -fall-instantiations.
+	(Wtemplates): Declare.
+
+2017-02-18  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* lang.opt (fassert): Update help text.
 	(fin): Likewise.
 	(finvariants): Likewise.

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -41,6 +41,11 @@
 	(d_parse_file): Likewise.
 	(deps_write): Update signature.
 
+2017-02-19  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-lang.cc (d_handle_option): Call D_handle_option_auto.
+	* lang.opt (Wunknown-pragmas): Turn on warning with -Wall.
+
 2017-02-18  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-lang.cc (d_handle_option): Replace -fin with -fpreconditions;

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -3,6 +3,13 @@
 	* imports.cc (ImportVisitor::visit(OverDeclaration)): New function.
 	(ImportVisitor::visit(FuncAliasDeclaration)): New function.
 
+2017-02-21  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* lang.opt (fd-vgc): Comment out help test.
+	(fd-verbose): Likewise.
+	(fd-vtls): Likewise.
+	(femit-modules): Likewise.
+
 2017-02-20  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-target.cc (Target::fieldalign): Adjust.

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -43,6 +43,13 @@
 
 2017-02-18  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-glue.cc (Global::init): Initialize errorLimit to flag_max_errors.
+	(verror): Don't halt program after invocation limit.
+	* d-lang.cc (d_handle_option): Remove handling -fmax-error-messages.
+	* lang.opt (fmax-error-messages): Remove option.
+
+2017-02-18  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* d-decls.cc (get_symbol_decl): Handle -Wtemplates.
 	* d-lang.cc (d_init_options): Remove setting flag_emit_templates.
 	(d_handle_option): Replace handling -femit-templates with

--- a/gcc/d/d-decls.cc
+++ b/gcc/d/d-decls.cc
@@ -384,10 +384,18 @@ get_symbol_decl (Declaration *decl)
       if (ti)
 	{
 	  D_DECL_ONE_ONLY (decl->csym) = 1;
-	  D_DECL_IS_TEMPLATE (decl->csym) = 1;
 
 	  if (!DECL_EXTERNAL (decl->csym) && ti->needsCodegen ())
-	    TREE_STATIC (decl->csym) = 1;
+	    {
+	      /* Warn about templates instantiated in this compilation.  */
+	      if (ti == decl->parent)
+		{
+		  warning (OPT_Wtemplates, "%s %s instantiated",
+			   ti->kind (), ti->toPrettyChars (false));
+		}
+
+	      TREE_STATIC (decl->csym) = 1;
+	    }
 	  else
 	    DECL_EXTERNAL (decl->csym) = 1;
 	}

--- a/gcc/d/d-glue.cc
+++ b/gcc/d/d-glue.cc
@@ -61,7 +61,7 @@ Global::init()
   this->stdmsg = stdout;
   this->main_d = "__main.d";
 
-  this->errorLimit = 20;
+  this->errorLimit = flag_max_errors;
 
   memset(&this->params, 0, sizeof(Param));
 }
@@ -165,10 +165,6 @@ verror(const Loc& loc, const char *format, va_list ap,
 
 	  error_at(location, "%s", msg);
 	}
-
-      // Moderate blizzard of cascading messages
-      if (global.errors >= 20)
-	fatal();
     }
   else
     global.gaggedErrors++;

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -803,6 +803,11 @@ d_handle_option (size_t scode, const char *arg, int value,
       break;
     }
 
+  D_handle_option_auto (&global_options, &global_options_set,
+			scode, arg, value,
+			d_option_lang_mask (), kind,
+			loc, handlers, global_dc);
+
   return result;
 }
 

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -800,16 +800,6 @@ d_handle_option (size_t scode, const char *arg, int value,
 	global.params.warnings = 1;
       break;
 
-    case OPT_fmax_error_messages_:
-      {
-	int limit = integral_argument(arg);
-	if (limit == -1)
-	  error ("bad argument for -fmax-error-messages '%s'", arg);
-	else
-	  global.errorLimit = limit;
-	break;
-      }
-
     default:
       break;
     }
@@ -849,7 +839,7 @@ d_post_options (const char ** fn)
   if (global.params.useDeprecated == 2 && global.params.warnings == 1)
     global.params.useDeprecated = 0;
 
-  // Make -fmax-errors visible to gdc's diagnostic machinery.
+  // Make -fmax-errors visible to frontend's diagnostic machinery.
   if (global_options_set.x_flag_max_errors)
     global.errorLimit = flag_max_errors;
 

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -612,10 +612,6 @@ d_handle_option (size_t scode, const char *arg, int value,
       global.params.ignoreUnsupportedPragmas = value;
       break;
 
-    case OPT_fin:
-      global.params.useIn = value;
-      break;
-
     case OPT_fintfc:
       global.params.doHdrGeneration = value;
       break;
@@ -642,8 +638,12 @@ d_handle_option (size_t scode, const char *arg, int value,
       d_option.fonly = arg;
       break;
 
-    case OPT_fout:
+    case OPT_fpostconditions:
       global.params.useOut = value;
+      break;
+
+    case OPT_fpreconditions:
+      global.params.useIn = value;
       break;
 
     case OPT_fproperty:
@@ -652,11 +652,10 @@ d_handle_option (size_t scode, const char *arg, int value,
 
     case OPT_frelease:
       global.params.release = value;
-      global.params.useInvariants = !value;
-      global.params.useIn = !value;
-      global.params.useOut = !value;
-      global.params.useAssert = !value;
-      global.params.useSwitchError = !value;
+      break;
+
+    case OPT_fswitch_errors:
+      global.params.useSwitchError = value;
       break;
 
     case OPT_ftransition_all:
@@ -833,6 +832,24 @@ d_post_options (const char ** fn)
       global.params.useArrayBounds = global.params.release
 	? BOUNDSCHECKsafeonly : BOUNDSCHECKon;
       flag_bounds_check = !global.params.release;
+    }
+
+  if (global.params.release)
+    {
+      if (!global_options_set.x_flag_invariants)
+	global.params.useInvariants = false;
+
+      if (!global_options_set.x_flag_preconditions)
+	global.params.useIn = false;
+
+      if (!global_options_set.x_flag_postconditions)
+	global.params.useOut = false;
+
+      if (!global_options_set.x_flag_assert)
+	global.params.useAssert = false;
+
+      if (!global_options_set.x_flag_switch_errors)
+	global.params.useSwitchError = false;
     }
 
   // Error about use of deprecated features.

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -366,8 +366,6 @@ d_init_options(unsigned int, cl_decoded_option *decoded_options)
   d_option.deps_target = NULL;
   d_option.deps_phony = false;
   d_option.stdinc = true;
-
-  flag_emit_templates = 1;
 }
 
 /* Initialize options structure OPTS.  */
@@ -539,6 +537,10 @@ d_handle_option (size_t scode, const char *arg, int value,
 
   switch (code)
     {
+    case OPT_fall_instantiations:
+      global.params.allInst = value;
+      break;
+
     case OPT_fassert:
       global.params.useAssert = value;
       break;
@@ -604,11 +606,6 @@ d_handle_option (size_t scode, const char *arg, int value,
 
     case OPT_fdoc_inc_:
       global.params.ddocfiles->push (arg);
-      break;
-
-    case OPT_femit_templates:
-      flag_emit_templates = value ? 1 : 0;
-      global.params.allInst = value;
       break;
 
     case OPT_fignore_unknown_pragmas:
@@ -1540,10 +1537,6 @@ d_pushdecl (tree decl)
       else
 	DECL_CONTEXT (decl) = get_global_context ();
     }
-
-  /* If template is not needed, don't send it to backend.  */
-  if (D_DECL_IS_TEMPLATE (decl) && !flag_emit_templates)
-    return decl;
 
   /* Put decls on list in reverse order.  */
   if (TREE_STATIC (decl) || d_global_bindings_p ())

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -183,10 +183,11 @@ PragmaDeclaration::toObjFile()
 {
   if (!global.params.ignoreUnsupportedPragmas)
     {
-      if (ident == Id::lib)
-	warning (loc, "pragma(lib) not implemented");
-       else if (ident == Id::startaddress)
-	 warning (loc, "pragma(startaddress) not implemented");
+      if (ident == Id::lib || ident == Id::startaddress)
+	{
+	  warning_at (get_linemap (this->loc), OPT_Wunknown_pragmas,
+		      "pragma(%s) not implemented", ident->toChars ());
+	}
     }
 
   AttribDeclaration::toObjFile();

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -46,8 +46,7 @@ class TypeFunction;
 
    Usage of DECL_LANG_FLAG_?:
    0: D_DECL_ONE_ONLY
-   1: D_DECL_IS_TEMPLATE
-   2: LABEL_VARIABLE_CASE (in LABEL_DECL).  */
+   1: LABEL_VARIABLE_CASE (in LABEL_DECL).  */
 
 /* The kinds of scopes we recognise.  */
 
@@ -328,15 +327,9 @@ lang_tree_node
 #define D_DECL_ONE_ONLY(NODE) \
   (DECL_LANG_FLAG_0 (NODE))
 
-/* True if the symbol is a template member.  Need to distinguish between
-   templates and other shared static data so that the latter is not affected
-   by -femit-templates.  */
-#define D_DECL_IS_TEMPLATE(NODE) \
-  (DECL_LANG_FLAG_1 (NODE))
-
 /* True if the decl is a variable case label decl.  */
 #define LABEL_VARIABLE_CASE(NODE) \
-  (DECL_LANG_FLAG_2 (LABEL_DECL_CHECK (NODE)))
+  (DECL_LANG_FLAG_1 (LABEL_DECL_CHECK (NODE)))
 
 enum d_tree_index
 {

--- a/gcc/d/lang-specs.h
+++ b/gcc/d/lang-specs.h
@@ -29,5 +29,6 @@
   "%{!E:cc1d %i %(cc1_options) %(cc1d) %I %{nostdinc*} %{+e*} %{I*} %{J*}\
     %{MD:-MD %b.deps} %{MMD:-MMD %b.deps}\
     %{M} %{MM} %{MF*} %{MG} %{MP} %{MQ*} %{MT*}\
+    %{X:-Xf %b.json} %{Xf*}\
     %{v} %{!fsyntax-only:%(invoke_as)}}", 0, 1, 0 },
 

--- a/gcc/d/lang.opt
+++ b/gcc/d/lang.opt
@@ -185,19 +185,19 @@ D Joined RejectNegative
 
 fd-vgc
 D Alias(ftransition=nogc)
-Deprecated in favor of -ftransition=nogc
+; Deprecated in favor of -ftransition=nogc
 
 fd-verbose
 D Alias(v)
-Deprecated in favor of --verbose
+; Deprecated in favor of --verbose
 
 fd-vtls
 D Alias(ftransition=tls)
-Deprecated in favor of -ftransition=tls.
+; Deprecated in favor of -ftransition=tls.
 
 femit-moduleinfo
 D Alias(fmoduleinfo)
-Deprecated in favor of -fmoduleinfo.
+; Deprecated in favor of -fmoduleinfo.
 
 femit-templates
 D Alias(fall-instantiations)

--- a/gcc/d/lang.opt
+++ b/gcc/d/lang.opt
@@ -157,7 +157,7 @@ Compile in debug code.
 
 fdebug=
 D Joined RejectNegative
--fdebug,-fdebug=<level>,-fdebug=<ident>	Compile in debug code, code <= 'level', or code identified by 'ident'.
+-fdebug=<level|ident>	Compile in debug code, code <= <level>, or code identified by <ident>.
 
 fdeps
 D
@@ -165,7 +165,7 @@ Print information about module dependencies.
 
 fdeps=
 D Joined RejectNegative
--fdeps=<filename>	Write module dependencies to 'filename'.
+-fdeps=<file>	Write module dependencies to <file>.
 
 fdoc
 D
@@ -173,15 +173,15 @@ Generate documentation.
 
 fdoc-dir=
 D Joined RejectNegative
--fdoc-dir=<docdir>	Write documentation file to 'docdir' directory.
+-fdoc-dir=<dir>	Write documentation file to directory <dir>.
 
 fdoc-file=
 D Joined RejectNegative
--fdoc-file=<filename>	Write documentation file to 'filename'.
+-fdoc-file=<file>	Write documentation to <file>.
 
 fdoc-inc=
 D Joined RejectNegative
--fdoc-inc=<filename>	Include a Ddoc macro file.
+-fdoc-inc=<file>	Include a Ddoc macro <file>.
 
 fd-vgc
 D Alias(ftransition=nogc)
@@ -216,11 +216,11 @@ Generate D interface files.
 
 fintfc-dir=
 D Joined RejectNegative
--fintfc-dir=<dir>	Write D interface files to directory 'dir'.
+-fintfc-dir=<dir>	Write D interface files to directory <dir>.
 
 fintfc-file=
 D Joined RejectNegative
--fintfc-file=<filename>	Write D interface file to 'filename'.
+-fintfc-file=<file>	Write D interface to <file>.
 
 finvariants
 D
@@ -304,11 +304,11 @@ Compile in unittest code.
 
 fversion=
 D Joined RejectNegative
--fversion=<level|ident>	Compile in version code >= 'level' or identified by 'ident'.
+-fversion=<level|ident>	Compile in version code >= <level> or identified by <ident>.
 
 fXf=
 D Joined RejectNegative
--fXf=<filename>	Write JSON file to 'filename'.
+-fXf=<file>	Write JSON file to <file>.
 
 imultilib
 D Joined Separate

--- a/gcc/d/lang.opt
+++ b/gcc/d/lang.opt
@@ -124,7 +124,7 @@ D
 Generate code for all template instantiations.
 
 fassert
-D
+D Var(flag_assert)
 Generate code for assert contracts.
 
 fbounds-check
@@ -208,8 +208,8 @@ D
 Ignore unsupported pragmas.
 
 fin
-D
-Generate code for precondition contracts.
+D Alias(fpreconditions)
+; Deprecated in favor of -fpreconditions.
 
 fintfc
 Generate D interface files.
@@ -223,7 +223,7 @@ D Joined RejectNegative
 -fintfc-file=<file>	Write D interface to <file>.
 
 finvariants
-D
+D Var(flag_invariants)
 Generate code for class invariant contracts.
 
 fmake-deps
@@ -251,8 +251,16 @@ D Joined RejectNegative
 Process all modules specified on the command line, but only generate code for the module specified by the argument.
 
 fout
-D
+D Alias(fpostconditions)
+; Deprecated in favor of -fpostconditions.
+
+fpostconditions
+D Var(flag_postconditions)
 Generate code for postcondition contracts.
+
+fpreconditions
+D Var(flag_preconditions)
+Generate code for precondition contracts.
 
 fproperty
 D
@@ -261,6 +269,10 @@ Enforce property syntax.
 frelease
 D
 Compile release version.
+
+fswitch-errors
+D Var(flag_switch_errors)
+Generate code for switches without a default case.
 
 ftransition=all
 D RejectNegative

--- a/gcc/d/lang.opt
+++ b/gcc/d/lang.opt
@@ -345,7 +345,3 @@ Link the standard D library dynamically in the compilation.
 v
 D
 ; Documented in C
-
-fmax-error-messages=
-D Joined RejectNegative
-Limit the number of error messages (0 means unlimited)

--- a/gcc/d/lang.opt
+++ b/gcc/d/lang.opt
@@ -92,7 +92,7 @@ D Alias(v)
 
 fassert
 D
-; Documented in Java
+Generate code for assert contracts.
 
 fbounds-check
 D
@@ -176,7 +176,7 @@ Ignore unsupported pragmas.
 
 fin
 D
-Generate runtime code for in() contracts.
+Generate code for precondition contracts.
 
 fintfc
 Generate D interface files.
@@ -191,7 +191,7 @@ D Joined RejectNegative
 
 finvariants
 D
-Generate runtime code for invariant()'s.
+Generate code for class invariant contracts.
 
 fmake-deps
 D Alias(M)
@@ -219,7 +219,7 @@ Process all modules specified on the command line, but only generate code for th
 
 fout
 D
-Generate runtime code for out() contracts.
+Generate code for postcondition contracts.
 
 fproperty
 D

--- a/gcc/d/lang.opt
+++ b/gcc/d/lang.opt
@@ -108,6 +108,14 @@ Wunknown-pragmas
 D LangEnabledBy(D, Wall)
 ; Documented in C
 
+X
+D
+Generate JSON file.
+
+Xf
+D Joined Separate
+-Xf <file>	Write JSON output to the given <file>.
+
 debuglib=
 Driver Joined
 Debug library to use instead of phobos.
@@ -319,8 +327,8 @@ D Joined RejectNegative
 -fversion=<level|ident>	Compile in version code >= <level> or identified by <ident>.
 
 fXf=
-D Joined RejectNegative
--fXf=<file>	Write JSON file to <file>.
+D Joined RejectNegative Alias(Xf)
+; Deprecated in favor of -Xf
 
 imultilib
 D Joined Separate

--- a/gcc/d/lang.opt
+++ b/gcc/d/lang.opt
@@ -20,9 +20,6 @@
 Language
 D
 
-Variable
-int flag_emit_templates
-
 -dependencies
 D Alias(M)
 ; Documented in C
@@ -89,6 +86,10 @@ Default library to use instead of phobos.
 
 -verbose
 D Alias(v)
+
+fall-instantiations
+D
+Generate code for all template instantiations.
 
 fassert
 D
@@ -167,8 +168,8 @@ D Alias(fmoduleinfo)
 Deprecated in favor of -fmoduleinfo.
 
 femit-templates
-D
-Generate code for all template instantiations.
+D Alias(fall-instantiations)
+; Deprecated in favor of -fall-instantiations.
 
 fignore-unknown-pragmas
 D
@@ -336,6 +337,10 @@ D
 Werror
 D
 ; Documented in common.opt
+
+Wtemplates
+D
+; Documented in C
 
 Wunknown-pragmas
 D

--- a/gcc/d/lang.opt
+++ b/gcc/d/lang.opt
@@ -105,7 +105,7 @@ D
 ; Documented in C
 
 Wunknown-pragmas
-D
+D LangEnabledBy(D, Wall)
 ; Documented in C
 
 debuglib=

--- a/gcc/d/lang.opt
+++ b/gcc/d/lang.opt
@@ -40,6 +40,14 @@ D NoDriverArg Separate Alias(MD)
 D NoDriverArg Separate Alias(MMD)
 ; Documented in C
 
+I
+D Joined Separate
+; Documented in C
+
+J
+D Joined Separate
+; Different from documented use in Fortran.
+
 M
 D
 ; Documented in C
@@ -74,6 +82,30 @@ D Joined Separate
 
 MQ
 D Joined Separate
+; Documented in C
+
+Wall
+D
+; Documented in C
+
+Wcast-result
+D Warning Var(warn_cast_result)
+Warn about casts that will produce a null result.
+
+Wdeprecated
+D
+; Documented in C
+
+Werror
+D
+; Documented in common.opt
+
+Wtemplates
+D
+; Documented in C
+
+Wunknown-pragmas
+D
 ; Documented in C
 
 debuglib=
@@ -294,14 +326,6 @@ isystem
 D Joined Separate
 ; Documented in C
 
-I
-D Joined Separate
-; Documented in C
-
-J
-D Joined Separate
-; Different from documented use in Fortran.
-
 nophoboslib
 Driver
 Do not link the standard D library in the compilation.
@@ -319,30 +343,6 @@ Driver
 Link the standard D library dynamically in the compilation.
 
 v
-D
-; Documented in C
-
-Wall
-D
-; Documented in C
-
-Wcast-result
-D Warning Var(warn_cast_result)
-Warn about casts that will produce a null result.
-
-Wdeprecated
-D
-; Documented in C
-
-Werror
-D
-; Documented in common.opt
-
-Wtemplates
-D
-; Documented in C
-
-Wunknown-pragmas
 D
 ; Documented in C
 


### PR DESCRIPTION
New:
- `-Wtemplates`
- `-X`
- `-Xf`
- `-fall-instantiations`
- `-fpostconditions`
- `-fpreconditions`
- `-fswitch-errors`

Fixed:
- `-Wunknown-pragmas`
- `-fassert`
- `-fdebug=`

Old:
- `-femit-templates`
- `-fin`
- `-fout`
- `-fXf=`
- `-fmax-error-messages=`

Would still like to do shorthand options `-H` and `-D`, deprecating `-fintfc` and `-fdoc`.  So far, am seeing if I can bounce some ideas here: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67304

