### PR TITLE
Add tests from previous LTO bugs to testsuite

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,7 @@
+2017-03-04  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-objfile.cc (emit_dso_registry_hooks): Set DECL_PRESERVE_P.
+
 2017-02-26  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-codegen.cc (build_frame_type): Update condition for scope

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -1900,6 +1900,7 @@ emit_dso_registry_hooks(tree sym, Dsymbol *compiler_dso_type, Dsymbol *dso_regis
   set_decl_location(decl, current_module_decl);
   TREE_PUBLIC (decl) = 1;
   TREE_STATIC (decl) = 1;
+  DECL_PRESERVE_P (decl) = 1;
   DECL_INITIAL (decl) = build_address(sym);
   TREE_STATIC (DECL_INITIAL (decl)) = 1;
 

--- a/gcc/testsuite/gdc.test/runnable/gdclto.d
+++ b/gcc/testsuite/gdc.test/runnable/gdclto.d
@@ -1,0 +1,89 @@
+// PERMUTE_ARGS: -g -release
+// EXTRA_SOURCES: imports/gdcltoa.d
+// { dg-additional-options "-flto" }
+
+module gdclto;
+
+import imports.gdcltoa;
+import core.stdc.stdio;
+
+
+/******************************************/
+
+/+ XBUG: Compiling with -O2 -shared-libphobos
+In function `gdc_dso_dtor':
+undefined reference to `__start_minfo'
+undefined reference to `__stop_minfo'
+a.out: hidden symbol `__stop_minfo' isn't defined
+final link failed: Bad value
++/
+
+/******************************************/
+
+/+ XBUG: lto1: internal compiler error: in get_odr_type
+interface I284
+{
+   void m284();
+}
+
+class C284 : I284
+{
+   void m284() { }
+}
++/
+
+/******************************************/
+
+/+ XBUG: lto1: internal compiler error: in get_odr_type
+class C304
+{
+}
+
+C304 c304;
++/
+
+/******************************************/
+
+// Bug 61
+
+struct S61a
+{
+    void a() { }
+    void b() { }
+}
+
+struct S61b
+{
+    S61a other;
+
+    void foo()
+    {
+        bar();
+    }
+
+    void bar()
+    {
+        try
+            other.a();
+        catch
+            other.b();
+    }
+}
+
+/******************************************/
+
+// Bug 88
+
+void test88()
+{
+    test88a();
+}
+
+/******************************************/
+
+void main(string[])
+{
+    test88();
+
+    printf("Success!\n");
+}

--- a/gcc/testsuite/gdc.test/runnable/gdclto.d
+++ b/gcc/testsuite/gdc.test/runnable/gdclto.d
@@ -1,4 +1,3 @@
-// PERMUTE_ARGS: -g -release
 // EXTRA_SOURCES: imports/gdcltoa.d
 // { dg-additional-options "-flto" }
 
@@ -7,16 +6,6 @@ module gdclto;
 import imports.gdcltoa;
 import core.stdc.stdio;
 
-
-/******************************************/
-
-/+ XBUG: Compiling with -O2 -shared-libphobos
-In function `gdc_dso_dtor':
-undefined reference to `__start_minfo'
-undefined reference to `__stop_minfo'
-a.out: hidden symbol `__stop_minfo' isn't defined
-final link failed: Bad value
-+/
 
 /******************************************/
 

--- a/gcc/testsuite/gdc.test/runnable/imports/gdcltoa.d
+++ b/gcc/testsuite/gdc.test/runnable/imports/gdcltoa.d
@@ -1,0 +1,10 @@
+module imports.gdcltoa;
+
+/******************************************/
+
+// Bug 88
+
+int test88a()
+{
+    return 0;
+}


### PR DESCRIPTION
Looks like there's a possible regression with virtual + classes.  Sadly can't mix shared library + -O2 together either, which needs looking into.