### PR TITLE
Bug 255: ICE walking chain to get right 'this'

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,10 @@
 2017-03-04  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-codegen.cc (get_decl_tree): Handle chaining over many levels of
+	nesting functions to get to the right parent for the 'this' field.
+
+2017-03-04  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* d-decls.cc (get_symbol_decl): Move generation of DECL_ARGUMENTS for
 	empty body declarations to ...
 	(make_thunk): ... here.  Also set-up DECL_RESULT.

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -457,48 +457,57 @@ get_decl_tree (Declaration *decl)
 	  return component_ref (build_deref (frame_ref),
 				DECL_LANG_FRAME_FIELD (vsym));
 	}
-      else if (vd->parent != func && vd->isThisDeclaration() && func->isThis())
+      else if (vd->parent != func && vd->isThisDeclaration ())
 	{
 	  // Get the non-local 'this' value by going through parent link
 	  // of nested classes, this routine pretty much undoes what
 	  // getRightThis in the frontend removes from codegen.
-	  AggregateDeclaration *ad = func->isThis();
-	  tree this_tree = get_symbol_decl (func->vthis);
-
-	  while (true)
+	  AggregateDeclaration *ad = func->isThis ();
+	  if (ad != NULL)
 	    {
-	      Dsymbol *outer = ad->toParent2();
-	      // Get the this->this parent link.
-	      tree vthis_field = get_symbol_decl (ad->vthis);
-	      this_tree = component_ref (build_deref (this_tree), vthis_field);
+	      tree this_tree = get_symbol_decl (func->vthis);
+	      Dsymbol *outer = func;
 
-	      ad = outer->isAggregateDeclaration();
-	      if (ad != NULL)
-		continue;
-
-	      FuncDeclaration *fd = outer->isFuncDeclaration();
-	      if (fd != NULL)
-		ad = fd->isThis();
-
-	      if (fd && ad)
+	      while (outer != vd->parent)
 		{
-		  // If outer function creates a closure, then the 'this' value
-		  // would be the closure pointer, and the real 'this' the first
-		  // field of that closure.
-		  tree ff = get_frameinfo (fd);
-		  if (FRAMEINFO_CREATES_FRAME (ff))
+		  gcc_assert (ad != NULL);
+		  outer = ad->toParent2 ();
+
+		  // Get the this->this parent link.
+		  tree vthis_field = get_symbol_decl (ad->vthis);
+		  this_tree = component_ref (build_deref (this_tree),
+					     vthis_field);
+
+		  ad = outer->isAggregateDeclaration ();
+		  if (ad != NULL)
+		    continue;
+
+		  FuncDeclaration *fd = outer->isFuncDeclaration ();
+		  while (fd != NULL)
 		    {
-		      this_tree = build_nop (build_pointer_type (FRAMEINFO_TYPE (ff)),
-					     this_tree);
-		      this_tree = indirect_ref (build_ctype(ad->type), this_tree);
+		      // If outer function creates a closure, then the 'this'
+		      // value would be the closure pointer, and the real
+		      // 'this' the first field of that closure.
+		      tree ff = get_frameinfo (fd);
+		      if (FRAMEINFO_CREATES_FRAME (ff))
+			{
+			  this_tree = build_nop (build_pointer_type (FRAMEINFO_TYPE (ff)),
+						 this_tree);
+			  this_tree = indirect_ref (build_ctype (fd->vthis->type),
+						    this_tree);
+			}
+
+		      if (fd == vd->parent)
+			break;
+
+		      // Continue looking for the right 'this'
+		      outer = outer->toParent2 ();
+		      fd = outer->isFuncDeclaration ();
 		    }
 
-		  // Continue looking for the right 'this'
-		  if (fd != vd->parent)
-		    continue;
+		  ad = outer->isAggregateDeclaration ();
 		}
 
-	      gcc_assert (outer == vd->parent);
 	      return this_tree;
 	    }
 	}

--- a/gcc/testsuite/gdc.test/compilable/gdc255.d
+++ b/gcc/testsuite/gdc.test/compilable/gdc255.d
@@ -1,0 +1,83 @@
+// Bug 255
+
+class C255
+{
+    void f2()
+    {
+        class C1
+        {
+            void f1()
+            {
+                void f0()
+                {
+                    class C0
+                    {
+                        void test255()
+                        {
+                            f2();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+class C255a
+{
+    void f3()
+    {
+        class C1
+        {
+            void f2()
+            {
+                void f1()
+                {
+                    void f0()
+                    {
+                        class C0
+                        {
+                            void test255a()
+                            {
+                                f3();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+class C255b
+{
+    void f4()
+    {
+        class C2
+        {
+            void f3()
+            {
+                void f2()
+                {
+                    class C1
+                    {
+                        void f1()
+                        {
+                            void f0()
+                            {
+                                class C0
+                                {
+                                    void test255b()
+                                    {
+                                        f4();
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
The original logic didn't take into account that we could encounter two or more levels of nested functions.

I'm sure there ought to be a way to build this using a visitor interface. It would certainly increase the maintainability of this code ten-fold. :-)