### PR TITLE
Merge more headers from upstream stable branch.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,17 @@
 2017-03-06  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-glue.cc (verror): Update to handle -Wspeculative.
+	(verrorSupplemental): Likewise.
+	* d-lang.cc (d_init_options): Initialize module alias array.
+	(d_init_options): Handle -fmodule-filepath= and -Wspeculative.
+	* d-port.cc (Port::stricmp): Remove function.
+	(Port::writelongLE): New function.
+	(Port::writelongBE): New function.
+	* lang.opt (Wspeculative): Declare.
+	(fmodule-filepath=): Declare.
+
+2017-03-06  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* d-lang.cc (d_handle_option): Handle -ftransition=dip1000
 	* lang.opt (ftransition=dip1000): Declare.
 	(ftransition=safe): Make alias for -ftransition=dip1000

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -354,6 +354,7 @@ d_init_options(unsigned int, cl_decoded_option *decoded_options)
 
   global.params.imppath = new Strings();
   global.params.fileImppath = new Strings();
+  global.params.modFileAliasStrings = new Strings ();
 
   /* Extra GDC-specific options.  */
   d_option.fonly = NULL;
@@ -630,6 +631,12 @@ d_handle_option (size_t scode, const char *arg, int value,
       global.params.useInvariants = value;
       break;
 
+    case OPT_fmodule_filepath_:
+      global.params.modFileAliasStrings->push (arg);
+      if (!strchr (arg, '='))
+	error ("bad argument for -fmodule-filepath");
+      break;
+
     case OPT_fmoduleinfo:
       global.params.betterC = !value;
       break;
@@ -793,6 +800,11 @@ d_handle_option (size_t scode, const char *arg, int value,
     case OPT_Werror:
       if (value)
 	global.params.warnings = 1;
+      break;
+
+    case OPT_Wspeculative:
+      if (value)
+	global.params.showGaggedErrors = 1;
       break;
 
     case OPT_Xf:
@@ -1035,7 +1047,7 @@ genCmain (Scope *sc)
 
   // We are emitting this straight to object file.
   entrypoint = m;
-  rootmodule = sc->module;
+  rootmodule = sc->_module;
 }
 
 void

--- a/gcc/d/d-port.cc
+++ b/gcc/d/d-port.cc
@@ -82,20 +82,6 @@ Port::fequal(longdouble x, longdouble y)
     || real_identical(&x.rv(), &y.rv());
 }
 
-char *
-Port::strupr(char *s)
-{
-  char *t = s;
-
-  while (*s)
-    {
-      *s = TOUPPER (*s);
-      s++;
-    }
-
-  return t;
-}
-
 int
 Port::memicmp(const char *s1, const char *s2, int n)
 {
@@ -118,30 +104,18 @@ Port::memicmp(const char *s1, const char *s2, int n)
   return result;
 }
 
-int
-Port::stricmp(const char *s1, const char *s2)
+char *
+Port::strupr(char *s)
 {
-  int result = 0;
+  char *t = s;
 
-  for (;;)
+  while (*s)
     {
-      char c1 = *s1;
-      char c2 = *s2;
-
-      result = c1 - c2;
-      if (result)
-	{
-	  result = TOUPPER (c1) - TOUPPER (c2);
-	  if (result)
-	    break;
-	}
-      if (!c1)
-	break;
-      s1++;
-      s2++;
+      *s = TOUPPER (*s);
+      s++;
     }
 
-  return result;
+  return t;
 }
 
 // Return a longdouble value from string BUFFER rounded to float mode.
@@ -204,6 +178,19 @@ Port::readwordBE(void *buffer)
   return ((unsigned) p[0] << 8) | (unsigned) p[1];
 }
 
+// Write a little-endian 32-bit value.
+
+void
+Port::writelongLE(unsigned value, void *buffer)
+{
+    unsigned char *p = (unsigned char*) buffer;
+
+    p[0] = (unsigned) value;
+    p[1] = (unsigned) value >> 8;
+    p[2] = (unsigned) value >> 16;
+    p[3] = (unsigned) value >> 24;
+}
+
 // Fetch a little-endian 32-bit value.
 
 unsigned
@@ -215,6 +202,19 @@ Port::readlongLE(void *buffer)
           | ((unsigned) p[2] << 16)
           | ((unsigned) p[1] << 8)
           | (unsigned) p[0]);
+}
+
+// Write a big-endian 32-bit value.
+
+void
+Port::writelongBE(unsigned value, void *buffer)
+{
+    unsigned char *p = (unsigned char*) buffer;
+
+    p[0] = (unsigned) value >> 24;
+    p[1] = (unsigned) value >> 16;
+    p[2] = (unsigned) value >> 8;
+    p[3] = (unsigned) value;
 }
 
 // Fetch a big-endian 32-bit value.

--- a/gcc/d/dfrontend/access.c
+++ b/gcc/d/dfrontend/access.c
@@ -198,7 +198,7 @@ bool checkAccess(AggregateDeclaration *ad, Loc loc, Scope *sc, Dsymbol *smember)
                  hasPrivateAccess(ad, f) ||
                  isFriendOf(ad, cdscope) ||
                  (access.kind == PROTpackage && hasPackageAccess(sc, smember)) ||
-                 ad->getAccessModule() == sc->module;
+                 ad->getAccessModule() == sc->_module;
 #if LOG
         printf("result1 = %d\n", result);
 #endif
@@ -266,7 +266,7 @@ bool isFriendOf(AggregateDeclaration *ad, AggregateDeclaration *cd)
  */
 bool hasPackageAccess(Scope *sc, Dsymbol *s)
 {
-    return hasPackageAccess(sc->module, s);
+    return hasPackageAccess(sc->_module, s);
 }
 
 bool hasPackageAccess(Module *mod, Dsymbol *s)
@@ -359,7 +359,7 @@ bool hasProtectedAccess(Scope *sc, Dsymbol *s)
                 return true;
         }
     }
-    return sc->module == s->getAccessModule();
+    return sc->_module == s->getAccessModule();
 }
 
 /**********************************
@@ -444,11 +444,11 @@ bool checkAccess(Loc loc, Scope *sc, Expression *e, Declaration *d)
     }
     if (!e)
     {
-        if (d->prot().kind == PROTprivate && d->getAccessModule() != sc->module ||
+        if (d->prot().kind == PROTprivate && d->getAccessModule() != sc->_module ||
             d->prot().kind == PROTpackage && !hasPackageAccess(sc, d))
         {
             error(loc, "%s %s is not accessible from module %s",
-                d->kind(), d->toPrettyChars(), sc->module->toChars());
+                d->kind(), d->toPrettyChars(), sc->_module->toChars());
             return true;
         }
     }
@@ -489,7 +489,7 @@ bool checkAccess(Loc loc, Scope *sc, Expression *e, Declaration *d)
  */
 bool checkAccess(Loc loc, Scope *sc, Package *p)
 {
-    if (sc->module == p)
+    if (sc->_module == p)
         return false;
     for (; sc; sc = sc->enclosing)
     {
@@ -565,9 +565,9 @@ bool symbolIsVisible(Scope *sc, Dsymbol *s)
         case PROTnone:
             return false; // no access
         case PROTprivate:
-            return sc->module == s->getAccessModule();
+            return sc->_module == s->getAccessModule();
         case PROTpackage:
-            return hasPackageAccess(sc->module, s);
+            return hasPackageAccess(sc->_module, s);
         case PROTprotected:
             return hasProtectedAccess(sc, s);
         case PROTpublic:

--- a/gcc/d/dfrontend/arrayop.c
+++ b/gcc/d/dfrontend/arrayop.c
@@ -77,10 +77,10 @@ FuncDeclaration *buildArrayOp(Identifier *ident, BinExp *exp, Scope *sc, Loc loc
     fd->linkage = LINKc;
     fd->isArrayOp = 1;
 
-    sc->module->importedFrom->members->push(fd);
+    sc->_module->importedFrom->members->push(fd);
 
     sc = sc->push();
-    sc->parent = sc->module->importedFrom;
+    sc->parent = sc->_module->importedFrom;
     sc->stc = 0;
     sc->linkage = LINKc;
     fd->semantic(sc);

--- a/gcc/d/dfrontend/attrib.c
+++ b/gcc/d/dfrontend/attrib.c
@@ -590,9 +590,9 @@ void ProtDeclaration::addMember(Scope *sc, ScopeDsymbol *sds)
         pkg_identifiers = NULL;
     }
 
-    if (protection.kind == PROTpackage && protection.pkg && sc->module)
+    if (protection.kind == PROTpackage && protection.pkg && sc->_module)
     {
-        Module *m = sc->module;
+        Module *m = sc->_module;
         Package* pkg = m->parent ? m->parent->isPackage() : NULL;
         if (!pkg || !protection.pkg->isAncestorPackageOf(pkg))
             error("does not bind to one of ancestor packages of module '%s'",
@@ -1445,7 +1445,7 @@ void CompileDeclaration::compileIt(Scope *sc)
         {
             se = se->toUTF8(sc);
             unsigned errors = global.errors;
-            Parser p(loc, sc->module, (utf8_t *)se->string, se->len, 0);
+            Parser p(loc, sc->_module, (utf8_t *)se->string, se->len, 0);
             p.nextToken();
 
             decl = p.parseDeclDefs(0);

--- a/gcc/d/dfrontend/class.c
+++ b/gcc/d/dfrontend/class.c
@@ -474,7 +474,7 @@ void ClassDeclaration::semantic(Scope *sc)
             {
                 //printf("\ttry later, forward reference of base class %s\n", tc->sym->toChars());
                 if (tc->sym->_scope)
-                    tc->sym->_scope->module->addDeferredSemantic(tc->sym);
+                    tc->sym->_scope->_module->addDeferredSemantic(tc->sym);
                 baseok = BASEOKnone;
             }
          L7: ;
@@ -526,7 +526,7 @@ void ClassDeclaration::semantic(Scope *sc)
             {
                 //printf("\ttry later, forward reference of base %s\n", tc->sym->toChars());
                 if (tc->sym->_scope)
-                    tc->sym->_scope->module->addDeferredSemantic(tc->sym);
+                    tc->sym->_scope->_module->addDeferredSemantic(tc->sym);
                 baseok = BASEOKnone;
             }
             i++;
@@ -536,7 +536,7 @@ void ClassDeclaration::semantic(Scope *sc)
             // Forward referencee of one or more bases, try again later
             _scope = scx ? scx : sc->copy();
             _scope->setNoFree();
-            _scope->module->addDeferredSemantic(this);
+            _scope->_module->addDeferredSemantic(this);
             //printf("\tL%d semantic('%s') failed due to forward references\n", __LINE__, toChars());
             return;
         }
@@ -649,8 +649,8 @@ Lancestorsdone:
             _scope = scx ? scx : sc->copy();
             _scope->setNoFree();
             if (tc->sym->_scope)
-                tc->sym->_scope->module->addDeferredSemantic(tc->sym);
-            _scope->module->addDeferredSemantic(this);
+                tc->sym->_scope->_module->addDeferredSemantic(tc->sym);
+            _scope->_module->addDeferredSemantic(this);
             //printf("\tL%d semantic('%s') failed due to forward references\n", __LINE__, toChars());
             return;
         }
@@ -749,7 +749,7 @@ Lancestorsdone:
 
         _scope = scx ? scx : sc->copy();
         _scope->setNoFree();
-        _scope->module->addDeferredSemantic(this);
+        _scope->_module->addDeferredSemantic(this);
         //printf("\tdeferring %s\n", toChars());
         return;
     }
@@ -1556,7 +1556,7 @@ void InterfaceDeclaration::semantic(Scope *sc)
             {
                 //printf("\ttry later, forward reference of base %s\n", tc->sym->toChars());
                 if (tc->sym->_scope)
-                    tc->sym->_scope->module->addDeferredSemantic(tc->sym);
+                    tc->sym->_scope->_module->addDeferredSemantic(tc->sym);
                 baseok = BASEOKnone;
             }
             i++;
@@ -1566,7 +1566,7 @@ void InterfaceDeclaration::semantic(Scope *sc)
             // Forward referencee of one or more bases, try again later
             _scope = scx ? scx : sc->copy();
             _scope->setNoFree();
-            _scope->module->addDeferredSemantic(this);
+            _scope->_module->addDeferredSemantic(this);
             return;
         }
         baseok = BASEOKdone;
@@ -1610,8 +1610,8 @@ Lancestorsdone:
             _scope = scx ? scx : sc->copy();
             _scope->setNoFree();
             if (tc->sym->_scope)
-                tc->sym->_scope->module->addDeferredSemantic(tc->sym);
-            _scope->module->addDeferredSemantic(this);
+                tc->sym->_scope->_module->addDeferredSemantic(tc->sym);
+            _scope->_module->addDeferredSemantic(this);
             return;
         }
     }

--- a/gcc/d/dfrontend/declaration.h
+++ b/gcc/d/dfrontend/declaration.h
@@ -90,6 +90,7 @@ enum PINLINE;
 #define STCreturn        0x100000000000LL // 'return ref' or 'return scope' for function parameters
 #define STCautoref       0x200000000000LL // Mark for the already deduced 'auto ref' parameter
 #define STCinference     0x400000000000LL // do attribute inference
+#define STCexptemp       0x800000000000LL // temporary variable that has lifetime restricted to an expression
 #define STCmaybescope    0x1000000000000LL // parameter might be 'scope'
 
 const StorageClass STCStorageClass = (STCauto | STCscope | STCstatic | STCextern | STCconst | STCfinal |
@@ -282,6 +283,7 @@ public:
     bool hasPointers();
     bool canTakeAddressOf();
     bool needsScopeDtor();
+    bool enclosesLifetimeOf(VarDeclaration *v) const;
     Expression *callScopeDtor(Scope *sc);
     Expression *getConstInitializer(bool needFullType = true);
     Expression *expandInitializer(Loc loc);
@@ -291,7 +293,6 @@ public:
     // Eliminate need for dynamic_cast
     VarDeclaration *isVarDeclaration() { return (VarDeclaration *)this; }
     void accept(Visitor *v) { v->visit(this); }
-    bool enclosesLifetimeOf(VarDeclaration *v) const;
 #ifdef IN_GCC
     void toObjFile();                       // compile to .obj file
 #endif
@@ -670,6 +671,7 @@ public:
 
     static FuncDeclaration *genCfunc(Parameters *args, Type *treturn, const char *name, StorageClass stc=0);
     static FuncDeclaration *genCfunc(Parameters *args, Type *treturn, Identifier *id, StorageClass stc=0);
+    void checkDmain();
 
     FuncDeclaration *isFuncDeclaration() { return this; }
 

--- a/gcc/d/dfrontend/doc.c
+++ b/gcc/d/dfrontend/doc.c
@@ -783,7 +783,7 @@ void emitComment(Dsymbol *s, OutBuffer *buf, Scope *sc)
             if (s)
             {
                 DocComment *dc = DocComment::parse(sc, s, com);
-                dc->pmacrotable = &sc->module->macrotable;
+                dc->pmacrotable = &sc->_module->macrotable;
                 sc->lastdc = dc;
             }
         }
@@ -2241,7 +2241,7 @@ void highlightText(Scope *sc, Dsymbols *a, OutBuffer *buf, size_t offset)
                     // text is already OK.
                 }
 
-                if (!sc->module->isDocFile &&
+                if (!sc->_module->isDocFile &&
                     !inCode && i == iLineStart && i + 1 < buf->offset)    // if "\n\n"
                 {
                     static const char blankline[] = "$(DDOC_BLANKLINE)\n";
@@ -2258,7 +2258,7 @@ void highlightText(Scope *sc, Dsymbols *a, OutBuffer *buf, size_t offset)
                 if (inCode)
                     break;
                 utf8_t *p = (utf8_t *)&buf->data[i];
-                const char *se = sc->module->escapetable->escapeChar('<');
+                const char *se = sc->_module->escapetable->escapeChar('<');
                 if (se && strcmp(se, "&lt;") == 0)
                 {
                     // Generating HTML
@@ -2319,7 +2319,7 @@ void highlightText(Scope *sc, Dsymbols *a, OutBuffer *buf, size_t offset)
                 if (inCode)
                     break;
                 // Replace '>' with '&gt;' character entity
-                const char *se = sc->module->escapetable->escapeChar('>');
+                const char *se = sc->_module->escapetable->escapeChar('>');
                 if (se)
                 {
                     size_t len = strlen(se);
@@ -2338,7 +2338,7 @@ void highlightText(Scope *sc, Dsymbols *a, OutBuffer *buf, size_t offset)
                 if (p[1] == '#' || isalpha(p[1]))
                     break;                      // already a character entity
                 // Replace '&' with '&amp;' character entity
-                const char *se = sc->module->escapetable->escapeChar('&');
+                const char *se = sc->_module->escapetable->escapeChar('&');
                 if (se)
                 {
                     size_t len = strlen(se);
@@ -2495,7 +2495,7 @@ void highlightText(Scope *sc, Dsymbols *a, OutBuffer *buf, size_t offset)
 
             default:
                 leadingBlank = 0;
-                if (sc->module->isDocFile || inCode)
+                if (sc->_module->isDocFile || inCode)
                     break;
 
                 utf8_t *start = (utf8_t *)buf->data + i;
@@ -2577,7 +2577,7 @@ void highlightCode(Scope *sc, Dsymbols *a, OutBuffer *buf, size_t offset)
     for (size_t i = offset; i < buf->offset; i++)
     {
         utf8_t c = buf->data[i];
-        const char *se = sc->module->escapetable->escapeChar(c);
+        const char *se = sc->_module->escapetable->escapeChar(c);
         if (se)
         {
             size_t len = strlen(se);
@@ -2618,7 +2618,7 @@ void highlightCode3(Scope *sc, OutBuffer *buf, const utf8_t *p, const utf8_t *pe
 {
     for (; p < pend; p++)
     {
-        const char *s = sc->module->escapetable->escapeChar(*p);
+        const char *s = sc->_module->escapetable->escapeChar(*p);
         if (s)
             buf->writestring(s);
         else

--- a/gcc/d/dfrontend/dsymbol.h
+++ b/gcc/d/dfrontend/dsymbol.h
@@ -196,7 +196,7 @@ public:
     Ungag ungagSpeculative();
 
     // kludge for template.isSymbol()
-    int dyncast() const { return DYNCAST_DSYMBOL; }
+    int dyncast() { return DYNCAST_DSYMBOL; }
 
     static Dsymbols *arraySyntaxCopy(Dsymbols *a);
 

--- a/gcc/d/dfrontend/enum.c
+++ b/gcc/d/dfrontend/enum.c
@@ -160,7 +160,7 @@ void EnumDeclaration::semantic(Scope *sc)
                 // memtype is forward referenced, so try again later
                 _scope = scx ? scx : sc->copy();
                 _scope->setNoFree();
-                _scope->module->addDeferredSemantic(this);
+                _scope->_module->addDeferredSemantic(this);
                 Module::dprogress = dprogress_save;
                 //printf("\tdeferring %s\n", toChars());
                 semanticRun = PASSinit;

--- a/gcc/d/dfrontend/escape.c
+++ b/gcc/d/dfrontend/escape.c
@@ -472,7 +472,7 @@ static bool checkEscapeImpl(Scope *sc, Expression *e, bool refs, bool gag)
             if (v->storage_class & STCreturn)
                 continue;
 
-            if (sc->module && sc->module->isRoot() &&
+            if (sc->_module && sc->_module->isRoot() &&
                 /* This case comes up when the ReturnStatement of a __foreachbody is
                  * checked for escapes by the caller of __foreachbody. Skip it.
                  *
@@ -555,7 +555,7 @@ static bool checkEscapeImpl(Scope *sc, Expression *e, bool refs, bool gag)
                 inferReturn(sc->func, v);        // infer addition of 'return'
             }
             else if (global.params.useDIP25 &&
-                     sc->module && sc->module->isRoot())
+                     sc->_module && sc->_module->isRoot())
             {
                 // Only look for errors if in module listed on command line
 

--- a/gcc/d/dfrontend/expression.c
+++ b/gcc/d/dfrontend/expression.c
@@ -53,6 +53,8 @@ bool checkAccess(AggregateDeclaration *ad, Loc loc, Scope *sc, Dsymbol *smember)
 bool symbolIsVisible(Module *mod, Dsymbol *s);
 bool checkFrameAccess(Loc loc, Scope *sc, AggregateDeclaration *ad, size_t istart = 0);
 bool checkNestedRef(Dsymbol *s, Dsymbol *p);
+VarDeclaration *copyToTemp(StorageClass stc, const char *name, Expression *e);
+Expression *extractSideEffect(Scope *sc, const char *name, Expression **e0, Expression *e, bool alwaysCopy = false);
 Type *getTypeInfoType(Type *t, Scope *sc);
 void MODtoBuffer(OutBuffer *buf, MOD mod);
 char *MODtoChars(MOD mod);
@@ -818,7 +820,7 @@ Expression *searchUFCS(Scope *sc, UnaExp *ue, Identifier *ident)
             if (!s)
                 s = searchScopes(sc, loc, ident, flags | SearchImportsOnly | IgnoreSymbolVisibility);
             if (s)
-                ::deprecation(loc, "%s is not visible from module %s", s->toPrettyChars(), sc->module->toChars());
+                ::deprecation(loc, "%s is not visible from module %s", s->toPrettyChars(), sc->_module->toChars());
         }
     }
     if (global.params.check10378)
@@ -1465,9 +1467,7 @@ Expression *callCpCtor(Scope *sc, Expression *e)
              * This is not the most efficent, ideally tmp would be constructed
              * directly onto the stack.
              */
-            Identifier *idtmp = Identifier::generateId("__copytmp");
-            VarDeclaration *tmp = new VarDeclaration(e->loc, e->type, idtmp, new ExpInitializer(e->loc, e));
-            tmp->storage_class |= STCtemp | STCctfe;
+            VarDeclaration *tmp = copyToTemp(STCrvalue, "__copytmp", e);
             tmp->storage_class |= STCnodtor;
             tmp->semantic(sc);
             Expression *de = new DeclarationExp(e->loc, tmp);
@@ -2008,9 +2008,7 @@ bool functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
             }
             if (appendToPrefix) // don't need to add to prefix until there's something to destruct
             {
-                Identifier *idtmp = Identifier::generateId("__pfx");
-                VarDeclaration *tmp = new VarDeclaration(loc, arg->type, idtmp, new ExpInitializer(loc, arg));
-                tmp->storage_class |= STCtemp | STCctfe;
+                VarDeclaration *tmp = copyToTemp(0, "__pfx", arg);
                 tmp->semantic(sc);
 
                 /* Modify the destructor so it only runs if gate==false
@@ -2037,9 +2035,7 @@ bool functionParameters(Loc loc, Scope *sc, TypeFunction *tf,
             }
             else if (anythrow && firstthrow <= i && i <= lastthrow && gate)
             {
-                Identifier *id = Identifier::generateId("__pfy");
-                VarDeclaration *tmp = new VarDeclaration(loc, arg->type, id, new ExpInitializer(loc, arg));
-                tmp->storage_class |= STCtemp | STCctfe;
+                VarDeclaration *tmp = copyToTemp(0, "__pfy", arg);
                 tmp->semantic(sc);
 
                 Expression *ae = new DeclarationExp(loc, tmp);
@@ -4724,10 +4720,8 @@ Expression *StructLiteralExp::addDtorHook(Scope *sc)
         strcpy(buf, "__sl");
         strncat(buf, sd->ident->toChars(), len - 4 - 1);
         assert(buf[len] == 0);
-        Identifier *idtmp = Identifier::generateId(buf);
 
-        VarDeclaration *tmp = new VarDeclaration(loc, type, idtmp, new ExpInitializer(loc, this));
-        tmp->storage_class |= STCtemp | STCctfe;
+        VarDeclaration *tmp = copyToTemp(0, buf, this);
         Expression *ae = new DeclarationExp(loc, tmp);
         Expression *e = new CommaExp(loc, ae, new VarExp(loc, tmp));
         e = e->semantic(sc);
@@ -5560,7 +5554,7 @@ Expression *NewAnonClassExp::semantic(Scope *sc)
 
     if (!cd->errors && sc->intypeof && !sc->parent->inNonRoot())
     {
-        ScopeDsymbol *sds = sc->tinst ? (ScopeDsymbol *)sc->tinst : sc->module;
+        ScopeDsymbol *sds = sc->tinst ? (ScopeDsymbol *)sc->tinst : sc->_module;
         sds->members->push(cd);
     }
 
@@ -7325,7 +7319,7 @@ Expression *CompileExp::semantic(Scope *sc)
     }
     se = se->toUTF8(sc);
     unsigned errors = global.errors;
-    Parser p(loc, sc->module, (utf8_t *)se->string, se->len, 0);
+    Parser p(loc, sc->_module, (utf8_t *)se->string, se->len, 0);
     p.nextToken();
     //printf("p.loc.linnum = %d\n", p.loc.linnum);
     Expression *e = p.parseExpression();
@@ -7687,7 +7681,7 @@ Expression *DotIdExp::semanticY(Scope *sc, int flag)
          * The check for 'is sds our current module' is because
          * the current module should have access to its own imports.
          */
-        if (ie->sds->isModule() && ie->sds != sc->module)
+        if (ie->sds->isModule() && ie->sds != sc->_module)
             flags |= IgnorePrivateImports;
         if (sc->flags & SCOPEignoresymbolvisibility)
             flags |= IgnoreSymbolVisibility;
@@ -7695,12 +7689,12 @@ Expression *DotIdExp::semanticY(Scope *sc, int flag)
         /* Check for visibility before resolving aliases because public
          * aliases to private symbols are public.
          */
-        if (s && !(sc->flags & SCOPEignoresymbolvisibility) && !symbolIsVisible(sc->module, s))
+        if (s && !(sc->flags & SCOPEignoresymbolvisibility) && !symbolIsVisible(sc->_module, s))
         {
             if (s->isDeclaration())
-                ::error(loc, "%s is not visible from module %s", s->toPrettyChars(), sc->module->toChars());
+                ::error(loc, "%s is not visible from module %s", s->toPrettyChars(), sc->_module->toChars());
             else
-                ::deprecation(loc, "%s is not visible from module %s", s->toPrettyChars(), sc->module->toChars());
+                ::deprecation(loc, "%s is not visible from module %s", s->toPrettyChars(), sc->_module->toChars());
             // s = NULL
         }
         if (s)
@@ -7930,31 +7924,19 @@ Expression *DotVarExp::semantic(Scope *sc)
 
     var = var->toAlias()->isDeclaration();
 
-    TupleDeclaration *tup = var->isTupleDeclaration();
-    if (tup)
+    e1 = e1->semantic(sc);
+
+    if (TupleDeclaration *tup = var->isTupleDeclaration())
     {
         /* Replace:
          *  e1.tuple(a, b, c)
          * with:
          *  tuple(e1.a, e1.b, e1.c)
          */
-        e1 = e1->semantic(sc);
-        Expressions *exps = new Expressions;
         Expression *e0 = NULL;
-        Expression *ev = e1;
-        if (sc->func && !isTrivialExp(e1))
-        {
-            Identifier *id = Identifier::generateId("__tup");
-            ExpInitializer *ei = new ExpInitializer(e1->loc, e1);
-            VarDeclaration *v = new VarDeclaration(e1->loc, NULL, id, ei);
-            v->storage_class |= STCtemp | STCctfe
-                             | (e1->isLvalue() ? STCref | STCforeach : STCrvalue);
-            e0 = new DeclarationExp(e1->loc, v);
-            ev = new VarExp(e1->loc, v);
-            e0 = e0->semantic(sc);
-            ev = ev->semantic(sc);
-        }
+        Expression *ev = extractSideEffect(sc, "__tup", &e0, e1);
 
+        Expressions *exps = new Expressions;
         exps->reserve(tup->objects->dim);
         for (size_t i = 0; i < tup->objects->dim; i++)
         {
@@ -7989,10 +7971,10 @@ Expression *DotVarExp::semantic(Scope *sc)
         return e;
     }
 
-    e1 = e1->semantic(sc);
     e1 = e1->addDtorHook(sc);
 
     Type *t1 = e1->type;
+
     if (FuncDeclaration *fd = var->isFuncDeclaration())
     {
         // for functions, do checks after overload resolution
@@ -9551,11 +9533,10 @@ Expression *CallExp::addDtorHook(Scope *sc)
             /* Type needs destruction, so declare a tmp
              * which the back end will recognize and call dtor on
              */
-            Identifier *idtmp = Identifier::generateId("__tmpfordtor");
-            VarDeclaration *tmp = new VarDeclaration(loc, type, idtmp, new ExpInitializer(loc, this));
-            tmp->storage_class |= STCtemp | STCctfe;
-            Expression *ae = new DeclarationExp(loc, tmp);
-            Expression *e = new CommaExp(loc, ae, new VarExp(loc, tmp));
+            VarDeclaration *tmp = copyToTemp(0, "__tmpfordtor", this);
+            Expression *de = new DeclarationExp(loc, tmp);
+            Expression *ve = new VarExp(loc, tmp);
+            Expression *e = new CommaExp(loc, de, ve);
             e = e->semantic(sc);
             return e;
         }
@@ -10152,11 +10133,9 @@ Expression *DeleteExp::semantic(Scope *sc)
                 VarDeclaration *v = NULL;
 
                 if (fd && f)
-                {   Identifier *id = Identifier::idPool("__tmpea");
-                    v = new VarDeclaration(loc, e1->type, id, new ExpInitializer(loc, e1));
-                    v->storage_class |= STCtemp;
+                {
+                    v = copyToTemp(0, "__tmpea", e1);
                     v->semantic(sc);
-                    v->parent = sc->parent;
                     ea = new DeclarationExp(loc, v);
                     ea->type = v->type;
                 }
@@ -10856,11 +10835,7 @@ Expression *ArrayLengthExp::rewriteOpAssign(BinExp *exp)
         /*    auto tmp = &array;
          *    (*tmp).length = (*tmp).length op e2
          */
-        Identifier *id = Identifier::generateId("__arraylength");
-        ExpInitializer *ei = new ExpInitializer(ale->loc, new AddrExp(ale->loc, ale->e1));
-        VarDeclaration *tmp = new VarDeclaration(ale->loc, ale->e1->type->pointerTo(), id, ei);
-        tmp->storage_class |= STCtemp;
-
+        VarDeclaration *tmp = copyToTemp(0, "__arraylength", new AddrExp(ale->loc, ale->e1));
         Expression *e1 = new ArrayLengthExp(ale->loc, new PtrExp(ale->loc, new VarExp(ale->loc, tmp)));
         Expression *elvalue = e1->syntaxCopy();
         e = opAssignToOp(exp->loc, exp->op, e1, exp->e2);
@@ -11488,10 +11463,7 @@ Expression *PostExp::semantic(Scope *sc)
         if (e1->op != TOKvar && e1->op != TOKarraylength)
         {
             // ref v = e1;
-            Identifier *id = Identifier::generateId("__postref");
-            ExpInitializer *ei = new ExpInitializer(loc, e1);
-            VarDeclaration *v = new VarDeclaration(loc, e1->type, id, ei);
-            v->storage_class |= STCtemp | STCref | STCforeach;
+            VarDeclaration *v = copyToTemp(STCref, "__postref", e1);
             de = new DeclarationExp(loc, v);
             e1 = new VarExp(e1->loc, v);
         }
@@ -11499,10 +11471,7 @@ Expression *PostExp::semantic(Scope *sc)
         /* Rewrite as:
          * auto tmp = e1; ++e1; tmp
          */
-        Identifier *id = Identifier::generateId("__pitmp");
-        ExpInitializer *ei = new ExpInitializer(loc, e1);
-        VarDeclaration *tmp = new VarDeclaration(loc, e1->type, id, ei);
-        tmp->storage_class |= STCtemp;
+        VarDeclaration *tmp = copyToTemp(0, "__pitmp", e1);
         Expression *ea = new DeclarationExp(loc, tmp);
 
         Expression *eb = e1->syntaxCopy();
@@ -11828,15 +11797,8 @@ Expression *AssignExp::semantic(Scope *sc)
             assert(e1->type->ty == Ttuple);
             TypeTuple *tt = (TypeTuple *)e1->type;
 
-            Identifier *id = Identifier::generateId("__tup");
-            ExpInitializer *ei = new ExpInitializer(e2x->loc, e2x);
-            VarDeclaration *v = new VarDeclaration(e2x->loc, NULL, id, ei);
-            v->storage_class |= STCtemp | STCctfe;
-            if (e2x->isLvalue())
-                v->storage_class = STCref | STCforeach;
-            Expression *e0 = new DeclarationExp(e2x->loc, v);
-            Expression *ev = new VarExp(e2x->loc, v);
-            ev->type = e2x->type;
+            Expression *e0 = NULL;
+            Expression *ev = extractSideEffect(sc, "__tup", &e0, e2x);
 
             Expressions *iexps = new Expressions();
             iexps->push(ev);
@@ -12093,43 +12055,11 @@ Expression *AssignExp::semantic(Scope *sc)
                  */
                 IndexExp *ie = (IndexExp *)e1x;
                 Type *t2 = e2x->type->toBasetype();
-                Expression *e0 = NULL;
 
-                Expression *ea = ie->e1;
-                Expression *ek = ie->e2;
-                Expression *ev = e2x;
-                if (!isTrivialExp(ea))
-                {
-                    VarDeclaration *v = new VarDeclaration(loc, ie->e1->type,
-                        Identifier::generateId("__aatmp"), new ExpInitializer(loc, ie->e1));
-                    v->storage_class |= STCtemp | STCctfe
-                                     | (ea->isLvalue() ? STCforeach | STCref : STCrvalue);
-                    v->semantic(sc);
-                    e0 = combine(e0, new DeclarationExp(loc, v));
-                    ea = new VarExp(loc, v);
-                }
-                if (!isTrivialExp(ek))
-                {
-                    VarDeclaration *v = new VarDeclaration(loc, ie->e2->type,
-                        Identifier::generateId("__aakey"), new ExpInitializer(loc, ie->e2));
-                    v->storage_class |= STCtemp | STCctfe
-                                     | (ek->isLvalue() ? STCforeach | STCref : STCrvalue);
-                    v->semantic(sc);
-                    e0 = combine(e0, new DeclarationExp(loc, v));
-                    ek = new VarExp(loc, v);
-                }
-                if (!isTrivialExp(ev))
-                {
-                    VarDeclaration *v = new VarDeclaration(loc, e2x->type,
-                        Identifier::generateId("__aaval"), new ExpInitializer(loc, e2x));
-                    v->storage_class |= STCtemp | STCctfe
-                                     | (ev->isLvalue() ? STCforeach | STCref : STCrvalue);
-                    v->semantic(sc);
-                    e0 = combine(e0, new DeclarationExp(loc, v));
-                    ev = new VarExp(loc, v);
-                }
-                if (e0)
-                    e0 = e0->semantic(sc);
+                Expression *e0 = NULL;
+                Expression *ea = extractSideEffect(sc, "__aatmp", &e0, ie->e1);
+                Expression *ek = extractSideEffect(sc, "__aakey", &e0, ie->e2);
+                Expression *ev = extractSideEffect(sc, "__aaval", &e0, e2x);
 
                 AssignExp *ae = (AssignExp *)copy();
                 ae->e1 = new IndexExp(loc, ea, ek);
@@ -12841,9 +12771,7 @@ Expression *PowAssignExp::semantic(Scope *sc)
         else
         {
             // Rewrite: ref tmp = e1; tmp = tmp ^^ e2
-            Identifier *id = Identifier::generateId("__powtmp");
-            VarDeclaration *v = new VarDeclaration(e1->loc, e1->type, id, new ExpInitializer(loc, e1));
-            v->storage_class |= STCtemp | STCref | STCforeach;
+            VarDeclaration *v = copyToTemp(STCref, "__powtmp", e1);
             Expression *de = new DeclarationExp(e1->loc, v);
             VarExp *ve = new VarExp(e1->loc, v);
             e = new PowExp(loc, ve, e2);
@@ -13558,17 +13486,15 @@ Expression *PowExp::semantic(Scope *sc)
     {
         // Replace x^^2 with (tmp = x, tmp*tmp)
         // Replace x^^3 with (tmp = x, tmp*tmp*tmp)
-        Identifier *idtmp = Identifier::generateId("__powtmp");
-        VarDeclaration *tmp = new VarDeclaration(loc, e1->type->toBasetype(), idtmp, new ExpInitializer(Loc(), e1));
-        tmp->storage_class |= STCtemp | STCctfe;
+        VarDeclaration *tmp = copyToTemp(0, "__powtmp", e1);
+        Expression *de = new DeclarationExp(loc, tmp);
         Expression *ve = new VarExp(loc, tmp);
-        Expression *ae = new DeclarationExp(loc, tmp);
         /* Note that we're reusing ve. This should be ok.
          */
         Expression *me = new MulExp(loc, ve, ve);
         if (intpow == 3)
             me = new MulExp(loc, me, ve);
-        e = new CommaExp(loc, ae, me);
+        e = new CommaExp(loc, de, me);
         e = e->semantic(sc);
         return e;
     }
@@ -14402,10 +14328,7 @@ void CondExp::hookDtors(Scope *sc)
                 {
                     if (!vcond)
                     {
-                        ExpInitializer *ei = new ExpInitializer(ce->econd->loc, ce->econd);
-                        Identifier *id = Identifier::generateId("__cond");
-                        vcond = new VarDeclaration(ce->econd->loc, ce->econd->type, id, ei);
-                        vcond->storage_class |= STCtemp | STCctfe | STCvolatile;
+                        vcond = copyToTemp(STCvolatile, "__cond", ce->econd);
                         vcond->semantic(sc);
 
                         Expression *de = new DeclarationExp(ce->econd->loc, vcond);
@@ -14496,7 +14419,7 @@ Expression *FileInitExp::semantic(Scope *sc)
 Expression *FileInitExp::resolveLoc(Loc loc, Scope *sc)
 {
     //printf("FileInitExp::resolve() %s\n", toChars());
-    const char *s = loc.filename ? loc.filename : sc->module->ident->toChars();
+    const char *s = loc.filename ? loc.filename : sc->_module->ident->toChars();
     Expression *e = new StringExp(loc, (char *)s);
     e = e->semantic(sc);
     e = e->castTo(sc, type);
@@ -14541,9 +14464,9 @@ Expression *ModuleInitExp::resolveLoc(Loc loc, Scope *sc)
 {
     const char *s;
     if (sc->callsc)
-        s = sc->callsc->module->toPrettyChars();
+        s = sc->callsc->_module->toPrettyChars();
     else
-        s = sc->module->toPrettyChars();
+        s = sc->_module->toPrettyChars();
     Expression *e = new StringExp(loc, (char *)s);
     e = e->semantic(sc);
     e = e->castTo(sc, type);
@@ -14652,16 +14575,10 @@ Expression *extractOpDollarSideEffect(Scope *sc, UnaExp *ue)
          *      (ref __dop = e1, __dop).opIndex( ... __dop.opDollar ...)
          *      (ref __dop = e1, __dop).opSlice( ... __dop.opDollar ...)
          */
-        Identifier *id = Identifier::generateId("__dop");
-        ExpInitializer *ei = new ExpInitializer(ue->loc, e1);
-        VarDeclaration *v = new VarDeclaration(ue->loc, e1->type, id, ei);
-        v->storage_class |= STCtemp | STCctfe
-                         | (e1->isLvalue() ? STCforeach | STCref : STCrvalue);
-        Expression *de = new DeclarationExp(ue->loc, v);
-        de = de->semantic(sc);
-        e0 = Expression::combine(e0, de);
-        e1 = new VarExp(ue->loc, v);
-        e1 = e1->semantic(sc);
+        e1 = extractSideEffect(sc, "__dop", &e0, e1);
+        assert(e1->op == TOKvar);
+        VarExp *ve = (VarExp *)e1;
+        ve->var->storage_class |= STCexptemp;     // lifetime limited to expression
     }
     ue->e1 = e1;
     return e0;
@@ -14820,20 +14737,12 @@ Expression *BinExp::reorderSettingAAElem(Scope *sc)
      *     __aatmp[__aakey3][__aakey2][__aakey1] op= __aaval;  // assignment
      */
 
-    Expression *de = NULL;
+    Expression *e0 = NULL;
     while (1)
     {
-        if (!isTrivialExp(ie->e2))
-        {
-            Identifier *id = Identifier::generateId("__aakey");
-            VarDeclaration *vd = new VarDeclaration(ie->e2->loc, ie->e2->type, id, new ExpInitializer(ie->e2->loc, ie->e2));
-            vd->storage_class |= STCtemp
-                              | (ie->e2->isLvalue() ? STCref | STCforeach : STCrvalue);
-            de = Expression::combine(new DeclarationExp(ie->e2->loc, vd), de);
-
-            ie->e2 = new VarExp(ie->e2->loc, vd);
-            ie->e2->type = vd->type;
-        }
+        Expression *de = NULL;
+        ie->e2 = extractSideEffect(sc, "__aakey", &de, ie->e2);
+        e0 = Expression::combine(de, e0);
 
         Expression *ie1 = ie->e1;
         if (ie1->op != TOKindex ||
@@ -14845,30 +14754,12 @@ Expression *BinExp::reorderSettingAAElem(Scope *sc)
     }
     assert(ie->e1->type->toBasetype()->ty == Taarray);
 
-    if (!isTrivialExp(ie->e1))
-    {
-        Identifier *id = Identifier::generateId("__aatmp");
-        VarDeclaration *vd = new VarDeclaration(ie->e1->loc, ie->e1->type, id, new ExpInitializer(ie->e1->loc, ie->e1));
-        vd->storage_class |= STCtemp
-                          | (ie->e1->isLvalue() ? STCref | STCforeach : STCrvalue);
-        de = Expression::combine(new DeclarationExp(ie->e1->loc, vd), de);
+    Expression *de = NULL;
+    ie->e1 = extractSideEffect(sc, "__aatmp", &de, ie->e1);
+    e0 = Expression::combine(de, e0);
 
-        ie->e1 = new VarExp(ie->e1->loc, vd);
-        ie->e1->type = vd->type;
-    }
+    be->e2 = extractSideEffect(sc, "__aaval", &e0, be->e2, true);
 
-    {
-        Identifier *id = Identifier::generateId("__aaval");
-        VarDeclaration *vd = new VarDeclaration(be->loc, be->e2->type, id, new ExpInitializer(be->e2->loc, be->e2));
-        vd->storage_class |= STCtemp
-                          | (be->e2->isLvalue() ? STCref | STCforeach : STCrvalue);
-        de = Expression::combine(de, new DeclarationExp(be->e2->loc, vd));
-
-        be->e2 = new VarExp(be->e2->loc, vd);
-        be->e2->type = vd->type;
-    }
-
-    de = de->semantic(sc);
-    //printf("-de = %s, be = %s\n", de->toChars(), be->toChars());
-    return Expression::combine(de, be);
+    //printf("-e0 = %s, be = %s\n", e0->toChars(), be->toChars());
+    return Expression::combine(e0, be);
 }

--- a/gcc/d/dfrontend/expression.h
+++ b/gcc/d/dfrontend/expression.h
@@ -80,7 +80,7 @@ Expression *doCopyOrMove(Scope *sc, Expression *e);
 Expression *resolveOpDollar(Scope *sc, ArrayExp *ae, Expression **pe0);
 Expression *resolveOpDollar(Scope *sc, ArrayExp *ae, IntervalExp *ie, Expression **pe0);
 Expression *integralPromotions(Expression *e, Scope *sc);
-void discardValue(Expression *e);
+bool discardValue(Expression *e);
 bool isTrivialExp(Expression *e);
 
 int isConst(Expression *e);
@@ -144,7 +144,7 @@ public:
     Expression *trySemantic(Scope *sc);
 
     // kludge for template.isExpression()
-    int dyncast() const { return DYNCAST_EXPRESSION; }
+    int dyncast() { return DYNCAST_EXPRESSION; }
 
     void print();
     const char *toChars();

--- a/gcc/d/dfrontend/func.c
+++ b/gcc/d/dfrontend/func.c
@@ -1091,38 +1091,7 @@ void FuncDeclaration::semantic(Scope *sc)
     }
 
     if (isMain())
-    {
-        // Check parameters to see if they are either () or (char[][] args)
-        switch (nparams)
-        {
-            case 0:
-                break;
-
-            case 1:
-            {
-                Parameter *fparam0 = Parameter::getNth(f->parameters, 0);
-                if (fparam0->type->ty != Tarray ||
-                    fparam0->type->nextOf()->ty != Tarray ||
-                    fparam0->type->nextOf()->nextOf()->ty != Tchar ||
-                    fparam0->storageClass & (STCout | STCref | STClazy))
-                    goto Lmainerr;
-                break;
-            }
-
-            default:
-                goto Lmainerr;
-        }
-
-        if (!f->nextOf())
-            error("must return int or void");
-        else if (f->nextOf()->ty != Tint32 && f->nextOf()->ty != Tvoid)
-            error("must return int or void, not %s", f->nextOf()->toChars());
-        if (f->varargs)
-        {
-        Lmainerr:
-            error("parameters must be main() or main(string[] args)");
-        }
-    }
+	checkDmain();       // Check main() parameters and return type
 
     if (isVirtual() && semanticRun != PASSsemanticdone)
     {
@@ -1235,7 +1204,7 @@ Ldone:
     if (global.params.verbose && !printedMain)
     {
         const char *type = isMain() ? "main" : isWinMain() ? "winmain" : isDllMain() ? "dllmain" : (const char *)NULL;
-        Module *mod = sc->module;
+        Module *mod = sc->_module;
 
         if (type && mod)
         {
@@ -1245,7 +1214,7 @@ Ldone:
         }
     }
 
-    if (fbody && isMain() && sc->module->isRoot())
+    if (fbody && isMain() && sc->_module->isRoot())
         genCmain(sc);
 
     assert(type->ty != Terror || errors);
@@ -2458,7 +2427,7 @@ void FuncDeclaration::buildResultVar(Scope *sc, Type *tret)
         assert(type->ty == Tfunction);
         TypeFunction *tf = (TypeFunction *)type;
         if (tf->isref)
-            vresult->storage_class |= STCref | STCforeach;
+            vresult->storage_class |= STCref;
         vresult->type = tret;
 
         vresult->semantic(sc);
@@ -4175,6 +4144,36 @@ FuncDeclaration *FuncDeclaration::genCfunc(Parameters *fparams, Type *treturn, I
     return fd;
 }
 
+/******************
+ * Check parameters and return type of D main() function.
+ * Issue error messages.
+ */
+void FuncDeclaration::checkDmain()
+{
+    TypeFunction *tf = (TypeFunction *)type;
+    const size_t nparams = Parameter::dim(tf->parameters);
+    bool argerr = false;
+    if (nparams == 1)
+    {
+        Parameter *fparam0 = Parameter::getNth(tf->parameters, 0);
+        Type *t = fparam0->type->toBasetype();
+        if (t->ty != Tarray ||
+            t->nextOf()->ty != Tarray ||
+            t->nextOf()->nextOf()->ty != Tchar ||
+            fparam0->storageClass & (STCout | STCref | STClazy))
+        {
+            argerr = true;
+        }
+    }
+
+    if (!tf->nextOf())
+        error("must return int or void");
+    else if (tf->nextOf()->ty != Tint32 && tf->nextOf()->ty != Tvoid)
+        error("must return int or void, not %s", tf->nextOf()->toChars());
+    else if (tf->varargs || nparams >= 2 || argerr)
+        error("parameters must be main() or main(string[] args)");
+}
+
 const char *FuncDeclaration::kind()
 {
     return generated ? "generated function" : "function";
@@ -5078,7 +5077,7 @@ void StaticCtorDeclaration::semantic(Scope *sc)
     // We're going to need ModuleInfo
     Module *m = getModule();
     if (!m)
-        m = sc->module;
+        m = sc->_module;
     if (m)
     {
         m->needmoduleinfo = 1;
@@ -5206,7 +5205,7 @@ void StaticDtorDeclaration::semantic(Scope *sc)
     // We're going to need ModuleInfo
     Module *m = getModule();
     if (!m)
-        m = sc->module;
+        m = sc->_module;
     if (m)
     {
         m->needmoduleinfo = 1;
@@ -5391,7 +5390,7 @@ void UnitTestDeclaration::semantic(Scope *sc)
     // (This doesn't make sense to me?)
     Module *m = getModule();
     if (!m)
-        m = sc->module;
+        m = sc->_module;
     if (m)
     {
         //printf("module3 %s needs moduleinfo\n", m->toChars());

--- a/gcc/d/dfrontend/globals.h
+++ b/gcc/d/dfrontend/globals.h
@@ -34,6 +34,24 @@ enum BOUNDSCHECK
     BOUNDSCHECKsafeonly // do bounds checking only in @safe functions
 };
 
+enum CPU
+{
+    x87,
+    mmx,
+    sse,
+    sse2,
+    sse3,
+    ssse3,
+    sse4_1,
+    sse4_2,
+    avx,                // AVX1 instruction set
+    avx2,               // AVX2 instruction set
+    avx512,             // AVX-512 instruction set
+
+    // Special values that don't survive past the command line processing
+    baseline,           // (default) the minimum capability CPU
+    native              // the machine the compiler is being run on
+};
 
 // Put command line switches in here
 struct Param
@@ -98,10 +116,13 @@ struct Param
     bool check10378;    // check for issues transitioning to 10738
     bool bug10378;      // use pre-bugzilla 10378 search strategy
     bool vsafe;         // use enhanced @safe checking
+    bool showGaggedErrors;  // print gagged errors anyway
 
+    CPU cpu;                // CPU instruction set to target
     BOUNDSCHECK useArrayBounds;
 
     const char *argv0;    // program name
+    Array<const char *> *modFileAliasStrings; // array of char*'s of -I module filename alias strings
     Array<const char *> *imppath;     // array of char*'s of where to look for import modules
     Array<const char *> *fileImppath; // array of char*'s of where to look for file import modules
     const char *objdir;   // .obj/.lib file output directory
@@ -129,6 +150,7 @@ struct Param
 
     const char *defaultlibname; // default library for non-debug builds
     const char *debuglibname;   // default library for debug builds
+    const char *mscrtlib;       // MS C runtime library
 
     const char *moduleDepsFile; // filename for deps output
     OutBuffer *moduleDeps;      // contents to be written to deps file
@@ -289,6 +311,17 @@ enum CPPMANGLE
     CPPMANGLEdefault,
     CPPMANGLEstruct,
     CPPMANGLEclass,
+};
+
+enum DYNCAST
+{
+    DYNCAST_OBJECT,
+    DYNCAST_EXPRESSION,
+    DYNCAST_DSYMBOL,
+    DYNCAST_TYPE,
+    DYNCAST_IDENTIFIER,
+    DYNCAST_TUPLE,
+    DYNCAST_PARAMETER,
 };
 
 enum MATCH

--- a/gcc/d/dfrontend/identifier.c
+++ b/gcc/d/dfrontend/identifier.c
@@ -93,7 +93,7 @@ void Identifier::print()
     fprintf(stderr, "%s",string);
 }
 
-int Identifier::dyncast() const
+int Identifier::dyncast()
 {
     return DYNCAST_IDENTIFIER;
 }

--- a/gcc/d/dfrontend/identifier.h
+++ b/gcc/d/dfrontend/identifier.h
@@ -36,7 +36,7 @@ public:
     const char *toChars();
     int getValue() const;
     const char *toHChars2();
-    int dyncast() const;
+    int dyncast();
 
     static StringTable stringtable;
     static Identifier *generateId(const char *prefix);

--- a/gcc/d/dfrontend/import.c
+++ b/gcc/d/dfrontend/import.c
@@ -181,7 +181,7 @@ void Import::load(Scope *sc)
         }
     }
     if (mod && !mod->importedFrom)
-        mod->importedFrom = sc ? sc->module->importedFrom : Module::rootModule;
+        mod->importedFrom = sc ? sc->_module->importedFrom : Module::rootModule;
     if (!pkg)
         pkg = mod;
 
@@ -237,8 +237,8 @@ void Import::semantic(Scope *sc)
     if (mod)
     {
         // Modules need a list of each imported module
-        //printf("%s imports %s\n", sc->module->toChars(), mod->toChars());
-        sc->module->aimports.push(mod);
+        //printf("%s imports %s\n", sc->_module->toChars(), mod->toChars());
+        sc->_module->aimports.push(mod);
 
         if (sc->explicitProtection)
             protection = sc->protection;
@@ -283,8 +283,8 @@ void Import::semantic(Scope *sc)
 
         if (mod->needmoduleinfo)
         {
-            //printf("module4 %s because of %s\n", sc->module->toChars(), mod->toChars());
-            sc->module->needmoduleinfo = 1;
+            //printf("module4 %s because of %s\n", sc->_module->toChars(), mod->toChars());
+            sc->_module->needmoduleinfo = 1;
         }
 
         sc = sc->push(mod);
@@ -316,9 +316,9 @@ void Import::semantic(Scope *sc)
     // object self-imports itself, so skip that (Bugzilla 7547)
     // don't list pseudo modules __entrypoint.d, __main.d (Bugzilla 11117, 11164)
     if (global.params.moduleDeps != NULL &&
-        !(id == Id::object && sc->module->ident == Id::object) &&
-        sc->module->ident != Id::entrypoint &&
-        strcmp(sc->module->ident->toChars(), "__main") != 0)
+        !(id == Id::object && sc->_module->ident == Id::object) &&
+        sc->_module->ident != Id::entrypoint &&
+        strcmp(sc->_module->ident->toChars(), "__main") != 0)
     {
         /* The grammar of the file is:
          *      ImportDeclaration
@@ -406,9 +406,9 @@ void Import::semantic2(Scope *sc)
         mod->semantic2(NULL);
         if (mod->needmoduleinfo)
         {
-            //printf("module5 %s because of %s\n", sc->module->toChars(), mod->toChars());
+            //printf("module5 %s because of %s\n", sc->_module->toChars(), mod->toChars());
             if (sc)
-                sc->module->needmoduleinfo = 1;
+                sc->_module->needmoduleinfo = 1;
         }
     }
 }

--- a/gcc/d/dfrontend/inline.c
+++ b/gcc/d/dfrontend/inline.c
@@ -1979,7 +1979,7 @@ static void expandInline(Loc callLoc, FuncDeclaration *fd, FuncDeclaration *pare
             ExpInitializer *ei = new ExpInitializer(callLoc, NULL);
             Identifier *tmp = Identifier::generateId("__retvar");
             vret = new VarDeclaration(fd->loc, eret->type, tmp, ei);
-            vret->storage_class |= STCtemp | STCforeach | STCref;
+            vret->storage_class |= STCtemp | STCref;
             vret->linkage = LINKd;
             vret->parent = parent;
 
@@ -2203,7 +2203,7 @@ static void expandInline(Loc callLoc, FuncDeclaration *fd, FuncDeclaration *pare
             ExpInitializer* ei = new ExpInitializer(callLoc, e);
             Identifier* tmp = Identifier::generateId("__inlineretval");
             VarDeclaration* vd = new VarDeclaration(callLoc, tf->next, tmp, ei);
-            vd->storage_class = (tf->isref ? STCref : 0) | STCtemp | STCrvalue;
+            vd->storage_class = STCtemp | (tf->isref ? STCref : STCrvalue);
             vd->linkage = tf->linkage;
             vd->parent = parent;
 

--- a/gcc/d/dfrontend/mtype.c
+++ b/gcc/d/dfrontend/mtype.c
@@ -52,6 +52,7 @@ bool symbolIsVisible(Scope *sc, Dsymbol *s);
 typedef int (*ForeachDg)(void *ctx, size_t paramidx, Parameter *param);
 int Parameter_foreach(Parameters *parameters, ForeachDg dg, void *ctx, size_t *pn = NULL);
 FuncDeclaration *isFuncAddress(Expression *e, bool *hasOverloads = NULL);
+Expression *extractSideEffect(Scope *sc, const char *name, Expression **e0, Expression *e, bool alwaysCopy = false);
 
 int Tsize_t = Tuns32;
 int Tptrdiff_t = Tint32;
@@ -6735,7 +6736,7 @@ void TypeQualified::resolveHelper(Loc loc, Scope *sc,
             Dsymbol *sm = s->searchX(loc, sc, id);
             if (sm && !(sc->flags & SCOPEignoresymbolvisibility) && !symbolIsVisible(sc, sm))
             {
-                ::deprecation(loc, "%s is not visible from module %s", sm->toPrettyChars(), sc->module->toChars());
+                ::deprecation(loc, "%s is not visible from module %s", sm->toPrettyChars(), sc->_module->toChars());
                 // sm = NULL;
             }
             if (global.errors != errorsave)
@@ -7744,21 +7745,14 @@ Expression *TypeStruct::dotExp(Scope *sc, Expression *e, Identifier *ident, int 
          */
         e = e->semantic(sc);    // do this before turning on noaccesscheck
         e->type->size();        // do semantic of type
-        Expressions *exps = new Expressions;
-        exps->reserve(sym->fields.dim);
 
         Expression *e0 = NULL;
         Expression *ev = e->op == TOKtype ? NULL : e;
-        if (sc->func && ev && !isTrivialExp(ev))
-        {
-            Identifier *id = Identifier::generateId("__tup");
-            ExpInitializer *ei = new ExpInitializer(e->loc, ev);
-            VarDeclaration *vd = new VarDeclaration(e->loc, NULL, id, ei);
-            vd->storage_class |= STCtemp | STCctfe
-                              | (ev->isLvalue() ? STCref | STCforeach : STCrvalue);
-            e0 = new DeclarationExp(e->loc, vd);
-            ev = new VarExp(e->loc, vd);
-        }
+        if (ev)
+            ev = extractSideEffect(sc, "__tup", &e0, ev);
+
+        Expressions *exps = new Expressions;
+        exps->reserve(sym->fields.dim);
         for (size_t i = 0; i < sym->fields.dim; i++)
         {
             VarDeclaration *v = sym->fields[i];
@@ -7808,7 +7802,7 @@ L1:
     }
     if (!(sc->flags & SCOPEignoresymbolvisibility) && !symbolIsVisible(sc, s))
     {
-        ::deprecation(e->loc, "%s is not visible from module %s", s->toPrettyChars(), sc->module->toPrettyChars());
+        ::deprecation(e->loc, "%s is not visible from module %s", s->toPrettyChars(), sc->_module->toPrettyChars());
         // return noMember(sc, e, ident, flag);
     }
     if (!s->isFuncDeclaration())        // because of overloading
@@ -8363,21 +8357,13 @@ Expression *TypeClass::dotExp(Scope *sc, Expression *e, Identifier *ident, int f
         // Detect that error, and at least try to run semantic() on it if we can
         sym->size(e->loc);
 
-        Expressions *exps = new Expressions;
-        exps->reserve(sym->fields.dim);
-
         Expression *e0 = NULL;
         Expression *ev = e->op == TOKtype ? NULL : e;
-        if (sc->func && ev && !isTrivialExp(ev))
-        {
-            Identifier *id = Identifier::generateId("__tup");
-            ExpInitializer *ei = new ExpInitializer(e->loc, ev);
-            VarDeclaration *vd = new VarDeclaration(e->loc, NULL, id, ei);
-            vd->storage_class |= STCtemp | STCctfe
-                              | (ev->isLvalue() ? STCref | STCforeach : STCrvalue);
-            e0 = new DeclarationExp(e->loc, vd);
-            ev = new VarExp(e->loc, vd);
-        }
+        if (ev)
+            ev = extractSideEffect(sc, "__tup", &e0, ev);
+
+        Expressions *exps = new Expressions;
+        exps->reserve(sym->fields.dim);
         for (size_t i = 0; i < sym->fields.dim; i++)
         {
             VarDeclaration *v = sym->fields[i];
@@ -8394,6 +8380,7 @@ Expression *TypeClass::dotExp(Scope *sc, Expression *e, Identifier *ident, int f
             }
             exps->push(ex);
         }
+
         e = new TupleExp(e->loc, e0, exps);
         Scope *sc2 = sc->push();
         sc2->flags = sc->flags | SCOPEnoaccesscheck;
@@ -8544,7 +8531,7 @@ L1:
     }
     if (!(sc->flags & SCOPEignoresymbolvisibility) && !symbolIsVisible(sc, s))
     {
-        ::deprecation(e->loc, "%s is not visible from module %s", s->toPrettyChars(), sc->module->toChars());
+        ::deprecation(e->loc, "%s is not visible from module %s", s->toPrettyChars(), sc->_module->toChars());
         // return noMember(sc, e, ident, flag);
     }
     if (!s->isFuncDeclaration())        // because of overloading

--- a/gcc/d/dfrontend/mtype.h
+++ b/gcc/d/dfrontend/mtype.h
@@ -240,7 +240,7 @@ public:
     bool equals(RootObject *o);
     bool equivalent(Type *t);
     // kludge for template.isType()
-    int dyncast() const { return DYNCAST_TYPE; }
+    int dyncast() { return DYNCAST_TYPE; }
     int covariant(Type *t, StorageClass *pstc = NULL);
     const char *toChars();
     char *toPrettyChars(bool QualifyTypes = false);
@@ -928,7 +928,7 @@ public:
     Parameter *syntaxCopy();
     Type *isLazyArray();
     // kludge for template.isType()
-    int dyncast() const { return DYNCAST_PARAMETER; }
+    int dyncast() { return DYNCAST_PARAMETER; }
     virtual void accept(Visitor *v) { v->visit(this); }
 
     static Parameters *arraySyntaxCopy(Parameters *parameters);

--- a/gcc/d/dfrontend/object.c
+++ b/gcc/d/dfrontend/object.c
@@ -39,9 +39,9 @@ const char *RootObject::toChars()
     return (char *)"Object";
 }
 
-int RootObject::dyncast() const
+int RootObject::dyncast()
 {
-    return DYNCAST_OBJECT;
+    return 0;
 }
 
 void RootObject::toBuffer(OutBuffer *b)

--- a/gcc/d/dfrontend/object.h
+++ b/gcc/d/dfrontend/object.h
@@ -22,18 +22,6 @@ typedef size_t hash_t;
 
 struct OutBuffer;
 
-enum DYNCAST
-{
-    DYNCAST_OBJECT,
-    DYNCAST_EXPRESSION,
-    DYNCAST_DSYMBOL,
-    DYNCAST_TYPE,
-    DYNCAST_IDENTIFIER,
-    DYNCAST_TUPLE,
-    DYNCAST_PARAMETER,
-    DYNCAST_STATEMENT,
-};
-
 /*
  * Root of our class library.
  */
@@ -62,7 +50,7 @@ public:
      * Used as a replacement for dynamic_cast. Returns a unique number
      * defined by the library user. For Object, the return value is 0.
      */
-    virtual int dyncast() const;
+    virtual int dyncast();
 };
 
 #endif

--- a/gcc/d/dfrontend/outbuffer.c
+++ b/gcc/d/dfrontend/outbuffer.c
@@ -387,7 +387,10 @@ void OutBuffer::remove(size_t offset, size_t nbytes)
 char *OutBuffer::peekString()
 {
     if (!offset || data[offset-1] != '\0')
+    {
         writeByte(0);
+        offset--; // allow appending more
+    }
     return (char *)data;
 }
 

--- a/gcc/d/dfrontend/port.h
+++ b/gcc/d/dfrontend/port.h
@@ -51,19 +51,19 @@ struct Port
     static longdouble fmodl(longdouble x, longdouble y);
     static int fequal(longdouble x, longdouble y);
 
-    static char *strupr(char *);
-
     static int memicmp(const char *s1, const char *s2, int n);
-    static int stricmp(const char *s1, const char *s2);
+    static char *strupr(char *s);
 
     static longdouble strtof(const char *p, char **endp);
     static longdouble strtod(const char *p, char **endp);
     static longdouble strtold(const char *p, char **endp);
 
-    static unsigned readlongLE(void* buffer);
-    static unsigned readlongBE(void* buffer);
-    static unsigned readwordLE(void* buffer);
-    static unsigned readwordBE(void* buffer);
+    static void writelongLE(unsigned value, void *buffer);
+    static unsigned readlongLE(void *buffer);
+    static void writelongBE(unsigned value, void *buffer);
+    static unsigned readlongBE(void *buffer);
+    static unsigned readwordLE(void *buffer);
+    static unsigned readwordBE(void *buffer);
     static void valcpy(void *dst, uint64_t val, size_t size);
 };
 

--- a/gcc/d/dfrontend/scope.c
+++ b/gcc/d/dfrontend/scope.c
@@ -52,7 +52,7 @@ Scope::Scope()
     // Create root scope
 
     //printf("Scope::Scope() %p\n", this);
-    this->module = NULL;
+    this->_module = NULL;
     this->scopesym = NULL;
     this->sds = NULL;
     this->enclosing = NULL;
@@ -103,7 +103,7 @@ Scope *Scope::copy()
     return sc;
 }
 
-Scope *Scope::createGlobal(Module *module)
+Scope *Scope::createGlobal(Module *_module)
 {
     Scope *sc = Scope::alloc();
     memset(sc, 0, sizeof(Scope));
@@ -113,24 +113,24 @@ Scope *Scope::createGlobal(Module *module)
     sc->inlining = PINLINEdefault;
     sc->protection = Prot(PROTpublic);
 
-    sc->module = module;
+    sc->_module = _module;
 
     sc->tinst = NULL;
-    sc->minst = module;
+    sc->minst = _module;
 
     sc->scopesym = new ScopeDsymbol();
     sc->scopesym->symtab = new DsymbolTable();
 
     // Add top level package as member of this global scope
-    Dsymbol *m = module;
+    Dsymbol *m = _module;
     while (m->parent)
         m = m->parent;
     m->addMember(NULL, sc->scopesym);
     m->parent = NULL;                   // got changed by addMember()
 
     // Create the module scope underneath the global scope
-    sc = sc->push(module);
-    sc->parent = module;
+    sc = sc->push(_module);
+    sc->parent = _module;
     return sc;
 }
 
@@ -387,7 +387,7 @@ void Scope::mergeFieldInit(Loc loc, unsigned *fies)
 Module *Scope::instantiatingModule()
 {
     // TODO: in speculative context, returning 'module' is correct?
-    return minst ? minst : module;
+    return minst ? minst : _module;
 }
 
 static Dsymbol *searchScopes(Scope *scope, Loc loc, Identifier *ident, Dsymbol **pscopesym, int flags)
@@ -521,7 +521,7 @@ Dsymbol *Scope::search(Loc loc, Identifier *ident, Dsymbol **pscopesym, int flag
                 s = searchScopes(this, loc, ident, pscopesym, flags | SearchImportsOnly | IgnoreSymbolVisibility);
 
             if (s && !(flags & IgnoreErrors))
-                ::deprecation(loc, "%s is not visible from module %s", s->toPrettyChars(), module->toChars());
+                ::deprecation(loc, "%s is not visible from module %s", s->toPrettyChars(), _module->toChars());
 #ifdef LOGSEARCH
             if (s)
                 printf("\t-Scope::search() found imported private symbol%s.%s, kind = '%s'\n",

--- a/gcc/d/dfrontend/scope.h
+++ b/gcc/d/dfrontend/scope.h
@@ -74,7 +74,7 @@ struct Scope
 {
     Scope *enclosing;           // enclosing Scope
 
-    Module *module;             // Root module
+    Module *_module;            // Root module
     ScopeDsymbol *scopesym;     // current symbol
     ScopeDsymbol *sds;          // if in static if, and declaring new symbols,
                                 // sds gets the addMember()

--- a/gcc/d/dfrontend/statement.c
+++ b/gcc/d/dfrontend/statement.c
@@ -31,6 +31,7 @@
 bool walkPostorder(Statement *s, StoppableVisitor *v);
 StorageClass mergeFuncAttrs(StorageClass s1, FuncDeclaration *f);
 bool checkEscapeRef(Scope *sc, Expression *e, bool gag);
+VarDeclaration *copyToTemp(StorageClass stc, const char *name, Expression *e);
 
 Identifier *fixupLabelName(Scope *sc, Identifier *ident)
 {
@@ -967,7 +968,7 @@ Statements *CompileStatement::flatten(Scope *sc)
         {
             se = se->toUTF8(sc);
             unsigned errors = global.errors;
-            Parser p(loc, sc->module, (utf8_t *)se->string, se->len, 0);
+            Parser p(loc, sc->_module, (utf8_t *)se->string, se->len, 0);
             p.nextToken();
 
             while (p.token.value != TOKeof)
@@ -1472,6 +1473,10 @@ static bool checkVar(SwitchStatement *s, VarDeclaration *vd)
     {
         // All good, the label's scope has no variables
     }
+    else if (vd->storage_class & STCexptemp)
+    {
+        // Lifetime ends at end of expression, so no issue with skipping the statement
+    }
     else if (vd->ident == Id::withSym)
     {
         s->error("'switch' skips declaration of 'with' temporary at %s", vd->loc.toChars());
@@ -1796,11 +1801,7 @@ Statement *OnScopeStatement::scopeCode(Scope *sc, Statement **sentry, Statement 
              *  sexception:    x = true;
              *  sfinally: if (!x) statement;
              */
-            Identifier *id = Identifier::generateId("__os");
-
-            ExpInitializer *ie = new ExpInitializer(loc, new IntegerExp(Loc(), 0, Type::tbool));
-            VarDeclaration *v = new VarDeclaration(loc, Type::tbool, id, ie);
-            v->storage_class |= STCtemp;
+            VarDeclaration *v = copyToTemp(0, "__os", new IntegerExp(Loc(), 0, Type::tbool));
             *sentry = new ExpStatement(loc, v);
 
             Expression *e = new IntegerExp(Loc(), 1, Type::tbool);

--- a/gcc/d/dfrontend/statement.h
+++ b/gcc/d/dfrontend/statement.h
@@ -101,8 +101,6 @@ public:
     virtual Statements *flatten(Scope *sc);
     virtual Statement *last();
 
-    int dyncast() const { return DYNCAST_STATEMENT; }
-
     // Avoid dynamic_cast
     virtual ErrorStatement *isErrorStatement() { return NULL; }
     virtual ScopeStatement *isScopeStatement() { return NULL; }

--- a/gcc/d/dfrontend/statementsem.c
+++ b/gcc/d/dfrontend/statementsem.c
@@ -36,6 +36,7 @@ bool checkEscapeRef(Scope *sc, Expression *e, bool gag);
 LabelStatement *checkLabeledLoop(Scope *sc, Statement *statement);
 Identifier *fixupLabelName(Scope *sc, Identifier *ident);
 FuncDeclaration *isFuncAddress(Expression *e, bool *hasOverloads = NULL);
+VarDeclaration *copyToTemp(StorageClass stc, const char *name, Expression *e);
 
 Statement *semantic(Statement *s, Scope *sc);
 void semantic(Catch *c, Scope *sc);
@@ -97,7 +98,8 @@ public:
                 if (f->checkForwardRef(s->exp->loc))
                     s->exp = new ErrorExp();
             }
-            discardValue(s->exp);
+            if (discardValue(s->exp))
+                s->exp = new ErrorExp();
 
             s->exp = s->exp->optimize(WANTvalue);
             s->exp = checkGC(sc, s->exp);
@@ -493,9 +495,7 @@ public:
             fs->aggr->op != TOKtype && !fs->aggr->isLvalue())
         {
             // Bugzilla 14653: Extend the life of rvalue aggregate till the end of foreach.
-            vinit = new VarDeclaration(loc, fs->aggr->type,
-                Identifier::generateId("__aggr"), new ExpInitializer(loc, fs->aggr));
-            vinit->storage_class |= STCtemp;
+            vinit = copyToTemp(STCrvalue, "__aggr", fs->aggr);
             vinit->semantic(sc);
             fs->aggr = new VarExp(fs->aggr->loc, vinit);
         }
@@ -1019,9 +1019,7 @@ public:
                     }
                     else
                     {
-                        Identifier *rid = Identifier::generateId("__r");
-                        r = new VarDeclaration(loc, NULL, rid, new ExpInitializer(loc, fs->aggr));
-                        r->storage_class |= STCtemp;
+                        r = copyToTemp(0, "__r", fs->aggr);
                         init = new ExpStatement(loc, r);
                         if (vinit)
                             init = new CompoundStatement(loc, new ExpStatement(loc, vinit), init);
@@ -1053,11 +1051,7 @@ public:
                     }
                     else
                     {
-                        Identifier *id = Identifier::generateId("__front");
-                        ExpInitializer *ei = new ExpInitializer(loc, einit);
-                        VarDeclaration *vd = new VarDeclaration(loc, NULL, id, ei);
-                        vd->storage_class |= STCtemp | STCctfe | STCref | STCforeach;
-
+                        VarDeclaration *vd = copyToTemp(STCref, "__front", einit);
                         makeargs = new ExpStatement(loc, vd);
 
                         Declaration *d = sfront->isDeclaration();
@@ -2878,10 +2872,7 @@ public:
              *  _d_monitorenter(tmp);
              *  try { body } finally { _d_monitorexit(tmp); }
              */
-            Identifier *id = Identifier::generateId("__sync");
-            ExpInitializer *ie = new ExpInitializer(ss->loc, ss->exp);
-            VarDeclaration *tmp = new VarDeclaration(ss->loc, ss->exp->type, id, ie);
-            tmp->storage_class |= STCtemp;
+            VarDeclaration *tmp = copyToTemp(0, "__sync", ss->exp);
 
             Statements *cs = new Statements();
             cs->push(new ExpStatement(ss->loc, tmp));
@@ -2914,7 +2905,7 @@ public:
              *  try { body } finally { _d_criticalexit(critsec.ptr); }
              */
             Identifier *id = Identifier::generateId("__critsec");
-            Type *t = new TypeSArray(Type::tint8, new IntegerExp(Target::ptrsize + Target::critsecsize()));
+            Type *t = Type::tint8->sarrayOf(Target::ptrsize + Target::critsecsize());
             VarDeclaration *tmp = new VarDeclaration(ss->loc, t, id, NULL);
             tmp->storage_class |= STCtemp | STCgshared | STCstatic;
 
@@ -3029,11 +3020,9 @@ public:
                      *   }
                      * }
                      */
-                    init = new ExpInitializer(ws->loc, ws->exp);
-                    ws->wthis = new VarDeclaration(ws->loc, ws->exp->type, Identifier::generateId("__withtmp"), init);
-                    ws->wthis->storage_class |= STCtemp;
-                    ExpStatement *es = new ExpStatement(ws->loc, ws->wthis);
-                    ws->exp = new VarExp(ws->loc, ws->wthis);
+                    VarDeclaration *tmp = copyToTemp(0, "__withtmp", ws->exp);
+                    ExpStatement *es = new ExpStatement(ws->loc, tmp);
+                    ws->exp = new VarExp(ws->loc, tmp);
                     Statement *ss = new ScopeStatement(ws->loc, new CompoundStatement(ws->loc, es, ws), ws->endloc);
                     result = semantic(ss, sc);
                     return;

--- a/gcc/d/dfrontend/struct.c
+++ b/gcc/d/dfrontend/struct.c
@@ -99,7 +99,7 @@ void semanticTypeInfo(Scope *sc, Type *t)
             if (!sc) // inline may request TypeInfo.
             {
                 Scope scx;
-                scx.module = sd->getModule();
+                scx._module = sd->getModule();
                 getTypeInfoType(t, &scx);
                 sd->requestTypeInfo = true;
             }
@@ -1122,7 +1122,7 @@ void StructDeclaration::semantic(Scope *sc)
 
         _scope = scx ? scx : sc->copy();
         _scope->setNoFree();
-        _scope->module->addDeferredSemantic(this);
+        _scope->_module->addDeferredSemantic(this);
 
         //printf("\tdeferring %s\n", toChars());
         return;

--- a/gcc/d/dfrontend/template.c
+++ b/gcc/d/dfrontend/template.c
@@ -494,14 +494,14 @@ void TemplateDeclaration::semantic(Scope *sc)
 #if LOG
     printf("TemplateDeclaration::semantic(this = %p, id = '%s')\n", this, ident->toChars());
     printf("sc->stc = %llx\n", sc->stc);
-    printf("sc->module = %s\n", sc->module->toChars());
+    printf("sc->module = %s\n", sc->_module->toChars());
 #endif
     if (semanticRun != PASSinit)
         return;         // semantic() already run
     semanticRun = PASSsemantic;
 
     // Remember templates defined in module object that we need to know about
-    if (sc->module && sc->module->ident == Id::object)
+    if (sc->_module && sc->_module->ident == Id::object)
     {
         if (ident == Id::RTInfo)
             Type::rtinfo = this;
@@ -5839,7 +5839,7 @@ void TemplateInstance::semantic(Scope *sc, Expressions *fargs)
     printf("Scope\n");
     for (Scope *scx = sc; scx; scx = scx->enclosing)
     {
-        printf("\t%s parent %s\n", scx->module ? scx->module->toChars() : "null", scx->parent ? scx->parent->toChars() : "null");
+        printf("\t%s parent %s\n", scx->_module ? scx->_module->toChars() : "null", scx->parent ? scx->parent->toChars() : "null");
     }
 #endif
 
@@ -8286,7 +8286,7 @@ void TemplateMixin::semantic(Scope *sc)
             //printf("forward reference - deferring\n");
             _scope = scx ? scx : sc->copy();
             _scope->setNoFree();
-            _scope->module->addDeferredSemantic(this);
+            _scope->_module->addDeferredSemantic(this);
             return;
         }
 

--- a/gcc/d/dfrontend/template.h
+++ b/gcc/d/dfrontend/template.h
@@ -47,7 +47,7 @@ public:
     Objects objects;
 
     // kludge for template.isType()
-    int dyncast() const { return DYNCAST_TUPLE; }
+    int dyncast() { return DYNCAST_TUPLE; }
 
     const char *toChars() { return objects.toChars(); }
 };

--- a/gcc/d/lang.opt
+++ b/gcc/d/lang.opt
@@ -100,6 +100,10 @@ Werror
 D
 ; Documented in common.opt
 
+Wspeculative
+D
+Warn from speculative compiles such as __traits(compiles).
+
 Wtemplates
 D
 ; Documented in C
@@ -249,6 +253,10 @@ D Alias(MM)
 fmake-mdeps=
 D Joined RejectNegative
 Deprecated in favor of -MMD
+
+fmodule-filepath=
+D Joined RejectNegative
+-fmodule-filepath=<package.module>=<filespec>	use <filespec> as source file for <package.module>
 
 fmoduleinfo
 D

--- a/gcc/d/typeinfo.cc
+++ b/gcc/d/typeinfo.cc
@@ -935,7 +935,7 @@ genTypeInfo (Type *type, Scope *sc)
 	  if (sc)
 	    {
 	      /* Find module that will go all the way to an object file.  */
-	      Module *m = sc->module->importedFrom;
+	      Module *m = sc->_module->importedFrom;
 	      m->members->push (t->vtinfo);
 	    }
 	  else

--- a/gcc/testsuite/gdc.test/compilable/imports/imp16798.d
+++ b/gcc/testsuite/gdc.test/compilable/imports/imp16798.d
@@ -1,0 +1,4 @@
+
+module its.a.dessert.topping;
+
+pragma(msg, "it's a dessert topping");

--- a/gcc/testsuite/gdc.test/compilable/imports/wax16798.d
+++ b/gcc/testsuite/gdc.test/compilable/imports/wax16798.d
@@ -1,0 +1,4 @@
+module its.a.floorwax.wax16798;
+
+pragma(msg, "it's a floor wax");
+

--- a/gcc/testsuite/gdc.test/compilable/test16292.d
+++ b/gcc/testsuite/gdc.test/compilable/test16292.d
@@ -1,0 +1,18 @@
+// PERMUTE_ARGS:
+// https://issues.dlang.org/show_bug.cgi?id=16292
+
+void main()
+{
+    goto label;
+    if (makeS()[0])
+    {
+        label:
+    }
+}
+
+S makeS() { return S(); }
+
+struct S
+{
+    int opIndex(size_t i) { return 0; }
+}

--- a/gcc/testsuite/gdc.test/compilable/test16798.d
+++ b/gcc/testsuite/gdc.test/compilable/test16798.d
@@ -1,0 +1,13 @@
+/*
+REQUIRED_ARGS: -mv=its.a.dessert.topping=imports/imp16798.d -mv=its.a.floorwax=imports/
+PERMUTE_ARGS:
+TEST_OUTPUT:
+---
+it's a floor wax
+it's a dessert topping
+---
+*/
+
+import its.a.floorwax.wax16798;
+import its.a.dessert.topping;
+

--- a/gcc/testsuite/gdc.test/compilable/verrors_spec.d
+++ b/gcc/testsuite/gdc.test/compilable/verrors_spec.d
@@ -1,0 +1,14 @@
+/*
+PERMUTE_ARGS:
+REQUIRED_ARGS: -verrors=spec
+TEST_OUTPUT:
+---
+(spec:1) compilable/verrors_spec.d(13): Error: cannot implicitly convert expression (& i) of type int* to int
+---
+*/
+
+void foo(int i)
+{
+    int p;
+    bool b = __traits(compiles, {p = &i;});
+}

--- a/gcc/testsuite/gdc.test/d_do_test.exp
+++ b/gcc/testsuite/gdc.test/d_do_test.exp
@@ -77,6 +77,9 @@ proc gdc-convert-args { args } {
         } elseif [string match "-inline" $arg] {
             lappend out "-finline-functions"
 
+        } elseif [regexp -- {^-mv=([\w+=./-]+)} $arg pattern value] {
+            lappend out "-fmodule-filepath=$value"
+
         } elseif [string match "-O" $arg] {
             lappend out "-O2"
 
@@ -91,6 +94,9 @@ proc gdc-convert-args { args } {
 
         } elseif [string match "-unittest" $arg] {
             lappend out "-funittest"
+
+        } elseif [string match "-verrors=spec" $arg] {
+            lappend out "-Wspeculative"
 
         } elseif [regexp -- {^-verrors=(\d+)} $arg pattern num] {
             lappend out "-fmax-errors=$num"


### PR DESCRIPTION
Adds following options:
- `-Wspeculative` warning for emitting gagged errors.
  There seems to be no nice diagnostic option for this, so I've used anachronism for the time being.  If you want me to try harder and make something more fancy, I'll certainly give it a go.
- `-fmodule-alias=` for the DMD option `-mv`.  Not sure about the name, but DMD's name is no better.

After this, the only bits that are missing are:
- C++ typeinfo / EH support.
- CTFloat.
- Removing the rest of the backend methods.

After this point, we're pretty much cleanly aligned with DMD stable enough to bootstrapping the D implementation of the frontend against GDC.

May want to backport 2.072 + upcoming 2.073 compiler regressions as a nice-to-have, along with phobos.