### PR TITLE
Convert toObjFile to DeclVisitor.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,11 @@
+2017-03-26  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-objfile.cc (DeclVisitor): New visitor interface to supercede the
+	toObjFile methods.
+	(build_decl_tree): New function.
+	(Dsymbol::toObjFile): Remove function and overrides.
+	Updated all callers to use build_decl_tree.
+
 2017-03-20  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-decls.cc (get_cpp_typeinfo_decl): New function.

--- a/gcc/d/d-decls.cc
+++ b/gcc/d/d-decls.cc
@@ -648,7 +648,7 @@ make_thunk (FuncDeclaration *decl, int offset)
       /* Compile the function body before generating the thunk, this is done
 	 even if the decl is external to the current module.  */
       if (decl->fbody)
-	decl->toObjFile ();
+	build_decl_tree (decl);
       else
 	{
 	  /* Build parameters for functions that are not being compiled,

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -73,290 +73,901 @@ static vec<FuncDeclaration *> static_dtor_list;
 // Returns true if DSYM is from the gcc.attribute module.
 
 static bool
-gcc_attribute_p(Dsymbol *dsym)
+gcc_attribute_p (Dsymbol *dsym)
 {
-  ModuleDeclaration *md = dsym->getModule()->md;
+  ModuleDeclaration *md = dsym->getModule ()->md;
 
   if (md && md->packages && md->packages->dim == 1)
     {
-      if (!strcmp((*md->packages)[0]->toChars(), "gcc")
-	  && !strcmp(md->id->toChars(), "attribute"))
+      if (!strcmp ((*md->packages)[0]->toChars (), "gcc")
+	  && !strcmp (md->id->toChars (), "attribute"))
 	return true;
     }
 
   return false;
 }
 
-void
-Dsymbol::toObjFile()
+/* Implements the visitor interface to lower all Declaration AST classes
+   emitted from the D Front-end to GCC trees.
+   All visit methods accept one parameter D, which holds the frontend AST
+   of the declaration to compile.  These also don't return any value, instead
+   generated code are appened to global_declarations or added to the
+   current_binding_level by d_pushdecl().  */
+
+class DeclVisitor : public Visitor
 {
-  // Emit the imported symbol to debug.
-  Import *imp = this->isImport();
+public:
+  DeclVisitor (void) { }
 
-  if (imp != NULL)
-    {
-      // Implements import declarations by telling the debug backend we are
-      // importing the NAMESPACE_DECL of the module or IMPORTED_DECL of the
-      // declaration into the current lexical scope CONTEXT.  NAME is set if
-      // this is a renamed import.
+  /* This should be overridden by each declaration class.  */
 
-      if (imp->isstatic)
+  void visit (Dsymbol *)
+  {
+  }
+
+  /* Write imported symbol D to debug.  */
+
+  void visit (Import *d)
+  {
+    /* Implements import declarations by telling the debug backend we are
+       importing the NAMESPACE_DECL of the module or IMPORTED_DECL of the
+       declaration into the current lexical scope CONTEXT.  NAME is set if
+       this is a renamed import.  */
+    if (d->isstatic)
+      return;
+
+    /* Get the context of this import, this should never be null.  */
+    tree context;
+    if (cfun != NULL)
+      context = current_function_decl;
+    else
+      context = build_import_decl (current_module_decl);
+
+    if (d->ident == NULL)
+      {
+	/* Importing declaration list.  */
+	for (size_t i = 0; i < d->names.dim; i++)
+	  {
+	    AliasDeclaration *aliasdecl = d->aliasdecls[i];
+	    tree decl = build_import_decl (aliasdecl);
+
+	    /* Skip over unhandled imports.  */
+	    if (decl == NULL_TREE)
+	      continue;
+
+	    set_decl_location (decl, d);
+
+	    Identifier *alias = d->aliases[i];
+	    tree name = (alias != NULL)
+	      ? get_identifier (alias->toChars ()) : NULL_TREE;
+
+	    (*debug_hooks->imported_module_or_decl)(decl, name, context, false);
+	  }
+      }
+    else
+      {
+	/* Importing the entire module.  */
+	tree decl = build_import_decl (d->mod);
+	set_input_location (d);
+
+	tree name = (d->aliasId != NULL)
+	  ? get_identifier (d->aliasId->toChars ()) : NULL_TREE;
+
+	(*debug_hooks->imported_module_or_decl)(decl, name, context, false);
+      }
+  }
+
+  /* Expand any local variables found in tuples.  */
+
+  void visit (TupleDeclaration *d)
+  {
+    for (size_t i = 0; i < d->objects->dim; i++)
+      {
+	RootObject *o = (*d->objects)[i];
+	if ((o->dyncast () == DYNCAST_EXPRESSION)
+	    && ((Expression *) o)->op == TOKdsymbol)
+	  {
+	    Declaration *d = ((DsymbolExp *) o)->s->isDeclaration ();
+	    if (d)
+	      d->accept (this);
+	  }
+      }
+  }
+
+  /* Walk over all declarations in the attribute scope.  */
+
+  void visit (AttribDeclaration *d)
+  {
+    Dsymbols *ds = d->include (NULL, NULL);
+
+    if (!ds)
+      return;
+
+    for (size_t i = 0; i < ds->dim; i++)
+      {
+	Dsymbol *s = (*ds)[i];
+	s->accept (this);
+      }
+  }
+
+  /* */
+
+  void visit (PragmaDeclaration *d)
+  {
+    if (!global.params.ignoreUnsupportedPragmas)
+      {
+	if (d->ident == Id::lib || d->ident == Id::startaddress)
+	  {
+	    warning_at (get_linemap (d->loc), OPT_Wunknown_pragmas,
+			"pragma(%s) not implemented", d->ident->toChars ());
+	  }
+      }
+
+    visit ((AttribDeclaration *) d);
+  }
+
+  /* Walk over all members in the namespace scope.  */
+
+  void visit (Nspace *d)
+  {
+    if (isError (d) || !d->members)
+      return;
+
+    for (size_t i = 0; i < d->members->dim; i++)
+      {
+	Dsymbol *s = (*d->members)[i];
+	s->accept (this);
+      }
+  }
+
+  /* Walk over all members in the instantiated template.  */
+
+  void visit (TemplateInstance *d)
+  {
+    if (isError (d)|| !d->members)
+      return;
+
+    if (!d->needsCodegen ())
+      return;
+
+    for (size_t i = 0; i < d->members->dim; i++)
+      {
+	Dsymbol *s = (*d->members)[i];
+	s->accept (this);
+      }
+  }
+
+  /* Walk over all members in the mixin template scope.  */
+
+  void visit (TemplateMixin *d)
+  {
+    if (isError (d)|| !d->members)
+      return;
+
+    for (size_t i = 0; i < d->members->dim; i++)
+      {
+	Dsymbol *s = (*d->members)[i];
+	s->accept (this);
+      }
+  }
+
+  /*  */
+
+  void visit (StructDeclaration *d)
+  {
+    if (d->type->ty == Terror)
+      {
+	d->error ("had semantic errors when compiling");
 	return;
+      }
 
-      // Get the context of this import, this should never be null.
-      tree context;
-      if (cfun != NULL)
-	context = current_function_decl;
-      else
-	context = build_import_decl(current_module_decl);
+    /* Add this decl to the current binding level.  */
+    tree ctype = build_ctype (d->type);
+    if (TYPE_NAME (ctype))
+      d_pushdecl (TYPE_NAME (ctype));
 
-      if (imp->ident == NULL)
-	{
-	  // Importing declaration list.
-	  for (size_t i = 0; i < imp->names.dim; i++)
-	    {
-	      AliasDeclaration *aliasdecl = imp->aliasdecls[i];
-	      tree decl = build_import_decl(aliasdecl);
-
-              // Skip over unhandled imports.
-	      if (decl == NULL_TREE)
-		continue;
-
-	      set_decl_location(decl, imp);
-
-	      Identifier *alias = imp->aliases[i];
-	      tree name = (alias != NULL)
-		? get_identifier(alias->toChars()) : NULL_TREE;
-
-	      (*debug_hooks->imported_module_or_decl)(decl, name, context, false);
-	    }
-	}
-      else
-	{
-	  // Importing the entire module.
-	  tree decl = build_import_decl(imp->mod);
-	  set_input_location(imp);
-
-	  tree name = (imp->aliasId != NULL)
-	    ? get_identifier(imp->aliasId->toChars()) : NULL_TREE;
-
-	  (*debug_hooks->imported_module_or_decl)(decl, name, context, false);
-	}
-
+    /* Anonymous structs/unions only exist as part of others,
+       do not output forward referenced structs's.  */
+    if (d->isAnonymous () || !d->members)
       return;
-    }
 
-  // Emit local variables for tuples.
-  TupleDeclaration *td = this->isTupleDeclaration();
-  if (td == NULL)
-    return;
-
-  for (size_t i = 0; i < td->objects->dim; i++)
-    {
-      RootObject *o = (*td->objects)[i];
-      if ((o->dyncast() == DYNCAST_EXPRESSION) && ((Expression *) o)->op == TOKdsymbol)
-	{
-	  Declaration *d = ((DsymbolExp *) o)->s->isDeclaration();
-	  if (d)
-	    d->toObjFile();
-	}
-    }
-}
-
-void
-AttribDeclaration::toObjFile()
-{
-  Dsymbols *d = include (NULL, NULL);
-
-  if (!d)
-    return;
-
-  for (size_t i = 0; i < d->dim; i++)
-    {
-      Dsymbol *s = (*d)[i];
-      s->toObjFile();
-    }
-}
-
-void
-PragmaDeclaration::toObjFile()
-{
-  if (!global.params.ignoreUnsupportedPragmas)
-    {
-      if (ident == Id::lib || ident == Id::startaddress)
-	{
-	  warning_at (get_linemap (this->loc), OPT_Wunknown_pragmas,
-		      "pragma(%s) not implemented", ident->toChars ());
-	}
-    }
-
-  AttribDeclaration::toObjFile();
-}
-
-void
-Nspace::toObjFile()
-{
-  if (isError(this) || !members)
-    return;
-
-  for (size_t i = 0; i < members->dim; i++)
-    {
-      Dsymbol *s = (*members)[i];
-      s->toObjFile();
-    }
-}
-
-void
-StaticAssert::toObjFile()
-{
-}
-
-void
-StructDeclaration::toObjFile()
-{
-  if (type->ty == Terror)
-    {
-      error ("had semantic errors when compiling");
+    /* Don't emit any symbols from gcc.attribute module.  */
+    if (gcc_attribute_p (d))
       return;
-    }
 
-  /* Add this decl to the current binding level.  */
-  tree ctype = build_ctype(type);
-  if (TYPE_NAME (ctype))
-    d_pushdecl(TYPE_NAME (ctype));
+    /* Generate TypeInfo.  */
+    genTypeInfo (d->type, NULL);
 
-  // Anonymous structs/unions only exist as part of others,
-  // do not output forward referenced structs's
-  if (isAnonymous() || !members)
-    return;
+    /* Generate static initialiser.  */
+    d->sinit = aggregate_initializer (d);
+    d->toDt (&DECL_LANG_INITIAL (d->sinit));
 
-  // Don't emit any symbols from gcc.attribute module.
-  if (gcc_attribute_p(this))
-    return;
+    d_finish_symbol (d->sinit);
 
-  // Generate TypeInfo
-  genTypeInfo(type, NULL);
+    /* Put out the members.  */
+    for (size_t i = 0; i < d->members->dim; i++)
+      {
+	Dsymbol *member = (*d->members)[i];
+	/* There might be static ctors in the members, and they cannot
+	   be put in separate object files.  */
+	member->accept (this);
+      }
 
-  // Generate static initialiser
-  sinit = aggregate_initializer (this);
-  toDt (&DECL_LANG_INITIAL (sinit));
+    /* Put out xopEquals, xopCmp and xopHash.  */
+    if (d->xeq && d->xeq != d->xerreq)
+      d->xeq->accept (this);
 
-  d_finish_symbol (sinit);
+    if (d->xcmp && d->xcmp != d->xerrcmp)
+      d->xcmp->accept (this);
 
-  // Put out the members
-  for (size_t i = 0; i < members->dim; i++)
-    {
-      Dsymbol *member = (*members)[i];
-      // There might be static ctors in the members, and they cannot
-      // be put in separate object files.
-      member->toObjFile();
-    }
+    if (d->xhash)
+      d->xhash->accept (this);
+  }
 
-  // Put out xopEquals, xopCmp and xopHash
-  if (xeq && xeq != xerreq)
-    xeq->toObjFile();
+  /*  */
+  void visit (ClassDeclaration *d)
+  {
+    if (d->type->ty == Terror)
+      {
+	d->error ("had semantic errors when compiling");
+	return;
+      }
 
-  if (xcmp && xcmp != xerrcmp)
-    xcmp->toObjFile();
+    if (!d->members)
+      return;
 
-  if (xhash)
-    xhash->toObjFile();
-}
+    /* Put out the members.  */
+    for (size_t i = 0; i < d->members->dim; i++)
+      {
+	Dsymbol *member = (*d->members)[i];
+	member->accept (this);
+      }
+
+    /* Generate C symbols.  */
+    d->csym = get_classinfo_decl (d);
+    d->vtblsym = get_vtable_decl (d);
+    d->sinit = aggregate_initializer (d);
+
+    /* Generate static initialiser.  */
+    d->toDt (&DECL_LANG_INITIAL (d->sinit));
+    d_finish_symbol (d->sinit);
+
+    /* Put out the TypeInfo.  */
+    genTypeInfo (d->type, NULL);
+    DECL_INITIAL (d->csym) = layout_classinfo (d);
+    d_finish_symbol (d->csym);
+
+    /* Put out the vtbl[].  */
+    vec<constructor_elt, va_gc> *elms = NULL;
+
+    /* First entry is ClassInfo reference.  */
+    if (d->vtblOffset ())
+      CONSTRUCTOR_APPEND_ELT (elms, size_zero_node, build_address (d->csym));
+
+    for (size_t i = d->vtblOffset (); i < d->vtbl.dim; i++)
+      {
+	FuncDeclaration *fd = d->vtbl[i]->isFuncDeclaration ();
+
+	if (!fd || (!fd->fbody && d->isAbstract ()))
+	  continue;
+
+	fd->functionSemantic ();
+
+	if (d->isFuncHidden (fd))
+	  {
+	    /* The function fd is hidden from the view of the class.
+	       If it overlaps with any function in the vtbl[], then
+	       issue an error.  */
+	    for (size_t j = 1; j < d->vtbl.dim; j++)
+	      {
+		if (j == i)
+		  continue;
+
+		FuncDeclaration *fd2 = d->vtbl[j]->isFuncDeclaration ();
+		if (!fd2->ident->equals (fd->ident))
+		  continue;
+
+		if (fd->leastAsSpecialized (fd2) || fd2->leastAsSpecialized (fd))
+		  {
+		    TypeFunction *tf = (TypeFunction *) fd->type;
+		    if (tf->ty == Tfunction)
+		      {
+			d->error ("use of %s%s is hidden by %s; "
+				  "use 'alias %s = %s.%s;' "
+				  "to introduce base class overload set.",
+				  fd->toPrettyChars (),
+				  parametersTypeToChars (tf->parameters, tf->varargs),
+				  d->toChars (), fd->toChars (),
+				  fd->parent->toChars (), fd->toChars ());
+		      }
+		    else
+		      {
+			error ("use of %s is hidden by %s",
+			       fd->toPrettyChars (), d->toChars ());
+		      }
+
+		    break;
+		  }
+	      }
+	  }
+
+	CONSTRUCTOR_APPEND_ELT (elms, size_int (i),
+				build_address (get_symbol_decl (fd)));
+      }
+
+    DECL_INITIAL (d->vtblsym)
+      = build_constructor (TREE_TYPE (d->vtblsym), elms);
+    d_finish_symbol (d->vtblsym);
+
+    /* Add this decl to the current binding level.  */
+    tree ctype = TREE_TYPE (build_ctype (d->type));
+    if (TYPE_NAME (ctype))
+      d_pushdecl (TYPE_NAME (ctype));
+  }
+
+  /*  */
+
+  void visit (InterfaceDeclaration *d)
+  {
+    if (d->type->ty == Terror)
+      {
+	d->error ("had semantic errors when compiling");
+	return;
+      }
+
+    if (!d->members)
+      return;
+
+    /* Put out the members.  */
+    for (size_t i = 0; i < d->members->dim; i++)
+      {
+	Dsymbol *member = (*d->members)[i];
+	member->accept (this);
+      }
+
+    /* Generate C symbols.  */
+    d->csym = get_classinfo_decl (d);
+
+    /* Put out the TypeInfo.  */
+    genTypeInfo (d->type, NULL);
+    d->type->vtinfo->accept (this);
+    DECL_INITIAL (d->csym) = layout_classinfo (d);
+    d_finish_symbol (d->csym);
+
+    /* Add this decl to the current binding level.  */
+    tree ctype = TREE_TYPE (build_ctype (d->type));
+    if (TYPE_NAME (ctype))
+      d_pushdecl (TYPE_NAME (ctype));
+  }
+
+  /*  */
+
+  void visit (EnumDeclaration *d)
+  {
+    if (d->semanticRun >= PASSobj)
+      return;
+
+    if (d->errors || d->type->ty == Terror)
+      {
+	d->error ("had semantic errors when compiling");
+	return;
+      }
+
+    if (d->isAnonymous ())
+      return;
+
+    /* Generate TypeInfo.  */
+    genTypeInfo (d->type, NULL);
+
+    TypeEnum *tc = (TypeEnum *) d->type;
+    if (tc->sym->members && !d->type->isZeroInit ())
+      {
+	/* Generate static initialiser.  */
+	d->sinit = enum_initializer (d);
+	DECL_INITIAL (d->sinit) = build_expr (tc->sym->defaultval, true);
+	d_finish_symbol (d->sinit);
+
+	/* Add this decl to the current binding level.  */
+	tree ctype = build_ctype (d->type);
+	if (TREE_CODE (ctype) == ENUMERAL_TYPE && TYPE_NAME (ctype))
+	  d_pushdecl (TYPE_NAME (ctype));
+      }
+
+    d->semanticRun = PASSobj;
+  }
+
+  /*  */
+
+  void visit (VarDeclaration *d)
+  {
+    if (d->type->ty == Terror)
+      {
+	d->error ("had semantic errors when compiling");
+	return;
+      }
+
+    if (d->aliassym)
+      {
+	d->toAlias ()->accept (this);
+	return;
+      }
+
+    /* Do not store variables we cannot take the address of,
+       but keep the values for purposes of debugging.  */
+    if (!d->canTakeAddressOf ())
+      {
+	/* Don't know if there is a good way to handle instantiations.  */
+	if (d->isInstantiated ())
+	  return;
+
+	tree decl = get_symbol_decl (d);
+	gcc_assert (d->_init && !d->_init->isVoidInitializer ());
+	Expression *ie = d->_init->toExpression ();
+
+	/* CONST_DECL was initially intended for enumerals and may be used for
+	   scalars in general, but not for aggregates.  Here a non-constant
+	   value is generated anyway so as the CONST_DECL only serves as a
+	   placeholder for the value, however the DECL itself should never be
+	   referenced in any generated code, or passed to the backend.  */
+	if (!d->type->isscalar ())
+	  DECL_INITIAL (decl) = build_expr (ie, false);
+	else
+	  {
+	    DECL_INITIAL (decl) = build_expr (ie, true);
+	    d_pushdecl (decl);
+	    rest_of_decl_compilation (decl, 1, 0);
+	  }
+      }
+    else if (d->isDataseg () && !(d->storage_class & STCextern))
+      {
+	tree s = get_symbol_decl (d);
+
+	/* Duplicated VarDeclarations map to the same symbol. Check if this
+	   is the one declaration which will be emitted.  */
+	tree ident = DECL_ASSEMBLER_NAME (s);
+	if (IDENTIFIER_DSYMBOL (ident) && IDENTIFIER_DSYMBOL (ident) != d)
+	  return;
+
+	if (d->isThreadlocal ())
+	  {
+	    ModuleInfo *mi = current_module_info;
+	    mi->tlsVars.safe_push (d);
+	  }
+
+	/* How big a symbol can be should depend on backend.  */
+	tree size = build_integer_cst (d->type->size (d->loc),
+				       build_ctype (Type::tsize_t));
+	if (!valid_constant_size_p (size))
+	  {
+	    d->error ("size is too large");
+	    return;
+	  }
+
+	if (d->_init && !d->_init->isVoidInitializer ())
+	  {
+	    /* Look for static array that is block initialised.  */
+	    Type *tb = d->type->toBasetype ();
+	    ExpInitializer *ie = d->_init->isExpInitializer ();
+
+	    if (ie != NULL && tb->ty == Tsarray
+		&& !d_types_same (tb, ie->exp->type))
+	      {
+		tree val = build_expr (ie->exp, true);
+		dt_cons (&DECL_LANG_INITIAL (s),
+			 build_array_from_val (tb, val));
+	      }
+	    else
+	      DECL_LANG_INITIAL (s) = d->_init->toDt ();
+	  }
+	else
+	  {
+	    if (d->type->ty == Tstruct)
+	      ((TypeStruct *) d->type)->sym->toDt (&DECL_LANG_INITIAL (s));
+	    else
+	      {
+		Expression *e = d->type->defaultInitLiteral (d->loc);
+		dt_cons (&DECL_LANG_INITIAL (s), build_expr (e, true));
+	      }
+	  }
+
+	/* Frontend should have already caught this.  */
+	gcc_assert (!integer_zerop (size)
+		    || d->type->toBasetype ()->ty == Tsarray);
+
+	d_finish_symbol (s);
+      }
+    else if (!d->isDataseg () && !d->isMember ())
+      {
+	/* This is needed for VarDeclarations in mixins that are to be local
+	   variables of a function.  Otherwise, it would be enough to make
+	   a check for isVarDeclaration() in DeclarationExp codegen.  */
+	build_local_var (d);
+
+	if (d->_init)
+	  {
+	    if (!d->_init->isVoidInitializer ())
+	      {
+		ExpInitializer *vinit = d->_init->isExpInitializer ();
+		Expression *ie = vinit->toExpression ();
+		tree exp = build_expr (ie);
+		add_stmt (exp);
+	      }
+	    else if (d->size (d->loc) != 0)
+	      {
+		/* Zero-length arrays do not have an initializer.  */
+		warning (OPT_Wuninitialized, "uninitialized variable '%s'",
+			 d->ident ? d->ident->toChars () : "(no name)");
+	      }
+	  }
+      }
+  }
+
+  /*  */
+
+  void visit (TypeInfoDeclaration *d)
+  {
+    if (isSpeculativeType (d->tinfo))
+      return;
+
+    tree s = get_typeinfo_decl (d);
+    DECL_INITIAL (s) = layout_typeinfo (d);
+    d_finish_symbol (s);
+  }
+
+  /* Finish up a function declaration and compile it all the way
+     down to assembler language output.  */
+
+  void visit (FuncDeclaration *d)
+  {
+    /* Already generated the function.  */
+    if (d->semanticRun >= PASSobj)
+      return;
+
+    /* Don't emit any symbols from gcc.attribute module.  */
+    if (gcc_attribute_p (d))
+      return;
+
+    /* Not emitting unittest functions.  */
+    if (!global.params.useUnitTests && d->isUnitTestDeclaration ())
+      return;
+
+    /* Check if any errors occurred when running semantic.  */
+    if (d->type->ty == Tfunction)
+      {
+	TypeFunction *tf = (TypeFunction *) d->type;
+	if (tf->next == NULL || tf->next->ty == Terror)
+	  return;
+      }
+
+    if (d->semantic3Errors)
+      return;
+
+    if (d->isNested ())
+      {
+	FuncDeclaration *fdp = d;
+	while (fdp && fdp->isNested ())
+	  {
+	    fdp = fdp->toParent2 ()->isFuncDeclaration ();
+
+	    if (fdp == NULL)
+	      break;
+
+	    /* Parent failed to compile, but errors were gagged.  */
+	    if (fdp->semantic3Errors)
+	      return;
+
+	    if (UnitTestDeclaration *udp = fdp->isUnitTestDeclaration ())
+	      {
+		/* Defer until outer unittest has been emitted.  */
+		if (udp->semanticRun < PASSobj)
+		  {
+		    udp->deferredNested.push (d);
+		    return;
+		  }
+	      }
+	  }
+      }
+
+    /* Ensure all semantic passes have ran.  */
+    if (d->semanticRun < PASSsemantic3)
+      {
+	d->functionSemantic3 ();
+	Module::runDeferredSemantic3 ();
+      }
+
+    if (global.errors)
+      return;
+
+    /* Duplicated FuncDeclarations map to the same symbol. Check if this
+       is the one declaration which will be emitted.  */
+    tree fndecl = get_symbol_decl (d);
+    tree ident = DECL_ASSEMBLER_NAME (fndecl);
+    if (IDENTIFIER_DSYMBOL (ident) && IDENTIFIER_DSYMBOL (ident) != d)
+      return;
+
+    /* For nested functions in particular, unnest fndecl in the cgraph, as
+       all static chain passing is handled by the front-end.  Do this even
+       if we are not emitting the body.  */
+    struct cgraph_node *node = cgraph_node::get_create (fndecl);
+    if (node->origin)
+      node->unnest ();
+
+    if (!d->fbody)
+      {
+	rest_of_decl_compilation (fndecl, 1, 0);
+	return;
+      }
+
+    /* This function exists in static storage.
+       (This does not mean `static' in the C sense!)  */
+    TREE_STATIC (fndecl) = 1;
+
+    /* Add this decl to the current binding level.  */
+    d_pushdecl (fndecl);
+
+    /* Start generating code for this function.  */
+    gcc_assert (d->semanticRun == PASSsemantic3done);
+    d->semanticRun = PASSobj;
+
+    /* Nested functions may not have its body compiled before the outer
+       function is finished.  GCC requires that nested functions be finished
+       first so we need to arrange for build_decl_tree to be called earlier.  */
+    FuncDeclaration *fdp = d->toParent2 ()->isFuncDeclaration ();
+    if (fdp && fdp->semanticRun < PASSobj)
+      fdp->accept (this);
+
+    if (global.params.verbose)
+      fprintf (global.stdmsg, "function  %s\n", d->toPrettyChars ());
+
+    tree old_current_function_decl = current_function_decl;
+    function *old_cfun = cfun;
+    current_function_decl = fndecl;
+
+    tree return_type = TREE_TYPE (TREE_TYPE (fndecl));
+    tree result_decl = build_decl (UNKNOWN_LOCATION, RESULT_DECL,
+				   NULL_TREE, return_type);
+
+    set_decl_location (result_decl, d);
+    DECL_RESULT (fndecl) = result_decl;
+    DECL_CONTEXT (result_decl) = fndecl;
+    DECL_ARTIFICIAL (result_decl) = 1;
+    DECL_IGNORED_P (result_decl) = 1;
+
+    allocate_struct_function (fndecl, false);
+    set_function_end_locus (d->endloc);
+
+    start_function (d);
+
+    tree parm_decl = NULL_TREE;
+    tree param_list = NULL_TREE;
+
+    /* Special arguments...  */
+
+    /* 'this' parameter:
+       For nested functions, D still generates a vthis, but it
+       should not be referenced in any expression.  */
+    if (d->vthis)
+      {
+	parm_decl = get_symbol_decl (d->vthis);
+	DECL_ARTIFICIAL (parm_decl) = 1;
+	TREE_READONLY (parm_decl) = 1;
+
+	if (d->vthis->type == Type::tvoidptr)
+	  {
+	    /* Replace generic pointer with backend closure type
+	       (this wins for gdb).  */
+	    tree frame_type = FRAMEINFO_TYPE (get_frameinfo (d));
+	    gcc_assert (frame_type != NULL_TREE);
+	    TREE_TYPE (parm_decl) = build_pointer_type (frame_type);
+	  }
+
+	set_decl_location (parm_decl, d->vthis);
+	param_list = chainon (param_list, parm_decl);
+	cfun->language->static_chain = parm_decl;
+      }
+
+    /* _arguments parameter.  */
+    if (d->v_arguments)
+      {
+	parm_decl = get_symbol_decl (d->v_arguments);
+	set_decl_location (parm_decl, d->v_arguments);
+	param_list = chainon (param_list, parm_decl);
+      }
+
+    /* formal function parameters.  */
+    size_t n_parameters = d->parameters ? d->parameters->dim : 0;
+
+    for (size_t i = 0; i < n_parameters; i++)
+      {
+	VarDeclaration *param = (*d->parameters)[i];
+	parm_decl = get_symbol_decl (param);
+	set_decl_location (parm_decl, (Dsymbol *) param);
+	/* Chain them in the correct order.  */
+	param_list = chainon (param_list, parm_decl);
+      }
+
+    DECL_ARGUMENTS (fndecl) = param_list;
+    rest_of_decl_compilation (fndecl, 1, 0);
+    DECL_INITIAL (fndecl) = error_mark_node;
+
+    push_stmt_list ();
+    push_binding_level (level_function);
+    set_input_location (d->loc);
+
+    /* If this is a member function that nested (possibly indirectly) in another
+       function, construct an expession for this member function's static chain
+       by going through parent link of nested classes.  */
+    if (d->isThis ())
+      {
+	AggregateDeclaration *ad = d->isThis ();
+	tree this_tree = get_symbol_decl (d->vthis);
+
+	while (ad->isNested ())
+	  {
+	    Dsymbol *pd = ad->toParent2 ();
+	    tree vthis_field = get_symbol_decl (ad->vthis);
+	    this_tree = component_ref (build_deref (this_tree), vthis_field);
+
+	    ad = pd->isAggregateDeclaration ();
+	    if (ad == NULL)
+	      {
+		cfun->language->static_chain = this_tree;
+		break;
+	      }
+	  }
+      }
+
+    /* May change cfun->static_chain.  */
+    build_closure (d);
+
+    if (d->vresult)
+      build_local_var (d->vresult);
+
+    if (d->v_argptr)
+      push_stmt_list ();
+
+    /* The fabled D named return value optimisation.
+       Implemented by overriding all the RETURN_EXPRs and replacing all
+       occurrences of VAR with the RESULT_DECL for the function.
+       This is only worth doing for functions that can return in memory.  */
+    if (d->nrvo_can)
+      {
+	if (!AGGREGATE_TYPE_P (return_type))
+	  d->nrvo_can = 0;
+	else
+	  d->nrvo_can = aggregate_value_p (return_type, fndecl);
+      }
+
+    if (d->nrvo_can)
+      {
+	TREE_TYPE (result_decl)
+	  = build_reference_type (TREE_TYPE (result_decl));
+	DECL_BY_REFERENCE (result_decl) = 1;
+	TREE_ADDRESSABLE (result_decl) = 0;
+	relayout_decl (result_decl);
+
+	if (d->nrvo_var)
+	  {
+	    tree var = get_symbol_decl (d->nrvo_var);
+
+	    /* Copy name from VAR to RESULT.  */
+	    DECL_NAME (result_decl) = DECL_NAME (var);
+	    /* Don't forget that we take it's address.  */
+	    TREE_ADDRESSABLE (var) = 1;
+
+	    result_decl = build_deref (result_decl);
+
+	    SET_DECL_VALUE_EXPR (var, result_decl);
+	    DECL_HAS_VALUE_EXPR_P (var) = 1;
+
+	    SET_DECL_LANG_NRVO (var, result_decl);
+	  }
+      }
+
+    build_ir (d);
+
+    if (d->v_argptr)
+      {
+	tree body = pop_stmt_list ();
+	tree var = get_decl_tree (d->v_argptr);
+	var = build_address (var);
+
+	tree init_exp = d_build_call_nary (builtin_decl_explicit (BUILT_IN_VA_START),
+					   2, var, parm_decl);
+	build_local_var (d->v_argptr);
+	add_stmt (init_exp);
+
+	tree cleanup = d_build_call_nary (builtin_decl_explicit (BUILT_IN_VA_END),
+					  1, var);
+	add_stmt (build2 (TRY_FINALLY_EXPR, void_type_node, body, cleanup));
+      }
+
+    /* Backend expects a statement list to come from somewhere, however
+       popStatementList returns expressions when there is a single statement.
+       So here we create a statement list unconditionally.  */
+    tree block = pop_binding_level ();
+    tree body = pop_stmt_list ();
+    tree bind = build3 (BIND_EXPR, void_type_node,
+			BLOCK_VARS (block), body, block);
+
+    if (TREE_CODE (body) != STATEMENT_LIST)
+      {
+	tree stmtlist = alloc_stmt_list ();
+	append_to_statement_list_force (body, &stmtlist);
+	BIND_EXPR_BODY (bind) = stmtlist;
+      }
+    else if (!STATEMENT_LIST_HEAD (body))
+      {
+	/* For empty functions: Without this, there is a segfault when inlined.
+	   Seen on build=ppc-linux but not others (why?).  */
+	tree ret = return_expr (NULL_TREE);
+	append_to_statement_list_force (ret, &body);
+      }
+
+    DECL_SAVED_TREE (fndecl) = bind;
+
+    if (!errorcount && !global.errors)
+      {
+	/* Dump the D-specific tree IR.  */
+	int local_dump_flags;
+	FILE *dump_file = dump_begin (TDI_original, &local_dump_flags);
+	if (dump_file)
+	  {
+	    fprintf (dump_file, "\n;; Function %s",
+		     lang_hooks.decl_printable_name (fndecl, 2));
+	    fprintf (dump_file, " (%s)\n",
+		     (!DECL_ASSEMBLER_NAME_SET_P (fndecl) ? "null"
+		      : IDENTIFIER_POINTER (DECL_ASSEMBLER_NAME (fndecl))));
+	    fprintf (dump_file, ";; enabled by -%s\n",
+		     dump_flag_name (TDI_original));
+	    fprintf (dump_file, "\n");
+
+	    if (local_dump_flags & TDF_RAW)
+	      dump_node (DECL_SAVED_TREE (fndecl),
+			 TDF_SLIM | local_dump_flags, dump_file);
+	    else
+	      print_generic_expr (dump_file, DECL_SAVED_TREE (fndecl),
+				  local_dump_flags);
+	    fprintf (dump_file, "\n");
+
+	    dump_end (TDI_original, dump_file);
+	  }
+      }
+
+    if (!errorcount && !global.errors)
+      d_finish_function (d);
+
+    /* Process all deferred nested functions.  */
+    for (size_t i = 0; i < cfun->language->deferred_fns.length (); ++i)
+      {
+	FuncDeclaration *fd = cfun->language->deferred_fns[i];
+	fd->accept (this);
+      }
+
+    if (UnitTestDeclaration *ud = d->isUnitTestDeclaration ())
+      {
+	for (size_t i = 0; i < ud->deferredNested.dim; ++i)
+	  {
+	    FuncDeclaration *fd = ud->deferredNested[i];
+	    fd->accept (this);
+	  }
+      }
+
+    end_function ();
+
+    current_function_decl = old_current_function_decl;
+    set_cfun (old_cfun);
+  }
+};
+
+/* Main entry point for the DeclVisitor interface to send
+   the Declaration AST class D to GCC backend.  */
 
 void
-ClassDeclaration::toObjFile()
+build_decl_tree (Dsymbol *d)
 {
-  if (type->ty == Terror)
-    {
-      error ("had semantic errors when compiling");
-      return;
-    }
-
-  if (!members)
-    return;
-
-  // Put out the members
-  for (size_t i = 0; i < members->dim; i++)
-    {
-      Dsymbol *member = (*members)[i];
-      member->toObjFile();
-    }
-
-  // Generate C symbols
-  csym = get_classinfo_decl (this);
-  vtblsym = get_vtable_decl (this);
-  sinit = aggregate_initializer (this);
-
-  // Generate static initialiser
-  toDt (&DECL_LANG_INITIAL (sinit));
-  d_finish_symbol (sinit);
-
-  // Put out the TypeInfo
-  genTypeInfo(type, NULL);
-  DECL_INITIAL (csym) = layout_classinfo (this);
-  d_finish_symbol (csym);
-
-  // Put out the vtbl[]
-  vec<constructor_elt, va_gc> *elms = NULL;
-
-  // first entry is ClassInfo reference
-  if (vtblOffset())
-    CONSTRUCTOR_APPEND_ELT (elms, size_zero_node, build_address (csym));
-
-  for (size_t i = vtblOffset(); i < vtbl.dim; i++)
-    {
-      FuncDeclaration *fd = vtbl[i]->isFuncDeclaration();
-
-      if (!fd || (!fd->fbody && isAbstract ()))
-	continue;
-
-      fd->functionSemantic ();
-
-      if (isFuncHidden (fd))
-	{
-	  // The function fd is hidden from the view of the class.  If it
-	  // overlaps with any function in the vtbl[], then issue an error.
-	  for (size_t j = 1; j < vtbl.dim; j++)
-	    {
-	      if (j == i)
-		continue;
-
-	      FuncDeclaration *fd2 = vtbl[j]->isFuncDeclaration ();
-	      if (!fd2->ident->equals (fd->ident))
-		continue;
-
-	      if (fd->leastAsSpecialized (fd2) || fd2->leastAsSpecialized (fd))
-		{
-		  TypeFunction *tf = (TypeFunction *) fd->type;
-		  if (tf->ty == Tfunction)
-		    {
-		      error ("use of %s%s is hidden by %s; use 'alias %s = "
-			     "%s.%s;' to introduce base class overload set.",
-			     fd->toPrettyChars(),
-			     parametersTypeToChars(tf->parameters, tf->varargs),
-			     toChars(), fd->toChars(),
-			     fd->parent->toChars(), fd->toChars());
-		    }
-		  else
-		    error("use of %s is hidden by %s",
-			  fd->toPrettyChars(), toChars());
-
-		  break;
-		}
-	    }
-	}
-
-      CONSTRUCTOR_APPEND_ELT (elms, size_int (i),
-			      build_address (get_symbol_decl (fd)));
-    }
-
-  DECL_INITIAL (vtblsym) = build_constructor (TREE_TYPE (vtblsym), elms);
-  d_finish_symbol (vtblsym);
-
-  /* Add this decl to the current binding level.  */
-  tree ctype = TREE_TYPE (build_ctype(type));
-  if (TYPE_NAME (ctype))
-    d_pushdecl(TYPE_NAME (ctype));
+  DeclVisitor v = DeclVisitor();
+  d->accept (&v);
 }
 
 // Get offset of base class's vtbl[] initialiser from start of csym.
@@ -391,240 +1002,6 @@ ClassDeclaration::baseVtblOffset (BaseClass *bc)
     }
 
   return ~0;
-}
-
-void
-InterfaceDeclaration::toObjFile()
-{
-  if (type->ty == Terror)
-    {
-      error ("had semantic errors when compiling");
-      return;
-    }
-
-  if (!members)
-    return;
-
-  // Put out the members
-  for (size_t i = 0; i < members->dim; i++)
-    {
-      Dsymbol *member = (*members)[i];
-      member->toObjFile();
-    }
-
-  // Generate C symbols
-  this->csym = get_classinfo_decl (this);
-
-  // Put out the TypeInfo
-  genTypeInfo(type, NULL);
-  type->vtinfo->toObjFile();
-  DECL_INITIAL (csym) = layout_classinfo (this);
-  d_finish_symbol (csym);
-
-  /* Add this decl to the current binding level.  */
-  tree ctype = TREE_TYPE (build_ctype(type));
-  if (TYPE_NAME (ctype))
-    d_pushdecl(TYPE_NAME (ctype));
-}
-
-void
-EnumDeclaration::toObjFile()
-{
-  if (semanticRun >= PASSobj)
-    return;
-
-  if (errors || type->ty == Terror)
-    {
-      error ("had semantic errors when compiling");
-      return;
-    }
-
-  if (isAnonymous())
-    return;
-
-  // Generate TypeInfo
-  genTypeInfo(type, NULL);
-
-  TypeEnum *tc = (TypeEnum *) type;
-  if (tc->sym->members && !type->isZeroInit())
-    {
-      // Generate static initialiser
-      sinit = enum_initializer (this);
-      DECL_INITIAL (sinit) = build_expr(tc->sym->defaultval, true);
-      d_finish_symbol (sinit);
-
-      /* Add this decl to the current binding level.  */
-      tree ctype = build_ctype(type);
-      if (TREE_CODE (ctype) == ENUMERAL_TYPE && TYPE_NAME (ctype))
-	d_pushdecl(TYPE_NAME (ctype));
-    }
-
-  semanticRun = PASSobj;
-}
-
-void
-VarDeclaration::toObjFile()
-{
-  if (type->ty == Terror)
-    {
-      error ("had semantic errors when compiling");
-      return;
-    }
-
-  if (aliassym)
-    {
-      toAlias()->toObjFile();
-      return;
-    }
-
-  // Do not store variables we cannot take the address of,
-  // but keep the values for purposes of debugging.
-  if (!canTakeAddressOf())
-    {
-      // Don't know if there is a good way to handle instantiations.
-      if (isInstantiated())
-	return;
-
-      tree decl = get_symbol_decl (this);
-      gcc_assert (this->_init && !this->_init->isVoidInitializer());
-      Expression *ie = this->_init->toExpression();
-
-      // CONST_DECL was initially intended for enumerals and may be used for
-      // scalars in general, but not for aggregates.  Here a non-constant value
-      // is generated anyway so as the CONST_DECL only serves as a placeholder
-      // for the value, however the DECL itself should never be referenced in
-      // any generated code, or passed to the backend.
-      if (!type->isscalar())
-	DECL_INITIAL (decl) = build_expr(ie, false);
-      else
-	{
-	  DECL_INITIAL (decl) = build_expr(ie, true);
-	  d_pushdecl (decl);
-	  rest_of_decl_compilation (decl, 1, 0);
-	}
-    }
-  else if (isDataseg() && !(storage_class & STCextern))
-    {
-      tree s = get_symbol_decl (this);
-
-      // Duplicated VarDeclarations map to the same symbol. Check if this
-      // is the one declaration which will be emitted.
-      tree ident = DECL_ASSEMBLER_NAME (s);
-      if (IDENTIFIER_DSYMBOL (ident) && IDENTIFIER_DSYMBOL (ident) != this)
-	return;
-
-      if (isThreadlocal())
-	{
-	  ModuleInfo *mi = current_module_info;
-	  mi->tlsVars.safe_push (this);
-	}
-
-      /* How big a symbol can be should depend on backend.  */
-      tree size = build_integer_cst (this->type->size (this->loc),
-				      build_ctype (Type::tsize_t));
-      if (!valid_constant_size_p (size))
-	{
-	  this->error("size is too large");
-	  return;
-	}
-
-      if (this->_init && !this->_init->isVoidInitializer())
-	{
-	  // Look for static array that is block initialised.
-	  Type *tb = type->toBasetype();
-	  ExpInitializer *ie = this->_init->isExpInitializer();
-
-	  if (ie != NULL && tb->ty == Tsarray
-	      && !d_types_same(tb, ie->exp->type))
-	    {
-	      tree val = build_expr(ie->exp, true);
-	      dt_cons (&DECL_LANG_INITIAL (s), build_array_from_val (tb, val));
-	    }
-	  else
-	    DECL_LANG_INITIAL (s) = this->_init->toDt();
-	}
-      else
-	{
-	  if (type->ty == Tstruct)
-	    ((TypeStruct *) type)->sym->toDt(&DECL_LANG_INITIAL (s));
-	  else
-	    {
-	      Expression *e = type->defaultInitLiteral(loc);
-	      dt_cons(&DECL_LANG_INITIAL (s), build_expr(e, true));
-	    }
-	}
-
-      // Frontend should have already caught this.
-      gcc_assert (!integer_zerop (size) || type->toBasetype()->ty == Tsarray);
-      d_finish_symbol (s);
-    }
-  else
-    {
-      // This is needed for VarDeclarations in mixins that are to be local
-      // variables of a function.  Otherwise, it would be enough to make
-      // a check for isVarDeclaration() in DeclarationExp codegen.
-      if (!isDataseg() && !isMember())
-	{
-	  build_local_var (this);
-
-	  if (this->_init)
-	    {
-	      if (!this->_init->isVoidInitializer())
-		{
-		  ExpInitializer *vinit = this->_init->isExpInitializer();
-		  Expression *ie = vinit->toExpression();
-		  tree exp = build_expr(ie);
-		  add_stmt(exp);
-		}
-	      else if (size (loc) != 0)
-		{
-		  // Zero-length arrays do not have an initializer.
-		  warning (OPT_Wuninitialized, "uninitialized variable '%s'",
-			   ident ? ident->toChars() : "(no name)");
-		}
-	    }
-	}
-    }
-}
-
-void
-TemplateInstance::toObjFile()
-{
-  if (isError (this)|| !members)
-    return;
-
-  if (!needsCodegen())
-    return;
-
-  for (size_t i = 0; i < members->dim; i++)
-    {
-      Dsymbol *s = (*members)[i];
-      s->toObjFile();
-    }
-}
-
-void
-TemplateMixin::toObjFile()
-{
-  if (isError (this)|| !members)
-    return;
-
-  for (size_t i = 0; i < members->dim; i++)
-    {
-      Dsymbol *s = (*members)[i];
-      s->toObjFile();
-    }
-}
-
-void
-TypeInfoDeclaration::toObjFile()
-{
-  if (isSpeculativeType(this->tinfo))
-    return;
-
-  tree s = get_typeinfo_decl (this);
-  DECL_INITIAL (s) = layout_typeinfo(this);
-  d_finish_symbol(s);
 }
 
 // Build the ModuleInfo symbol for Module m
@@ -776,345 +1153,6 @@ build_moduleinfo_symbol(Module *m)
   return msym;
 }
 
-// Finish up a function declaration and compile it all the way
-// down to assembler language output.
-
-void
-FuncDeclaration::toObjFile()
-{
-  // Already generated the function.
-  if (this->semanticRun >= PASSobj)
-    return;
-
-  // Don't emit any symbols from gcc.attribute module.
-  if (gcc_attribute_p(this))
-    return;
-
-  // Not emitting unittest functions.
-  if (!global.params.useUnitTests && this->isUnitTestDeclaration())
-    return;
-
-  // Check if any errors occurred when running semantic.
-  if (this->type->ty == Tfunction)
-    {
-      TypeFunction *tf = (TypeFunction *) this->type;
-      if (tf->next == NULL || tf->next->ty == Terror)
-	return;
-    }
-
-  if (this->semantic3Errors)
-    return;
-
-  if (this->isNested())
-    {
-      FuncDeclaration *fdp = this;
-      while (fdp && fdp->isNested())
-	{
-	  fdp = fdp->toParent2()->isFuncDeclaration();
-
-	  if (fdp == NULL)
-	    break;
-
-	  // Parent failed to compile, but errors were gagged.
-	  if (fdp->semantic3Errors)
-	    return;
-
-	  if (UnitTestDeclaration *udp = fdp->isUnitTestDeclaration())
-	    {
-	      // Defer until outer unittest has been emitted.
-	      if (udp->semanticRun < PASSobj)
-		{
-		  udp->deferredNested.push(this);
-		  return;
-		}
-	    }
-	}
-    }
-
-  // Ensure all semantic passes have ran.
-  if (semanticRun < PASSsemantic3)
-    {
-      functionSemantic3();
-      Module::runDeferredSemantic3();
-    }
-
-  if (global.errors)
-    return;
-
-  // Duplicated FuncDeclarations map to the same symbol. Check if this
-  // is the one declaration which will be emitted.
-  tree fndecl = get_symbol_decl (this);
-  tree ident = DECL_ASSEMBLER_NAME (fndecl);
-  if (IDENTIFIER_DSYMBOL (ident) && IDENTIFIER_DSYMBOL (ident) != this)
-    return;
-
-  // For nested functions in particular, unnest fndecl in the cgraph, as
-  // all static chain passing is handled by the front-end.  Do this even
-  // if we are not emitting the body.
-  struct cgraph_node *node = cgraph_node::get_create(fndecl);
-  if (node->origin)
-    node->unnest();
-
-  if (!fbody)
-    {
-      rest_of_decl_compilation (fndecl, 1, 0);
-      return;
-    }
-
-  /* This function exists in static storage.
-     (This does not mean `static' in the C sense!)  */
-  TREE_STATIC (fndecl) = 1;
-
-  /* Add this decl to the current binding level.  */
-  d_pushdecl(fndecl);
-
-  // Start generating code for this function.
-  gcc_assert(this->semanticRun == PASSsemantic3done);
-  this->semanticRun = PASSobj;
-
-  // Nested functions may not have its toObjFile called before the outer
-  // function is finished.  GCC requires that nested functions be finished
-  // first so we need to arrange for toObjFile to be called earlier.
-  FuncDeclaration *fdp = this->toParent2()->isFuncDeclaration();
-  if (fdp && fdp->semanticRun < PASSobj)
-    fdp->toObjFile();
-
-  if (global.params.verbose)
-    fprintf (global.stdmsg, "function  %s\n", this->toPrettyChars());
-
-  tree old_current_function_decl = current_function_decl;
-  function *old_cfun = cfun;
-  current_function_decl = fndecl;
-
-  tree return_type = TREE_TYPE (TREE_TYPE (fndecl));
-  tree result_decl = build_decl (UNKNOWN_LOCATION, RESULT_DECL, NULL_TREE, return_type);
-
-  set_decl_location (result_decl, this);
-  DECL_RESULT (fndecl) = result_decl;
-  DECL_CONTEXT (result_decl) = fndecl;
-  DECL_ARTIFICIAL (result_decl) = 1;
-  DECL_IGNORED_P (result_decl) = 1;
-
-  allocate_struct_function (fndecl, false);
-  set_function_end_locus (endloc);
-
-  start_function(this);
-
-  tree parm_decl = NULL_TREE;
-  tree param_list = NULL_TREE;
-
-  // Special arguments...
-
-  // 'this' parameter
-  // For nested functions, D still generates a vthis, but it
-  // should not be referenced in any expression.
-  if (vthis)
-    {
-      parm_decl = get_symbol_decl (vthis);
-      DECL_ARTIFICIAL (parm_decl) = 1;
-      TREE_READONLY (parm_decl) = 1;
-
-      if (vthis->type == Type::tvoidptr)
-	{
-	  // Replace generic pointer with backend closure type (this wins for gdb).
-	  tree frame_type = FRAMEINFO_TYPE (get_frameinfo (this));
-	  gcc_assert (frame_type != NULL_TREE);
-	  TREE_TYPE (parm_decl) = build_pointer_type (frame_type);
-	}
-
-      set_decl_location (parm_decl, vthis);
-      param_list = chainon (param_list, parm_decl);
-      cfun->language->static_chain = parm_decl;
-    }
-
-  // _arguments parameter.
-  if (v_arguments)
-    {
-      parm_decl = get_symbol_decl (v_arguments);
-      set_decl_location (parm_decl, v_arguments);
-      param_list = chainon (param_list, parm_decl);
-    }
-
-  // formal function parameters.
-  size_t n_parameters = parameters ? parameters->dim : 0;
-
-  for (size_t i = 0; i < n_parameters; i++)
-    {
-      VarDeclaration *param = (*parameters)[i];
-      parm_decl = get_symbol_decl (param);
-      set_decl_location (parm_decl, (Dsymbol *) param);
-      // chain them in the correct order
-      param_list = chainon (param_list, parm_decl);
-    }
-
-  DECL_ARGUMENTS (fndecl) = param_list;
-  rest_of_decl_compilation (fndecl, 1, 0);
-  DECL_INITIAL (fndecl) = error_mark_node;
-
-  push_stmt_list();
-  push_binding_level(level_function);
-  set_input_location (loc);
-
-  // If this is a member function that nested (possibly indirectly) in another
-  // function, construct an expession for this member function's static chain
-  // by going through parent link of nested classes.
-  if (isThis())
-    {
-      AggregateDeclaration *ad = isThis();
-      tree this_tree = get_symbol_decl (vthis);
-
-      while (ad->isNested())
-	{
-	  Dsymbol *d = ad->toParent2();
-	  tree vthis_field = get_symbol_decl (ad->vthis);
-	  this_tree = component_ref (build_deref (this_tree), vthis_field);
-
-	  ad = d->isAggregateDeclaration();
-	  if (ad == NULL)
-	    {
-	      cfun->language->static_chain = this_tree;
-	      break;
-	    }
-	}
-    }
-
-  // May change cfun->static_chain
-  build_closure(this);
-
-  if (vresult)
-    build_local_var (vresult);
-
-  if (v_argptr)
-    push_stmt_list();
-
-  // The fabled D named return value optimisation.
-  // Implemented by overriding all the RETURN_EXPRs and replacing all
-  // occurrences of VAR with the RESULT_DECL for the function.
-  // This is only worth doing for functions that can return in memory.
-  if (nrvo_can)
-    {
-      if (!AGGREGATE_TYPE_P (return_type))
-	nrvo_can = 0;
-      else
-	nrvo_can = aggregate_value_p (return_type, fndecl);
-    }
-
-  if (nrvo_can)
-    {
-      TREE_TYPE (result_decl) = build_reference_type(TREE_TYPE (result_decl));
-      DECL_BY_REFERENCE (result_decl) = 1;
-      TREE_ADDRESSABLE (result_decl) = 0;
-      relayout_decl(result_decl);
-
-      if (nrvo_var)
-	{
-	  tree var = get_symbol_decl (nrvo_var);
-
-	  // Copy name from VAR to RESULT.
-	  DECL_NAME (result_decl) = DECL_NAME (var);
-	  // Don't forget that we take it's address.
-	  TREE_ADDRESSABLE (var) = 1;
-
-	  result_decl = build_deref(result_decl);
-
-	  SET_DECL_VALUE_EXPR (var, result_decl);
-	  DECL_HAS_VALUE_EXPR_P (var) = 1;
-
-	  SET_DECL_LANG_NRVO (var, result_decl);
-	}
-    }
-
-  build_ir (this);
-
-  if (v_argptr)
-    {
-      tree body = pop_stmt_list();
-      tree var = get_decl_tree (v_argptr);
-      var = build_address (var);
-
-      tree init_exp = d_build_call_nary (builtin_decl_explicit (BUILT_IN_VA_START), 2, var, parm_decl);
-      build_local_var (v_argptr);
-      add_stmt(init_exp);
-
-      tree cleanup = d_build_call_nary (builtin_decl_explicit (BUILT_IN_VA_END), 1, var);
-      add_stmt(build2 (TRY_FINALLY_EXPR, void_type_node, body, cleanup));
-    }
-
-  // Backend expects a statement list to come from somewhere, however
-  // popStatementList returns expressions when there is a single statement.
-  // So here we create a statement list unconditionally.
-  tree block = pop_binding_level();
-  tree body = pop_stmt_list();
-  tree bind = build3(BIND_EXPR, void_type_node,
-		     BLOCK_VARS (block), body, block);
-
-  if (TREE_CODE (body) != STATEMENT_LIST)
-    {
-      tree stmtlist = alloc_stmt_list();
-      append_to_statement_list_force (body, &stmtlist);
-      BIND_EXPR_BODY (bind) = stmtlist;
-    }
-  else if (!STATEMENT_LIST_HEAD (body))
-    {
-      /* For empty functions: Without this, there is a segfault when inlined.
-	 Seen on build=ppc-linux but not others (why?).  */
-      tree ret = return_expr (NULL_TREE);
-      append_to_statement_list_force (ret, &body);
-    }
-
-  DECL_SAVED_TREE (fndecl) = bind;
-
-  if (!errorcount && !global.errors)
-    {
-      // Dump the D-specific tree IR.
-      int local_dump_flags;
-      FILE *dump_file = dump_begin (TDI_original, &local_dump_flags);
-      if (dump_file)
-	{
-	  fprintf (dump_file, "\n;; Function %s",
-		   lang_hooks.decl_printable_name (fndecl, 2));
-	  fprintf (dump_file, " (%s)\n",
-		   (!DECL_ASSEMBLER_NAME_SET_P (fndecl) ? "null"
-		    : IDENTIFIER_POINTER (DECL_ASSEMBLER_NAME (fndecl))));
-	  fprintf (dump_file, ";; enabled by -%s\n", dump_flag_name (TDI_original));
-	  fprintf (dump_file, "\n");
-
-	  if (local_dump_flags & TDF_RAW)
-	    dump_node (DECL_SAVED_TREE (fndecl),
-		       TDF_SLIM | local_dump_flags, dump_file);
-	  else
-	    print_generic_expr (dump_file, DECL_SAVED_TREE (fndecl), local_dump_flags);
-	  fprintf (dump_file, "\n");
-
-	  dump_end (TDI_original, dump_file);
-	}
-    }
-
-  if (!errorcount && !global.errors)
-    d_finish_function (this);
-
-  // Process all deferred nested functions.
-  for (size_t i = 0; i < cfun->language->deferred_fns.length(); ++i)
-    {
-      FuncDeclaration *fd = cfun->language->deferred_fns[i];
-      fd->toObjFile();
-    }
-
-  if (UnitTestDeclaration *ud = this->isUnitTestDeclaration())
-    {
-      for (size_t i = 0; i < ud->deferredNested.dim; ++i)
-	{
-	  FuncDeclaration *fd = ud->deferredNested[i];
-	  fd->toObjFile();
-	}
-    }
-
-  end_function();
-
-  current_function_decl = old_current_function_decl;
-  set_cfun (old_cfun);
-}
-
 //
 
 void
@@ -1130,7 +1168,7 @@ Module::genobjfile(bool)
       for (size_t i = 0; i < members->dim; i++)
 	{
 	  Dsymbol *dsym = (*members)[i];
-	  dsym->toObjFile();
+	  build_decl_tree (dsym);
 	}
     }
 
@@ -1573,7 +1611,7 @@ build_simple_function (const char *name, tree expr, bool static_ctor)
   TREE_PUBLIC (func_decl) = 0;
   TREE_USED (func_decl) = 1;
 
-  func->toObjFile();
+  build_decl_tree (func);
 
   return func;
 }
@@ -1666,7 +1704,7 @@ build_emutls_function (vec<VarDeclaration *> tlsVars)
     }
   func->fbody = new CompoundStatement (mod->loc, body);
   func->semantic3 (mod->_scope);
-  func->toObjFile();
+  build_decl_tree (func);
 
   return get_symbol_decl (func);
 }
@@ -1858,7 +1896,7 @@ emit_dso_registry_cdtor(Dsymbol *compiler_dso_type, Dsymbol *dso_registry_func,
     DECL_STATIC_DESTRUCTOR (func_tree) = 1;
 
   d_comdat_linkage(func_tree);
-  func_decl->toObjFile();
+  build_decl_tree (func_decl);
 }
 
 // Build and emit the helper functions for the DSO registry code, including

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -428,6 +428,9 @@ extern tree d_unsigned_type (tree);
 extern tree d_signed_type (tree);
 extern void d_keep (tree);
 
+/* In d-objfile.cc.  */
+extern void build_decl_tree (Dsymbol *);
+
 /* In imports.cc.  */
 extern tree build_import_decl (Dsymbol *);
 

--- a/gcc/d/dfrontend/aggregate.h
+++ b/gcc/d/dfrontend/aggregate.h
@@ -205,7 +205,6 @@ public:
     StructDeclaration *isStructDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 #ifdef IN_GCC
-    void toObjFile();                       // compile to .obj file
     void toDt(dt_t **pdt);
 #endif
 };
@@ -325,7 +324,6 @@ public:
     ClassDeclaration *isClassDeclaration() { return (ClassDeclaration *)this; }
     void accept(Visitor *v) { v->visit(this); }
 #ifdef IN_GCC
-    void toObjFile();                       // compile to .obj file
     unsigned baseVtblOffset(BaseClass *bc);
     void toDt(dt_t **pdt);
 #endif
@@ -347,9 +345,6 @@ public:
 
     InterfaceDeclaration *isInterfaceDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
-#ifdef IN_GCC
-    void toObjFile();                       // compile to .obj file
-#endif
 };
 
 #endif /* DMD_AGGREGATE_H */

--- a/gcc/d/dfrontend/attrib.h
+++ b/gcc/d/dfrontend/attrib.h
@@ -56,9 +56,6 @@ public:
     AttribDeclaration *isAttribDeclaration() { return this; }
 
     void accept(Visitor *v) { v->visit(this); }
-#ifdef IN_GCC
-    void toObjFile();                       // compile to .obj file
-#endif
 };
 
 class StorageClassDeclaration : public AttribDeclaration
@@ -175,9 +172,6 @@ public:
     void semantic(Scope *sc);
     const char *kind() const;
     void accept(Visitor *v) { v->visit(this); }
-#ifdef IN_GCC
-    void toObjFile();                       // compile to .obj file
-#endif
 };
 
 class ConditionalDeclaration : public AttribDeclaration

--- a/gcc/d/dfrontend/declaration.h
+++ b/gcc/d/dfrontend/declaration.h
@@ -293,9 +293,6 @@ public:
     // Eliminate need for dynamic_cast
     VarDeclaration *isVarDeclaration() { return (VarDeclaration *)this; }
     void accept(Visitor *v) { v->visit(this); }
-#ifdef IN_GCC
-    void toObjFile();                       // compile to .obj file
-#endif
 };
 
 /**************************************************************/
@@ -327,9 +324,6 @@ public:
 
     TypeInfoDeclaration *isTypeInfoDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
-#ifdef IN_GCC
-    void toObjFile();                       // compile to .obj file
-#endif
 };
 
 class TypeInfoStructDeclaration : public TypeInfoDeclaration
@@ -677,9 +671,6 @@ public:
 
     virtual FuncDeclaration *toAliasFunc() { return this; }
     void accept(Visitor *v) { v->visit(this); }
-#ifdef IN_GCC
-    void toObjFile();                       // compile to .obj file
-#endif
 };
 
 FuncDeclaration *resolveFuncCall(Loc loc, Scope *sc, Dsymbol *s,

--- a/gcc/d/dfrontend/dsymbol.h
+++ b/gcc/d/dfrontend/dsymbol.h
@@ -287,9 +287,6 @@ public:
     virtual AnonDeclaration *isAnonDeclaration() { return NULL; }
     virtual OverloadSet *isOverloadSet() { return NULL; }
     virtual void accept(Visitor *v) { v->visit(this); }
-#ifdef IN_GCC
-    virtual void toObjFile();                   // compile to .obj file
-#endif
 };
 
 // Dsymbol that generates a scope

--- a/gcc/d/dfrontend/enum.h
+++ b/gcc/d/dfrontend/enum.h
@@ -68,9 +68,6 @@ public:
 
     Symbol *sinit;
     void accept(Visitor *v) { v->visit(this); }
-#ifdef IN_GCC
-    void toObjFile();                       // compile to .obj file
-#endif
 };
 
 

--- a/gcc/d/dfrontend/nspace.h
+++ b/gcc/d/dfrontend/nspace.h
@@ -34,9 +34,6 @@ class Nspace : public ScopeDsymbol
     const char *kind();
     Nspace *isNspace() { return this; }
     void accept(Visitor *v) { v->visit(this); }
-#ifdef IN_GCC
-    void toObjFile();
-#endif
 };
 
 #endif /* DMD_NSPACE_H */

--- a/gcc/d/dfrontend/staticassert.h
+++ b/gcc/d/dfrontend/staticassert.h
@@ -35,9 +35,6 @@ public:
     bool oneMember(Dsymbol **ps, Identifier *ident);
     const char *kind();
     void accept(Visitor *v) { v->visit(this); }
-#ifdef IN_GCC
-    void toObjFile();
-#endif
 };
 
 #endif

--- a/gcc/d/dfrontend/template.h
+++ b/gcc/d/dfrontend/template.h
@@ -362,9 +362,6 @@ public:
 
     TemplateInstance *isTemplateInstance() { return this; }
     void accept(Visitor *v) { v->visit(this); }
-#ifdef IN_GCC
-    void toObjFile();                       // compile to .obj file
-#endif
 };
 
 class TemplateMixin : public TemplateInstance
@@ -388,9 +385,6 @@ public:
 
     TemplateMixin *isTemplateMixin() { return this; }
     void accept(Visitor *v) { v->visit(this); }
-#ifdef IN_GCC
-    void toObjFile();                       // compile to .obj file
-#endif
 };
 
 Expression *isExpression(RootObject *o);

--- a/gcc/d/expr.cc
+++ b/gcc/d/expr.cc
@@ -1898,7 +1898,7 @@ public:
   {
     // Compile the declaration.
     push_stmt_list();
-    e->declaration->toObjFile();
+    build_decl_tree (e->declaration);
     tree result = pop_stmt_list();
 
     // Construction of an array for typesafe-variadic function arguments
@@ -1972,7 +1972,7 @@ public:
     if (cfun != NULL)
       cfun->language->deferred_fns.safe_push(e->fd);
     else
-      e->fd->toObjFile();
+      build_decl_tree (e->fd);
 
     // If nested, this will be a trampoline...
     if (e->fd->isNested())
@@ -2058,7 +2058,7 @@ public:
 	if (cfun != NULL)
 	  cfun->language->deferred_fns.safe_push(fld);
 	else
-	  fld->toObjFile();
+	  build_decl_tree (fld);
       }
 
     if (this->constp_)

--- a/gcc/d/toir.cc
+++ b/gcc/d/toir.cc
@@ -1042,7 +1042,7 @@ public:
 	Dsymbol *dsym = (*s->imports)[i];
 
 	if (dsym != NULL)
-	  dsym->toObjFile();
+	  build_decl_tree (dsym);
       }
   }
 };

--- a/gcc/d/typeinfo.cc
+++ b/gcc/d/typeinfo.cc
@@ -689,22 +689,22 @@ public:
 	gcc_assert (tinst->minst || sd->requestTypeInfo);
 
 	if (sd->xeq && sd->xeq != StructDeclaration::xerreq)
-	  sd->xeq->toObjFile ();
+	  build_decl_tree (sd->xeq);
 
 	if (sd->xcmp && sd->xcmp != StructDeclaration::xerrcmp)
-	  sd->xcmp->toObjFile ();
+	  build_decl_tree (sd->xcmp);
 
 	if (FuncDeclaration *ftostr = search_toString (sd))
-	  ftostr->toObjFile ();
+	  build_decl_tree (ftostr);
 
 	if (sd->xhash)
-	  sd->xhash->toObjFile ();
+	  build_decl_tree (sd->xhash);
 
 	if (sd->postblit)
-	  sd->postblit->toObjFile ();
+	  build_decl_tree (sd->postblit);
 
 	if (sd->dtor)
-	  sd->dtor->toObjFile ();
+	  build_decl_tree (sd->dtor);
       }
 
     /* Name of the struct declaration.  */
@@ -973,7 +973,7 @@ genTypeInfo (Type *type, Scope *sc)
 	      m->members->push (t->vtinfo);
 	    }
 	  else
-	    t->vtinfo->toObjFile ();
+	    build_decl_tree (t->vtinfo);
 	}
     }
   /* Types aren't merged, but we can share the vtinfo's.  */


### PR DESCRIPTION
For now, just a straight-forward conversion, there's room for common-izing things, such as `TemplateMixin`/`Nspace` into a `ScopeDsymbol` visitor, and making static functions private to the interface.