### PR TITLE
Move Module::genobjfile to DeclVisitor

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,9 @@
+2017-03-27  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-objfile.cc (DeclVisitor::visit(Module)): New function.
+	(Module::genobjfile): Remove function.
+	Updated all callers to use build_decl_tree.
+
 2017-03-26  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-objfile.cc (base_vtable_offset): New function.

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -3,6 +3,9 @@
 	* d-objfile.cc (DeclVisitor::visit(Module)): New function.
 	(Module::genobjfile): Remove function.
 	Updated all callers to use build_decl_tree.
+	(layout_moduleinfo): New function.
+	(Module::genmoduleinfo): Remove function.
+	Update all callers to use layout_moduleinfo.
 
 2017-03-26  Iain Buclaw  <ibuclaw@gdcproject.org>
 

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -1357,9 +1357,9 @@ d_parse_file()
       if (!flag_syntax_only)
 	{
 	  if ((entrypoint != NULL) && (m == rootmodule))
-	    entrypoint->genobjfile(false);
+	    build_decl_tree (entrypoint);
 
-	  m->genobjfile(false);
+	  build_decl_tree (m);
 	}
     }
 

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -432,6 +432,7 @@ extern void d_keep (tree);
 /* In d-objfile.cc.  */
 extern void build_decl_tree (Dsymbol *);
 extern unsigned base_vtable_offset (ClassDeclaration *, BaseClass *);
+extern void layout_moduleinfo (Module *);
 
 /* In imports.cc.  */
 extern tree build_import_decl (Dsymbol *);

--- a/gcc/d/dfrontend/module.h
+++ b/gcc/d/dfrontend/module.h
@@ -173,7 +173,6 @@ public:
     Module *isModule() { return this; }
     void accept(Visitor *v) { v->visit(this); }
 #ifdef IN_GCC
-    void genobjfile(bool multiobj);
     void genmoduleinfo();
 #endif
 };

--- a/gcc/d/dfrontend/module.h
+++ b/gcc/d/dfrontend/module.h
@@ -172,9 +172,6 @@ public:
 
     Module *isModule() { return this; }
     void accept(Visitor *v) { v->visit(this); }
-#ifdef IN_GCC
-    void genmoduleinfo();
-#endif
 };
 
 


### PR DESCRIPTION
~Nothing here yet, just using CI to see if `Module` could be found anywhere in the AST trees.~

Looks like it's never hit - according to testsuite at least - so going to use it for `genobjfile`.

~Will probably safeguard such a visit function with `isRoot` and checking `semanticRun` anyway.~

Using a mixture of checking `semanticRun` and asserting that `current_module_decl` is null to ensure that only one module is compiled at a time, or send alarm bells otherwise.