### PR TITLE
Remove non-virtual toDt methods from frontend.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,14 @@
+2017-03-29  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-decls.cc (aggregate_initializer): Renamed to
+	aggregate_initializer_decl.  Updated all callers.
+	(enum_initializer): Renamed to enum_initializer_decl.
+	Updated all callers.
+	(layout_class_initializer): New function.
+	(layout_struct_initializer): New function.
+	* d-todt.cc (ClassDeclaration::toDt): Remove function.
+	(StructDeclaration::toDt): Remove function.
+
 2017-03-27  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-objfile.cc (DeclVisitor::visit(Module)): New function.

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -335,8 +335,8 @@ public:
     genTypeInfo (d->type, NULL);
 
     /* Generate static initialiser.  */
-    d->sinit = aggregate_initializer (d);
-    d->toDt (&DECL_LANG_INITIAL (d->sinit));
+    d->sinit = aggregate_initializer_decl (d);
+    DECL_INITIAL (d->sinit) = layout_struct_initializer (d);
 
     d_finish_symbol (d->sinit);
 
@@ -382,10 +382,10 @@ public:
     /* Generate C symbols.  */
     d->csym = get_classinfo_decl (d);
     d->vtblsym = get_vtable_decl (d);
-    d->sinit = aggregate_initializer (d);
+    d->sinit = aggregate_initializer_decl (d);
 
     /* Generate static initialiser.  */
-    d->toDt (&DECL_LANG_INITIAL (d->sinit));
+    DECL_INITIAL (d->sinit) = layout_class_initializer (d);
     d_finish_symbol (d->sinit);
 
     /* Put out the TypeInfo.  */
@@ -519,7 +519,7 @@ public:
     if (tc->sym->members && !d->type->isZeroInit ())
       {
 	/* Generate static initialiser.  */
-	d->sinit = enum_initializer (d);
+	d->sinit = enum_initializer_decl (d);
 	DECL_INITIAL (d->sinit) = build_expr (tc->sym->defaultval, true);
 	d_finish_symbol (d->sinit);
 
@@ -618,7 +618,10 @@ public:
 	else
 	  {
 	    if (d->type->ty == Tstruct)
-	      ((TypeStruct *) d->type)->sym->toDt (&DECL_LANG_INITIAL (s));
+	      {
+		StructDeclaration *sd = ((TypeStruct *) d->type)->sym;
+		DECL_INITIAL (s) = layout_struct_initializer (sd);
+	      }
 	    else
 	      {
 		Expression *e = d->type->defaultInitLiteral (d->loc);

--- a/gcc/d/d-todt.cc
+++ b/gcc/d/d-todt.cc
@@ -166,31 +166,3 @@ ExpInitializer::toDt()
   dt_cons(&dt, build_expr(exp, true));
   return dt;
 }
-
-/* ================================================================ */
-
-// Generate the data for the static initialiser.
-
-void
-ClassDeclaration::toDt(dt_t **pdt)
-{
-  NewExp *ne = new NewExp(this->loc, NULL, NULL, this->type, NULL);
-  ne->type = this->type;
-
-  Expression *e = ne->ctfeInterpret();
-  gcc_assert (e->op == TOKclassreference);
-
-  dt_cons(pdt, build_class_instance((ClassReferenceExp *) e));
-}
-
-void
-StructDeclaration::toDt(dt_t **pdt)
-{
-  StructLiteralExp *sle = StructLiteralExp::create (loc, this, NULL);
-
-  if (!fill(loc, sle->elements, true))
-    gcc_unreachable();
-
-  sle->type = type;
-  dt_cons(pdt, build_expr(sle, true));
-}

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -26,6 +26,7 @@ class AggregateDeclaration;
 class ClassDeclaration;
 class EnumDeclaration;
 class FuncDeclaration;
+class StructDeclaration;
 class TypeInfoDeclaration;
 class VarDeclaration;
 class Expression;
@@ -409,8 +410,10 @@ extern tree get_classinfo_decl (ClassDeclaration *);
 extern tree get_vtable_decl (ClassDeclaration *);
 extern tree get_cpp_typeinfo_decl (ClassDeclaration *);
 extern tree build_new_class_expr (ClassReferenceExp *expr);
-extern tree aggregate_initializer (AggregateDeclaration *);
-extern tree enum_initializer (EnumDeclaration *);
+extern tree aggregate_initializer_decl (AggregateDeclaration *);
+extern tree layout_struct_initializer (StructDeclaration *);
+extern tree layout_class_initializer (ClassDeclaration *);
+extern tree enum_initializer_decl (EnumDeclaration *);
 
 /* In d-expr.cc.  */
 extern tree build_expr (Expression *, bool = false);

--- a/gcc/d/dfrontend/aggregate.h
+++ b/gcc/d/dfrontend/aggregate.h
@@ -35,9 +35,6 @@ class DeleteDeclaration;
 class InterfaceDeclaration;
 class TypeInfoClassDeclaration;
 class VarDeclaration;
-#ifdef IN_GCC
-typedef union tree_node dt_t;
-#endif
 
 enum Sizeok
 {
@@ -204,9 +201,6 @@ public:
 
     StructDeclaration *isStructDeclaration() { return this; }
     void accept(Visitor *v) { v->visit(this); }
-#ifdef IN_GCC
-    void toDt(dt_t **pdt);
-#endif
 };
 
 class UnionDeclaration : public StructDeclaration
@@ -323,9 +317,6 @@ public:
 
     ClassDeclaration *isClassDeclaration() { return (ClassDeclaration *)this; }
     void accept(Visitor *v) { v->visit(this); }
-#ifdef IN_GCC
-    void toDt(dt_t **pdt);
-#endif
 };
 
 class InterfaceDeclaration : public ClassDeclaration

--- a/gcc/d/expr.cc
+++ b/gcc/d/expr.cc
@@ -2076,12 +2076,12 @@ public:
 	    else
 	      {
 		var->inuse++;
-		init = var->_init->toDt();
+		init = dtvector_to_tree (var->_init->toDt());
 		var->inuse--;
 	      }
 	  }
 	else if (sd && sd->dsym)
-	  sd->dsym->toDt(&init);
+	  init = layout_struct_initializer (sd->dsym);
 	else
 	  e->error("non-constant expression %s", e->toChars());
 
@@ -2133,7 +2133,7 @@ public:
 	    tree stack_var = build_local_temp(rec_type);
 	    expand_decl(stack_var);
 	    new_call = build_address(stack_var);
-	    setup_exp = modify_expr(stack_var, aggregate_initializer (cd));
+	    setup_exp = modify_expr(stack_var, aggregate_initializer_decl (cd));
 	  }
 	else if (e->allocator)
 	  {
@@ -2141,7 +2141,7 @@ public:
 	    new_call = d_save_expr(new_call);
 	    // copy memory...
 	    setup_exp = modify_expr(indirect_ref(rec_type, new_call),
-				    aggregate_initializer (cd));
+				    aggregate_initializer_decl (cd));
 	  }
 	else
 	  {
@@ -2645,7 +2645,7 @@ public:
     // processing has complete.  Build the static initialiser now.
     if (e->useStaticInit && !this->constp_)
       {
-	this->result_ = aggregate_initializer (e->sd);
+	this->result_ = aggregate_initializer_decl (e->sd);
 	return;
       }
 

--- a/gcc/d/typeinfo.cc
+++ b/gcc/d/typeinfo.cc
@@ -317,7 +317,7 @@ public:
       {
 	tree type = build_ctype (Type::tvoid->arrayOf ());
 	tree length = size_int (ed->type->size ());
-	tree ptr = build_address (enum_initializer (ed));
+	tree ptr = build_address (enum_initializer_decl (ed));
 	this->set_field ("m_init", d_array_value (type, length, ptr));
       }
   }
@@ -493,7 +493,7 @@ public:
 	/* Default initialiser for class.  */
 	tree value = d_array_value (build_ctype (Type::tint8->arrayOf ()),
 				    size_int (cd->structsize),
-				    build_address (aggregate_initializer (cd)));
+				    build_address (aggregate_initializer_decl (cd)));
 	this->set_field ("m_init", value);
 
 	/* Name of the class declaration.  */
@@ -714,7 +714,7 @@ public:
     tree type = build_ctype (Type::tvoid->arrayOf ());
     tree length = size_int (sd->structsize);
     tree ptr = (sd->zeroInit) ? null_pointer_node :
-      build_address (aggregate_initializer (sd));
+      build_address (aggregate_initializer_decl (sd));
     this->set_field ("m_init", d_array_value (type, length, ptr));
 
     /* hash_t function (in void*) xtoHash;  */


### PR DESCRIPTION
Trivial, now just to deal with the virtual `Initializer::toDt` methods, and laying out the variadic ModuleInfo symbol.