### PR TITLE
Use push/pop function context for storing cfun state.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,16 @@
 2017-04-07  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-objfile.cc (DeclVisitor::visit(FuncDeclaration)): Use
+	push_function_decl for storing current state when switching to nested
+	functions.  Remove handling of deferred functions.
+	* d-tree.h (language_function): Remove deferred_fns.
+	* expr.cc (ExprVisitor::visit(DelegateExp)): Don't defer compiling
+	the delegate lambda.
+	(ExprVisitor::visit(FuncExp)): Likewise for function literals.
+	(ExprVisitor::visit(VarExp)): Likewise.
+
+2017-04-07  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* d-codegen.cc (start_function): Move to d-objfile.cc, make it static.
 	(end_function): Likewise.  Renamed to finish_function.
 

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -206,9 +206,6 @@ struct GTY(()) language_function
      compiling the function.  */
   vec<tree, va_gc> *stmt_list;
 
-  /* Any nested functions that were deferred during codegen.  */
-  vec<FuncDeclaration *> GTY((skip)) deferred_fns;
-
   /* Variables that are in scope that will need destruction later.  */
   vec<VarDeclaration *> GTY((skip)) vars_in_scope;
 

--- a/gcc/d/expr.cc
+++ b/gcc/d/expr.cc
@@ -1730,7 +1730,7 @@ public:
 	while (!owner->isTemplateInstance() && owner->toParent())
 	  owner = owner->toParent();
 	if (owner->isTemplateInstance() || owner == cfun->language->module)
-	  cfun->language->deferred_fns.safe_push(e->func);
+	  build_decl_tree (e->func);
       }
 
     tree fndecl;
@@ -1968,13 +1968,10 @@ public:
 	e->fd->vthis = NULL;
       }
 
-    // Emit after current function body has finished.
-    if (cfun != NULL)
-      cfun->language->deferred_fns.safe_push(e->fd);
-    else
-      build_decl_tree (e->fd);
+    // Compile the function literal body.
+    build_decl_tree (e->fd);
 
-    // If nested, this will be a trampoline...
+    // If nested, this will be a trampoline.
     if (e->fd->isNested())
       {
 	if (this->constp_)
@@ -2054,11 +2051,8 @@ public:
 	    fld->vthis = NULL;
 	  }
 
-	// Emit after current function body has finished.
-	if (cfun != NULL)
-	  cfun->language->deferred_fns.safe_push(fld);
-	else
-	  build_decl_tree (fld);
+	// Compiler the function literal body.
+	build_decl_tree (fld);
       }
 
     if (this->constp_)


### PR DESCRIPTION
Remove logic for "deferring" function compilation.  GCC prefers that nested are compiled before outer anyway (inverse to DMD's preference).