### PR TITLE
Make current_module_info/decl private to d-objfile.cc

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -14,6 +14,17 @@
 
 2017-04-07  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-codgen.h (current_module_decl): Moved to d-objfile.cc.
+	* d-objfile.h (current_module_info): Likewise.
+	(ModuleInfoFlags): Likewise.
+	(ModuleInfo): Likewise.
+	* d-objfile.cc (start_function): Move updating ModuleInfo structure to
+	...
+	(DeclVisitor::visit(FuncDeclaration)): ... here.  Set it after
+	finishing off the function.
+
+2017-04-07  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* d-objfile.cc (DeclVisitor::visit(FuncDeclaration)): Use
 	push_function_decl for storing current state when switching to nested
 	functions.  Remove handling of deferred functions.

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -48,9 +48,6 @@
 #include "id.h"
 
 
-Module *current_module_decl;
-
-
 // Update data for defined and undefined labels when leaving a scope.
 
 bool

--- a/gcc/d/d-codegen.h
+++ b/gcc/d/d-codegen.h
@@ -224,7 +224,6 @@ extern bool call_by_alias_p (FuncDeclaration *caller, FuncDeclaration *callee);
 
 // Globals.
 extern Modules builtin_modules;
-extern Module *current_module_decl;
 
 #endif
 

--- a/gcc/d/d-objfile.h
+++ b/gcc/d/d-objfile.h
@@ -18,39 +18,6 @@
 #ifndef GCC_DCMPLR_OBFILE_H
 #define GCC_DCMPLR_OBFILE_H
 
-// These must match the values in object_.d
-enum ModuleInfoFlags
-{
-  MIstandalone	    = 0x4,
-  MItlsctor	    = 0x8,
-  MItlsdtor	    = 0x10,
-  MIctor	    = 0x20,
-  MIdtor	    = 0x40,
-  MIxgetMembers	    = 0x80,
-  MIictor	    = 0x100,
-  MIunitTest	    = 0x200,
-  MIimportedModules = 0x400,
-  MIlocalClasses    = 0x800,
-  MIname	    = 0x1000,
-};
-
-struct ModuleInfo
-{
-  auto_vec<ClassDeclaration *> classes;
-  auto_vec<FuncDeclaration *> ctors;
-  auto_vec<FuncDeclaration *> dtors;
-  auto_vec<VarDeclaration *> ctorgates;
-
-  auto_vec<FuncDeclaration *> sharedctors;
-  auto_vec<FuncDeclaration *> shareddtors;
-  auto_vec<VarDeclaration *> sharedctorgates;
-
-  auto_vec<FuncDeclaration *> unitTests;
-  auto_vec<VarDeclaration *> tlsVars;
-};
-
-extern ModuleInfo *current_module_info;
-
 extern location_t get_linemap (const Loc& loc);
 extern void set_input_location (const Loc& loc);
 extern void set_input_location (Dsymbol *decl);


### PR DESCRIPTION
It's not used anywhere else.

Also moved updating ModuleInfo out of `start_function`, making it the last thing we update in `DeclVisitor::visit(FuncDeclaration)`.  It's not needed there, and more reshuffling of the `FuncDeclaration` visitor will come to put only the essentials inside `start_function`/`finish_function`, with the intent in mind to remove `WrappedExp` and related code.