### PR TITLE
global.stdmsg should be stderr to not conflict with -pipe

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,7 @@
+2017-04-08  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-glue.cc (Global::_init): Set global.stdmsg to stderr.
+
 2017-04-07  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-objfile.cc (DeclVisitor::visit(FuncDeclaration)): Use

--- a/gcc/d/d-glue.cc
+++ b/gcc/d/d-glue.cc
@@ -58,7 +58,7 @@ Global::_init()
     ;
 
   this->compiler.vendor = "GNU D";
-  this->stdmsg = stdout;
+  this->stdmsg = stderr;
   this->main_d = "__main.d";
 
   this->errorLimit = flag_max_errors;


### PR DESCRIPTION
I seem to have regressed with this on 11b8084, where verbatim messages used to be sent to `stderr`.

This allows `-pipe -v` to work nicely together again.