### PR TITLE
Implement support for reading from stdin.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,11 @@
 2017-04-08  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-lang.cc (d_post_options): Don't overwrite in_fnames.
+	(d_parse_file): Don't error about not being able to use stdin.
+	Implement support for reading source code from stdin.
+
+2017-04-08  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* d-lang.cc (d_parse_file): Remove invalid file name checks.
 
 2017-04-08  Iain Buclaw  <ibuclaw@gdcproject.org>


### PR DESCRIPTION
A fun exercise that follows on from #439.

Tested with the following sources.
```
$ file hello*
hello.d:        C source, ASCII text
helloUTF16BE.d: C source, Big-endian UTF-16 Unicode text, with CRLF line terminators
helloUTF16.d:   C source, Little-endian UTF-16 Unicode text, with CRLF, CR line terminators
helloUTF32.d:   Unicode text, UTF-32, little-endian
helloUTF8.d:    C source, UTF-8 Unicode (with BOM) text

$ gdc -x d - < hello.d; ./a.out 
hello world
$ gdc -x d - < helloUTF8.d; ./a.out 
hello world
$ gdc -x d - < helloUTF16.d; ./a.out 
hello world
$ gdc -x d - < helloUTF16BE.d; ./a.out 
hello world
$ gdc -x d - < helloUTF32.d; ./a.out 
hello world
```

And sanity checked a few fail tests.
```
$ gdc -x d - < fail_compilation/failattr.d 
<stdin>:16:25: error: variable __stdin1.C2901.v1 cannot be synchronized
<stdin>:17:25: error: variable __stdin1.C2901.v2 cannot be override
<stdin>:18:25: error: variable __stdin1.C2901.v3 cannot be abstract
<stdin>:19:25: error: variable __stdin1.C2901.v4 cannot be final, perhaps you meant const?
<stdin>:31:46: error: variable __stdin1.C2901.v13 cannot be final abstract synchronized override
<stdin>:33:22: error: variable __stdin1.C2901.v14 cannot be final, perhaps you meant const?

$ cat fail_compilation/failattr.d 
// REQUIRED_ARGS: -o-

/*
TEST_OUTPUT:
---
fail_compilation/failattr.d(16): Error: variable failattr.C2901.v1 cannot be synchronized
fail_compilation/failattr.d(17): Error: variable failattr.C2901.v2 cannot be override
fail_compilation/failattr.d(18): Error: variable failattr.C2901.v3 cannot be abstract
fail_compilation/failattr.d(19): Error: variable failattr.C2901.v4 cannot be final, perhaps you meant const?
fail_compilation/failattr.d(31): Error: variable failattr.C2901.v13 cannot be final abstract synchronized override
fail_compilation/failattr.d(33): Error: variable failattr.C2901.v14 cannot be final, perhaps you meant const?
---
*/
...
```

Looks like `generateId` is not so good for creating a unique identifier, but I can't imagine this being used for anything but quick experiments. ;-)