### PR TITLE
Remove logic that parent functions need a body before nested

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,10 @@
 2017-04-08  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-objfile.cc (DeclVisitor::visit(FuncDeclaration)): Remove logic
+	that parent needs to be compiled before nested.
+
+2017-04-08  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* d-lang.cc (d_post_options): Don't overwrite in_fnames.
 	(d_parse_file): Don't error about not being able to use stdin.
 	Implement support for reading source code from stdin.

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -796,26 +796,19 @@ public:
 	return;
       }
 
+    /* Start generating code for this function.  */
+    gcc_assert (d->semanticRun == PASSsemantic3done);
+    d->semanticRun = PASSobj;
+
+    if (global.params.verbose)
+      fprintf (global.stdmsg, "function  %s\n", d->toPrettyChars ());
+
     /* This function exists in static storage.
        (This does not mean `static' in the C sense!)  */
     TREE_STATIC (fndecl) = 1;
 
     /* Add this decl to the current binding level.  */
     d_pushdecl (fndecl);
-
-    /* Start generating code for this function.  */
-    gcc_assert (d->semanticRun == PASSsemantic3done);
-    d->semanticRun = PASSobj;
-
-    /* Nested functions may not have its body compiled before the outer
-       function is finished.  GCC requires that nested functions be finished
-       first so we need to arrange for build_decl_tree to be called earlier.  */
-    FuncDeclaration *fdp = d->toParent2 ()->isFuncDeclaration ();
-    if (fdp && fdp->semanticRun < PASSobj)
-      fdp->accept (this);
-
-    if (global.params.verbose)
-      fprintf (global.stdmsg, "function  %s\n", d->toPrettyChars ());
 
     bool nested = current_function_decl != NULL_TREE;
     if (nested)


### PR DESCRIPTION
This is a fix-up to #436.  We don't rely that functions are compiled in any particular order.