### PR TITLE
Refactor and reformat d-incpath.cc

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,12 @@
 2017-04-17  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-incpath.cc (add_env_var_paths): Rename to add_environment_paths.
+	(make_absolute): Remove function.
+	(add_import_path): Rename to add_globalpaths.
+	(add_fileimp_path): Rename to add_filepaths.
+
+2017-04-17  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* d-codegen.h (d_types_same): Renamed to same_type_p.
 	Moved to types.cc.
 	(build_object_type): Renamed to get_object_type.  Moved to types.cc.

--- a/gcc/d/d-incpath.cc
+++ b/gcc/d/d-incpath.cc
@@ -1,19 +1,19 @@
-// d-incpath.cc -- D frontend for GCC.
-// Copyright (C) 2011-2015 Free Software Foundation, Inc.
+/* d-incpath.cc -- Set up combined import paths for the D frontend.
+   Copyright (C) 2011-2017 Free Software Foundation, Inc.
 
-// GCC is free software; you can redistribute it and/or modify it under
-// the terms of the GNU General Public License as published by the Free
-// Software Foundation; either version 3, or (at your option) any later
-// version.
+GCC is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3, or (at your option)
+any later version.
 
-// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or
-// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
-// for more details.
+GCC is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
-// You should have received a copy of the GNU General Public License
-// along with GCC; see the file COPYING3.  If not see
-// <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU General Public License
+along with GCC; see the file COPYING3.  If not see
+<http://www.gnu.org/licenses/>.  */
 
 #include "config.h"
 #include "system.h"
@@ -28,131 +28,101 @@
 
 #include "d-tree.h"
 
-// Read ENV_VAR for a PATH_SEPARATOR-separated list of file names; and
-// append all the names to the import search path.
+/* Read ENV_VAR for a PATH_SEPARATOR-separated list of file names; and
+   append all the names to the import search path.  */
 
 static void
-add_env_var_paths(const char *env_var)
+add_environment_paths (const char *env_var)
 {
-  char *p, *q, *path;
-
-  q = getenv(env_var);
+  char *q = getenv (env_var);
+  char *path;
 
   if (!q)
     return;
 
-  for (p = q; *q; p = q + 1)
+  for (char *p = q; *q; p = q + 1)
     {
       q = p;
       while (*q != 0 && *q != PATH_SEPARATOR)
 	q++;
 
       if (p == q)
-	path = xstrdup(".");
+	path = xstrdup (".");
       else
 	{
-	  path = XNEWVEC(char, q - p + 1);
-	  memcpy(path, p, q - p);
+	  path = XNEWVEC (char, q - p + 1);
+	  memcpy (path, p, q - p);
 	  path[q - p] = '\0';
 	}
 
-      global.params.imppath->push(path);
+      global.params.imppath->push (path);
     }
 }
 
-
-// Look for directories that start with the standard prefix.
-// "Translate" them, i.e. replace /usr/local/lib/gcc... with
-// IPREFIX and search them first.
+/* Look for directories that start with the standard prefix.
+   "Translate" them, i.e. replace /usr/local/lib/gcc with
+   IPREFIX and search them first.  Based on incpath.c.  */
 
 static char *
-prefixed_path(const char *path, const char *iprefix)
+prefixed_path (const char *path, const char *iprefix)
 {
-  // based on incpath.c
   size_t len;
 
-  if (cpp_relocated() && (len = cpp_PREFIX_len) != 0)
+  if (cpp_relocated () && (len = cpp_PREFIX_len) != 0)
   {
-    if (!strncmp(path, cpp_PREFIX, len))
+    if (!strncmp (path, cpp_PREFIX, len))
       {
 	static const char *relocated_prefix;
 	/* If this path starts with the configure-time prefix,
 	   but the compiler has been relocated, replace it
-	   with the run-time prefix.  The run-time exec prefix
-	   is GCC_EXEC_PREFIX.  Compute the path from there back
-	   to the toplevel prefix.  */
+	   with the run-time prefix.  */
 	if (!relocated_prefix)
 	  {
-	    char *dummy;
 	    /* Make relative prefix expects the first argument
 	       to be a program, not a directory.  */
-	    dummy = concat(gcc_exec_prefix, "dummy", NULL);
+	    char *dummy = concat (gcc_exec_prefix, "dummy", NULL);
 	    relocated_prefix
-	      = make_relative_prefix(dummy,
-				     cpp_EXEC_PREFIX,
-				     cpp_PREFIX);
-	    free(dummy);
+	      = make_relative_prefix (dummy,
+				      cpp_EXEC_PREFIX,
+				      cpp_PREFIX);
+	    free (dummy);
 	  }
-	return concat(relocated_prefix, path + len, NULL);
+
+	return concat (relocated_prefix, path + len, NULL);
       }
   }
 
   if (iprefix && (len = cpp_GCC_INCLUDE_DIR_len) != 0)
     {
-      if (!strncmp(path, cpp_GCC_INCLUDE_DIR, len))
-	return concat(iprefix, path + len, NULL);
+      if (!strncmp (path, cpp_GCC_INCLUDE_DIR, len))
+	return concat (iprefix, path + len, NULL);
     }
 
-  return xstrdup(path);
-}
-
-
-// Given a pointer to a string containing a pathname, returns a
-// canonical version of the filename.
-
-static char *
-make_absolute(char *path)
-{
-#if defined (HAVE_DOS_BASED_FILE_SYSTEM)
-  /* Remove unnecessary trailing slashes.  On some versions of MS
-     Windows, trailing  _forward_ slashes cause no problems for stat().
-     On newer versions, stat() does not recognize a directory that ends
-     in a '\\' or '/', unless it is a drive root dir, such as "c:/",
-     where it is obligatory.  */
-  int pathlen = strlen(path);
-  char *end = path + pathlen - 1;
-  /* Preserve the lead '/' or lead "c:/".  */
-  char *start = path + (pathlen > 2 && path[1] == ':' ? 3 : 1);
-
-  for (; end > start && IS_DIR_SEPARATOR(*end); end--)
-    *end = 0;
-#endif
-
-  return lrealpath(path);
+  return xstrdup (path);
 }
 
 /* Add PATHS to the global import lookup path.  */
 
 static void
-add_import_path(Strings *paths)
+add_globalpaths (Strings *paths)
 {
   if (paths)
     {
       if (!global.path)
-	global.path = new Strings();
+	global.path = new Strings ();
 
       for (size_t i = 0; i < paths->dim; i++)
 	{
 	  const char *path = (*paths)[i];
-	  char *target_dir = make_absolute(CONST_CAST(char *, path));
+	  const char *target = FileName::canonicalName (path);
 
-	  if (!FileName::exists(target_dir))
+	  if (!FileName::exists (target))
 	    {
-	      free(target_dir);
+	      free (CONST_CAST (char *, target));
 	      continue;
 	    }
 
-	  global.path->push(target_dir);
+	  global.path->push (target);
 	}
     }
 }
@@ -160,59 +130,58 @@ add_import_path(Strings *paths)
 /* Add PATHS to the global file import lookup path.  */
 
 static void
-add_fileimp_path(Strings *paths)
+add_filepaths (Strings *paths)
 {
   if (paths)
     {
       if (!global.filePath)
-	global.filePath = new Strings();
+	global.filePath = new Strings ();
 
       for (size_t i = 0; i < paths->dim; i++)
 	{
 	  const char *path = (*paths)[i];
-	  char *target_dir = make_absolute(CONST_CAST(char *, path));
+	  const char *target = FileName::canonicalName (path);
 
-	  if (!FileName::exists(target_dir))
+	  if (!FileName::exists (target))
 	    {
-	      free(target_dir);
+	      free (CONST_CAST (char *, target));
 	      continue;
 	    }
 
-	  global.filePath->push(target_dir);
+	  global.filePath->push (target);
 	}
     }
 }
 
-
-// Add all search directories to compiler runtime.
-// if STDINC, also include standard library paths.
+/* Add all search directories to compiler runtime.
+   if STDINC, also include standard library paths.  */
 
 void
-add_import_paths(const char *iprefix, const char *imultilib, bool stdinc)
+add_import_paths (const char *iprefix, const char *imultilib, bool stdinc)
 {
   if (stdinc)
     {
       for (const default_include *p = cpp_include_defaults; p->fname; p++)
 	{
-	  char *import_path;
+	  char *path;
 
-	  // Ignore C++
+	  /* Ignore C++ paths.  */
 	  if (p->cplusplus)
 	    continue;
 
 	  if (!p->add_sysroot)
-	    import_path = prefixed_path(p->fname, iprefix);
+	    path = prefixed_path (p->fname, iprefix);
 	  else
-	    import_path = xstrdup(p->fname);
+	    path = xstrdup (p->fname);
 
-	  // Add D-specific suffix.
-	  import_path = concat(import_path, "/d", NULL);
+	  /* Add D-specific suffix.  */
+	  path = concat (path, "/d", NULL);
 
-	  // Ignore duplicate entries.
+	  /* Ignore duplicate entries.  */
 	  bool found = false;
 	  for (size_t i = 0; i < global.params.imppath->dim; i++)
 	    {
-	      if (strcmp(import_path, (*global.params.imppath)[i]) == 0)
+	      if (strcmp (path, (*global.params.imppath)[i]) == 0)
 		{
 		  found = true;
 		  break;
@@ -221,43 +190,43 @@ add_import_paths(const char *iprefix, const char *imultilib, bool stdinc)
 
 	  if (found)
 	    {
-	      free(import_path);
+	      free (path);
 	      continue;
 	    }
 
-	  // Multilib support.
+	  /* Multilib support.  */
 	  if (imultilib)
 	    {
-	      char *target_path = concat(import_path, "/", imultilib, NULL);
-	      global.params.imppath->shift(target_path);
+	      char *target_path = concat (path, "/", imultilib, NULL);
+	      global.params.imppath->shift (target_path);
 	    }
 
-	  global.params.imppath->shift(import_path);
+	  global.params.imppath->shift (path);
 	}
     }
 
-  // Language-dependent environment variables may add to the include chain.
-  add_env_var_paths("D_IMPORT_PATH");
+  /* Language-dependent environment variables may add to the include chain.  */
+  add_environment_paths ("D_IMPORT_PATH");
 
-  // Add import search paths
+  /* Add import search paths  */
   if (global.params.imppath)
     {
       for (size_t i = 0; i < global.params.imppath->dim; i++)
 	{
 	  const char *path = (*global.params.imppath)[i];
 	  if (path)
-	    add_import_path(FileName::splitPath(path));
+	    add_globalpaths (FileName::splitPath (path));
 	}
     }
 
-  // Add string import search paths
+  /* Add string import search paths.  */
   if (global.params.fileImppath)
     {
       for (size_t i = 0; i < global.params.fileImppath->dim; i++)
 	{
 	  const char *path = (*global.params.fileImppath)[i];
 	  if (path)
-	    add_fileimp_path(FileName::splitPath(path));
+	    add_filepaths (FileName::splitPath (path));
 	}
     }
 }


### PR DESCRIPTION
Removes `make_absolute`, the frontend has `FileName::canonicalName` instead.