### PR TITLE
Small cleanups of language spec handlers

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,10 @@
 2017-04-19  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* lang-specs.h: Add rule for forwarding -iprefix and -imultilib to the
+	compiler proper.
+
+2017-04-19  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* lang-specs.h: Remove cc1d spec.
 
 2017-04-19  Iain Buclaw  <ibuclaw@gdcproject.org>

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,7 @@
+2017-04-19  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* lang-specs.h: Remove +e handling.
+
 2017-04-18  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-diagnostic.cc: New file.

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,9 @@
 2017-04-19  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* lang-specs.h: Remove capitalized D source suffixes.
+
+2017-04-19  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* lang-specs.h: Add rule for forwarding -iprefix and -imultilib to the
 	compiler proper.
 

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,9 @@
 2017-04-19  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* lang-specs.h: Remove cc1d spec.
+
+2017-04-19  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* lang-specs.h: Remove +e handling.
 
 2017-04-18  Iain Buclaw  <ibuclaw@gdcproject.org>

--- a/gcc/d/lang-specs.h
+++ b/gcc/d/lang-specs.h
@@ -25,9 +25,9 @@ along with GCC; see the file COPYING3.  If not see
 {".di", "@d", 0, 1, 0 },
 {".DI", "@d", 0, 1, 0 },
 {"@d",
-  "%{!E:cc1d %i %(cc1_options) %(cc1d) %I %{nostdinc*} %{+e*} %{I*} %{J*}\
-    %{MD:-MD %b.deps} %{MMD:-MMD %b.deps}\
-    %{M} %{MM} %{MF*} %{MG} %{MP} %{MQ*} %{MT*}\
-    %{X:-Xf %b.json} %{Xf*}\
+  "%{!E:cc1d %i %(cc1_options) %(cc1d) %I %{nostdinc*} %{I*} %{J*} \
+    %{MD:-MD %b.deps} %{MMD:-MMD %b.deps} \
+    %{M} %{MM} %{MF*} %{MG} %{MP} %{MQ*} %{MT*} \
+    %{X:-Xf %b.json} %{Xf*} \
     %{v} %{!fsyntax-only:%(invoke_as)}}", 0, 1, 0 },
 

--- a/gcc/d/lang-specs.h
+++ b/gcc/d/lang-specs.h
@@ -19,11 +19,8 @@ along with GCC; see the file COPYING3.  If not see
    for the D language.  */
 
 {".d", "@d", 0, 1, 0 },
-{".D", "@d", 0, 1, 0 },
 {".dd", "@d", 0, 1, 0 },
-{".DD", "@d", 0, 1, 0 },
 {".di", "@d", 0, 1, 0 },
-{".DI", "@d", 0, 1, 0 },
 {"@d",
   "%{!E:cc1d %i %(cc1_options) %I %{nostdinc*} %{i*} %{I*} %{J*} \
     %{MD:-MD %b.deps} %{MMD:-MMD %b.deps} \

--- a/gcc/d/lang-specs.h
+++ b/gcc/d/lang-specs.h
@@ -25,7 +25,7 @@ along with GCC; see the file COPYING3.  If not see
 {".di", "@d", 0, 1, 0 },
 {".DI", "@d", 0, 1, 0 },
 {"@d",
-  "%{!E:cc1d %i %(cc1_options) %(cc1d) %I %{nostdinc*} %{I*} %{J*} \
+  "%{!E:cc1d %i %(cc1_options) %I %{nostdinc*} %{I*} %{J*} \
     %{MD:-MD %b.deps} %{MMD:-MMD %b.deps} \
     %{M} %{MM} %{MF*} %{MG} %{MP} %{MQ*} %{MT*} \
     %{X:-Xf %b.json} %{Xf*} \

--- a/gcc/d/lang-specs.h
+++ b/gcc/d/lang-specs.h
@@ -25,7 +25,7 @@ along with GCC; see the file COPYING3.  If not see
 {".di", "@d", 0, 1, 0 },
 {".DI", "@d", 0, 1, 0 },
 {"@d",
-  "%{!E:cc1d %i %(cc1_options) %I %{nostdinc*} %{I*} %{J*} \
+  "%{!E:cc1d %i %(cc1_options) %I %{nostdinc*} %{i*} %{I*} %{J*} \
     %{MD:-MD %b.deps} %{MMD:-MMD %b.deps} \
     %{M} %{MM} %{MF*} %{MG} %{MP} %{MQ*} %{MT*} \
     %{X:-Xf %b.json} %{Xf*} \


### PR DESCRIPTION
- Remove `+e*` - this was removed over 7 years ago in gcc.  Not sure why we had it, old documentation said that it was for backwards compatibility with cfront!
- Remove `%(cc1d)` spec.  See https://issues.dlang.org/show_bug.cgi?id=2068 for context.  IMO there's a `self_spec` which handles this in a generic way.  If we really need this, would be better as patches to gcc.c, maybe add a `%3` spec format.
- Do what the documentation says in #444.
- Remove capital suffixes, what are we, from the 80s?!?