### PR TITLE
Use macro accessor to get current lang_function.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2017-04-23  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-tree.h (d_function_chain): Declare macro.  Update all uses of
+	`cfun->language' to use it.
+
 2017-04-22  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-decls.cc: Rename to decl.cc.

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -1766,7 +1766,7 @@ array_bounds_check()
 
     case BOUNDSCHECKsafeonly:
       // For D2 safe functions only
-      func = cfun->language->function;
+      func = d_function_chain->function;
       if (func && func->type->ty == Tfunction)
 	{
 	  TypeFunction *tf = (TypeFunction *) func->type;
@@ -2743,7 +2743,7 @@ build_vthis_type(tree basetype, tree type)
 tree
 get_frame_for_symbol (Dsymbol *sym)
 {
-  FuncDeclaration *func = cfun ? cfun->language->function : NULL;
+  FuncDeclaration *func = d_function_chain ? d_function_chain->function : NULL;
   FuncDeclaration *thisfd = sym->isFuncDeclaration();
   FuncDeclaration *parentfd = NULL;
 
@@ -2875,7 +2875,7 @@ d_nested_struct (StructDeclaration *sd)
 static tree
 find_this_tree(ClassDeclaration *ocd)
 {
-  FuncDeclaration *func = cfun ? cfun->language->function : NULL;
+  FuncDeclaration *func = d_function_chain ? d_function_chain->function : NULL;
 
   while (func)
     {
@@ -3105,7 +3105,7 @@ build_closure(FuncDeclaration *fd)
 
   // Set the first entry to the parent closure/frame, if any.
   tree chain_field = component_ref(decl_ref, TYPE_FIELDS(type));
-  tree chain_expr = modify_expr(chain_field, cfun->language->static_chain);
+  tree chain_expr = modify_expr(chain_field, d_function_chain->static_chain);
   add_stmt(chain_expr);
 
   // Copy parameters that are referenced nonlocally.
@@ -3126,7 +3126,7 @@ build_closure(FuncDeclaration *fd)
   if (!FRAMEINFO_IS_CLOSURE (ffi))
     decl = build_address (decl);
 
-  cfun->language->static_chain = decl;
+  d_function_chain->static_chain = decl;
 }
 
 // Return the frame of FD.  This could be a static chain or a closure
@@ -3219,7 +3219,7 @@ get_frameinfo(FuncDeclaration *fd)
 tree
 get_framedecl (FuncDeclaration *inner, FuncDeclaration *outer)
 {
-  tree result = cfun->language->static_chain;
+  tree result = d_function_chain->static_chain;
   FuncDeclaration *fd = inner;
 
   while (fd && fd != outer)

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -869,7 +869,7 @@ public:
 
 	set_decl_location (parm_decl, d->vthis);
 	param_list = chainon (param_list, parm_decl);
-	cfun->language->static_chain = parm_decl;
+	d_function_chain->static_chain = parm_decl;
       }
 
     /* _arguments parameter.  */

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -238,6 +238,10 @@ struct GTY(()) lang_decl
   tree frame_info;
 };
 
+/* The current D per-function global variables.  */
+
+#define d_function_chain (cfun ? cfun->language : NULL)
+
 /* The D frontend Declaration AST for GCC decl NODE.  */
 #define DECL_LANG_FRONTEND(NODE) \
   (DECL_LANG_SPECIFIC (NODE) \

--- a/gcc/d/expr.cc
+++ b/gcc/d/expr.cc
@@ -1760,7 +1760,7 @@ public:
 	if (fd->isNested ())
 	  {
 	    /* Maybe re-evaluate symbol storage treating 'fd' as public.  */
-	    if (call_by_alias_p (cfun->language->function, fd))
+	    if (call_by_alias_p (d_function_chain->function, fd))
 	      TREE_PUBLIC (callee) = 1;
 
 	    object = get_frame_for_symbol (fd);
@@ -1806,7 +1806,7 @@ public:
 	Dsymbol *owner = e->func->toParent ();
 	while (!owner->isTemplateInstance () && owner->toParent ())
 	  owner = owner->toParent ();
-	if (owner->isTemplateInstance () || owner == cfun->language->module)
+	if (owner->isTemplateInstance () || owner == d_function_chain->module)
 	  build_decl_tree (e->func);
       }
 
@@ -1909,7 +1909,7 @@ public:
     tree tmsg = NULL_TREE;
     LibCall libcall;
 
-    if (cfun->language->function->isUnitTestDeclaration ())
+    if (d_function_chain->function->isUnitTestDeclaration ())
       {
 	if (e->msg)
 	  {
@@ -2007,7 +2007,7 @@ public:
 	    && !(vd->storage_class & (STCextern | STCtls | STCgshared)))
 	  {
 	    if (vd->needsScopeDtor ())
-	      cfun->language->vars_in_scope.safe_push (vd);
+	      d_function_chain->vars_in_scope.safe_push (vd);
 	  }
       }
 
@@ -2201,7 +2201,7 @@ public:
 
   void visit (ThisExp *e)
   {
-    FuncDeclaration *fd = cfun ? cfun->language->function : NULL;
+    FuncDeclaration *fd = d_function_chain ? d_function_chain->function : NULL;
     tree result = NULL_TREE;
 
     if (e->var)
@@ -3036,10 +3036,10 @@ build_dtor_list (size_t starti, size_t endi)
 
   for (size_t i = starti; i != endi; ++i)
     {
-      VarDeclaration *vd = cfun->language->vars_in_scope[i];
+      VarDeclaration *vd = d_function_chain->vars_in_scope[i];
       if (vd)
 	{
-	  cfun->language->vars_in_scope[i] = NULL;
+	  d_function_chain->vars_in_scope[i] = NULL;
 	  tree t = build_expr (vd->edtor);
 	  dtors = compound_expr (t, dtors);
 	}
@@ -3055,9 +3055,9 @@ build_expr_dtor (Expression *e)
 {
   /* Codegen can be improved by determining if no exceptions can be thrown
      between the ctor and dtor, and eliminating the ctor and dtor.  */
-  size_t starti = cfun->language->vars_in_scope.length ();
+  size_t starti = d_function_chain->vars_in_scope.length ();
   tree result = build_expr (e);
-  size_t endi = cfun->language->vars_in_scope.length ();
+  size_t endi = d_function_chain->vars_in_scope.length ();
 
   tree dtors = build_dtor_list (starti, endi);
 
@@ -3115,9 +3115,9 @@ build_expr_dtor (Expression *e)
 tree
 build_return_dtor (Expression *e, Type *type, TypeFunction *tf)
 {
-  size_t starti = cfun->language->vars_in_scope.length ();
+  size_t starti = d_function_chain->vars_in_scope.length ();
   tree result = build_expr (e);
-  size_t endi = cfun->language->vars_in_scope.length ();
+  size_t endi = d_function_chain->vars_in_scope.length ();
 
   /* Convert for initialising the DECL_RESULT.  */
   result = convert_expr (result, e->type, type);


### PR DESCRIPTION
Uses of `cfun ? cfun->language->field : NULL` should really check that language is non-null too.  This puts it into a macro.