### PR TITLE
Refactor and reformat typeinfo.cc

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,40 @@
+2017-04-24  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-tree.h (d_tree_index): Add DTI_VTABLE_ENTRY_TYPE,
+	DTI_VTBL_INTERFACE_TYPE, DTI_ARRAY_TYPE, and DTI_NULL_ARRAY.
+	(vtable_entry_type): New macro.
+	(vtbl_interface_type_node): New macro.
+	(array_type_node): New macro.
+	(null_array_node): New macro.
+	* d-builtins.cc (d_build_d_type_nodes): Initialize new trees.
+	* d-codegen.cc (build_struct_literal): Allow NULL index when
+	looking for next field to initialize.
+	(copy_aggregate_type): New function.
+	* d-target.cc (Target::loadModule): Look for object module,
+	call create_tinfo_types.
+	* decl.cc (TypeInfoDeclVisitor): Move to typeinfo.cc.
+	(get_typeinfo_decl): Likewise.
+	(copy_struct): Remove function.  Updated callers to use
+	copy_aggregate_type.
+	(layout_classinfo_interfaces): Move to typeinfo.cc.
+	(get_classinfo_decl): Likewise.
+	(get_cpp_typeinfo_decl): Likewise.
+	* typeinfo.cc (tinfo_kind): New enum.
+	(tinfo_types): New static variable.
+	(get_typeinfo_kind): New function.
+	(make_internal_typeinfo): New function.
+	(make_frontend_typeinfo): New function.
+	(create_tinfo_types): New function.
+	(TypeInfoVisitor::set_field): Remove function.
+	Update all callers to use layout_field.
+	(TypeInfoVisitor::layout_vtable): Remove function.
+	Update all callers to use layout_base.
+	(TypeInfoVisitor::layout_field): New function.
+	(TypeInfoVisitor::layout_base): New function.
+	(builtin_typeinfo_p): New function.
+	(genTypeInfo): Rename to create_typeinfo.
+	(isSpeculativeType): Rename to speculative_type_p.
+
 2017-04-23  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-tree.h (d_function_chain): Declare macro.  Update all uses of

--- a/gcc/d/d-codegen.h
+++ b/gcc/d/d-codegen.h
@@ -30,6 +30,7 @@ enum LibCall
 
 // Code generation routines.
 extern tree d_decl_context (Dsymbol *dsym);
+extern tree copy_aggregate_type (tree);
 
 extern tree d_mark_addressable (tree exp);
 extern tree d_mark_used (tree exp);

--- a/gcc/d/d-dmd-gcc.h
+++ b/gcc/d/d-dmd-gcc.h
@@ -35,10 +35,6 @@ const char *cppTypeInfoMangle(Dsymbol *s);
 // Used in d-lang.cc
 void initTraitsStringTable();
 
-// Used in d-objfile.cc
-void genTypeInfo(Type *type, Scope *sc);
-bool isSpeculativeType(Type *t);
-
 #endif /* GCC_SAFE_DMD */
 
 #endif

--- a/gcc/d/d-frontend.cc
+++ b/gcc/d/d-frontend.cc
@@ -488,3 +488,13 @@ eval_builtin (Loc loc, FuncDeclaration *fd, Expressions *arguments)
 
   return e;
 }
+
+/* Build and return typeinfo type for TYPE.  */
+
+Type *
+getTypeInfoType (Type *type, Scope *sc)
+{
+  gcc_assert (type->ty != Terror);
+  create_typeinfo (type, sc ? sc->_module->importedFrom : NULL);
+  return type->vtinfo->type;
+}

--- a/gcc/d/d-objfile.cc
+++ b/gcc/d/d-objfile.cc
@@ -409,7 +409,7 @@ public:
       return;
 
     /* Generate TypeInfo.  */
-    genTypeInfo (d->type, NULL);
+    create_typeinfo (d->type, NULL);
 
     /* Generate static initialiser.  */
     d->sinit = aggregate_initializer_decl (d);
@@ -466,7 +466,7 @@ public:
     d_finish_symbol (d->sinit);
 
     /* Put out the TypeInfo.  */
-    genTypeInfo (d->type, NULL);
+    create_typeinfo (d->type, NULL);
     DECL_INITIAL (d->csym) = layout_classinfo (d);
     d_finish_symbol (d->csym);
 
@@ -562,7 +562,7 @@ public:
     d->csym = get_classinfo_decl (d);
 
     /* Put out the TypeInfo.  */
-    genTypeInfo (d->type, NULL);
+    create_typeinfo (d->type, NULL);
     d->type->vtinfo->accept (this);
     DECL_INITIAL (d->csym) = layout_classinfo (d);
     d_finish_symbol (d->csym);
@@ -590,7 +590,7 @@ public:
       return;
 
     /* Generate TypeInfo.  */
-    genTypeInfo (d->type, NULL);
+    create_typeinfo (d->type, NULL);
 
     TypeEnum *tc = (TypeEnum *) d->type;
     if (tc->sym->members && !d->type->isZeroInit ())
@@ -728,7 +728,7 @@ public:
 
   void visit (TypeInfoDeclaration *d)
   {
-    if (isSpeculativeType (d->tinfo))
+    if (speculative_type_p (d->tinfo))
       return;
 
     tree s = get_typeinfo_decl (d);
@@ -1100,7 +1100,8 @@ unsigned
 base_vtable_offset (ClassDeclaration *cd, BaseClass *bc)
 {
   unsigned csymoffset = Target::classinfosize;
-  csymoffset += cd->vtblInterfaces->dim * (4 * Target::ptrsize);
+  unsigned interfacesize = int_size_in_bytes (vtbl_interface_type_node);
+  csymoffset += cd->vtblInterfaces->dim * interfacesize;
 
   for (size_t i = 0; i < cd->vtblInterfaces->dim; i++)
     {

--- a/gcc/d/d-target.cc
+++ b/gcc/d/d-target.cc
@@ -341,6 +341,7 @@ Target::paintAsType (Expression *expr, Type *type)
 
 /* Check imported module M for any special processing.
    Modules we look out for are:
+    - object: For D runtime type information.
     - gcc.builtins: For all gcc builtins.
     - core.stdc.*: For all gcc library builtins.  */
 
@@ -348,10 +349,15 @@ void
 Target::loadModule (Module *m)
 {
   ModuleDeclaration *md = m->md;
-  if (!md || !md->packages || !md->id)
+  if (!md || !md->id)
     return;
 
-  if (md->packages->dim == 1)
+  if (!md->packages)
+    {
+      if (!strcmp (md->id->toChars (), "object"))
+	create_tinfo_types (m);
+    }
+  else if (md->packages->dim == 1)
     {
       if (!strcmp ((*md->packages)[0]->toChars (), "gcc")
 	  && !strcmp (md->id->toChars (), "builtins"))

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -38,6 +38,7 @@ class Type;
 class TypeFunction;
 class Parameter;
 struct BaseClass;
+struct Scope;
 
 template <typename TYPE> struct Array;
 typedef Array<Expression *> Expressions;
@@ -336,7 +337,9 @@ lang_tree_node
 
 enum d_tree_index
 {
+  DTI_VTABLE_ENTRY_TYPE,
   DTI_VTBL_PTR_TYPE,
+  DTI_VTBL_INTERFACE_TYPE,
 
   DTI_BOOL_TYPE,
   DTI_CHAR_TYPE,
@@ -360,12 +363,17 @@ enum d_tree_index
 
   DTI_UNKNOWN_TYPE,
 
+  DTI_ARRAY_TYPE,
+  DTI_NULL_ARRAY,
+
   DTI_MAX
 };
 
 extern GTY(()) tree d_global_trees[DTI_MAX];
 
+#define vtable_entry_type		d_global_trees[DTI_VTABLE_ENTRY_TYPE]
 #define vtbl_ptr_type_node		d_global_trees[DTI_VTBL_PTR_TYPE]
+#define vtbl_interface_type_node	d_global_trees[DTI_VTBL_INTERFACE_TYPE]
 #define bool_type_node			d_global_trees[DTI_BOOL_TYPE]
 #define char8_type_node			d_global_trees[DTI_CHAR_TYPE]
 #define char16_type_node		d_global_trees[DTI_DCHAR_TYPE]
@@ -384,6 +392,8 @@ extern GTY(()) tree d_global_trees[DTI_MAX];
 #define idouble_type_node		d_global_trees[DTI_IDOUBLE_TYPE]
 #define ireal_type_node			d_global_trees[DTI_IREAL_TYPE]
 #define unknown_type_node		d_global_trees[DTI_UNKNOWN_TYPE]
+#define array_type_node			d_global_trees[DTI_ARRAY_TYPE]
+#define null_array_node			d_global_trees[DTI_NULL_ARRAY]
 
 /* In d-attribs.c.  */
 extern tree insert_type_attribute (tree, const char *, tree = NULL_TREE);
@@ -439,10 +449,7 @@ extern tree get_decl_tree (Declaration *);
 extern tree make_thunk (FuncDeclaration *, int);
 extern tree layout_moduleinfo_fields (Module *, tree);
 extern tree get_moduleinfo_decl (Module *);
-extern tree get_typeinfo_decl (TypeInfoDeclaration *);
-extern tree get_classinfo_decl (ClassDeclaration *);
 extern tree get_vtable_decl (ClassDeclaration *);
-extern tree get_cpp_typeinfo_decl (ClassDeclaration *);
 extern tree build_new_class_expr (ClassReferenceExp *expr);
 extern tree aggregate_initializer_decl (AggregateDeclaration *);
 extern tree layout_struct_initializer (StructDeclaration *);
@@ -458,10 +465,16 @@ extern tree build_return_dtor (Expression *, Type *, TypeFunction *);
 extern tree build_import_decl (Dsymbol *);
 
 /* In typeinfo.cc.  */
-extern tree build_typeinfo (Type *);
 extern tree layout_typeinfo (TypeInfoDeclaration *);
 extern tree layout_classinfo (ClassDeclaration *);
+extern tree get_typeinfo_decl (TypeInfoDeclaration *);
+extern tree get_classinfo_decl (ClassDeclaration *);
+extern tree build_typeinfo (Type *);
+extern void create_typeinfo (Type *, Module *);
+extern void create_tinfo_types (Module *);
 extern void layout_cpp_typeinfo (ClassDeclaration *);
+extern tree get_cpp_typeinfo_decl (ClassDeclaration *);
+extern bool speculative_type_p (Type *);
 
 /* In toir.cc.  */
 extern void push_binding_level (level_kind);

--- a/gcc/d/dfrontend/dstruct.c
+++ b/gcc/d/dfrontend/dstruct.c
@@ -980,10 +980,6 @@ StructDeclaration::StructDeclaration(Loc loc, Identifier *id, bool inObject)
     {
         if (id == Id::ModuleInfo && !Module::moduleinfo)
             Module::moduleinfo = this;
-#ifdef IN_GCC
-        else if (id == Id::Interface && !Type::typeinterface)
-            Type::typeinterface = this;
-#endif
     }
 }
 

--- a/gcc/d/dfrontend/mtype.c
+++ b/gcc/d/dfrontend/mtype.c
@@ -76,9 +76,6 @@ ClassDeclaration *Type::typeinfoinvariant;
 ClassDeclaration *Type::typeinfoshared;
 ClassDeclaration *Type::typeinfowild;
 
-#ifdef IN_GCC
-StructDeclaration *Type::typeinterface;
-#endif
 TemplateDeclaration *Type::rtinfo;
 
 Type *Type::tvoid;

--- a/gcc/d/dfrontend/mtype.h
+++ b/gcc/d/dfrontend/mtype.h
@@ -224,9 +224,6 @@ public:
     static ClassDeclaration *typeinfoshared;
     static ClassDeclaration *typeinfowild;
 
-#ifdef IN_GCC
-    static StructDeclaration *typeinterface;
-#endif
     static TemplateDeclaration *rtinfo;
 
     static Type *basic[TMAX];


### PR DESCRIPTION
Massive change that decouples `typeinfo.cc` from the front-end.

- TypeInfo classes now internally defined, we refer to them when generating TypeInfo structures, as opposed to taking the object.d defined type directly (and for ClassInfo, modifying its layout).
- Missing TypeInfo in object.d has stubs generated, to keep the frontend happy.
- However we throw an error if `TypeInfo` itself is missing.
- Removed `Type::typeinterface`, replaced it with `type_vtbl_interface_type`, which itself represents a `void*[4]`.
- Threw the idea of looking up fields by name out the window.  Since we're laying out for an internally generated type, there can be no mismatch.  Just layout values in order.
- `build_struct_literal` has been fixed up to accept null indexes when searching for the next field to initialize.
- Exposed a tree for `void[]` and `{0, null}`, used it in a lot of places instead of always calling `build_ctype (Type::tvoid->arrayOf ())`

Some rationale (comment at top of file)
```
/* D returns type information to the user as TypeInfo class objects, and can
   be retrieved for any type using `typeid()'.  We also use type information
   to implement many runtime library helpers, including `new', `delete', most
   dynamic array operations, and all associative array operations.

   Type information for a particular type is indicated with an ABI defined
   structure derived from TypeInfo.  This would all be very straight forward,
   but for the fact that the runtime library provides the definitions of the
   TypeInfo structure and the ABI defined derived classes in `object.d', as
   well as having specific implementations of TypeInfo for built-in types
   in `rt/typeinfo`.  We cannot build declarations of these directly in the
   compiler, but we need to layout objects of their type.

   To get around this, we define layout compatible POD-structs and generate the
   appropriate initializations for them.  When we have to provide a TypeInfo to
   the user, we cast the internal compiler type to TypeInfo.

   It is only required that TypeInfo has a definition in `object.d'.  It could
   happen that we are generating a type information for a TypeInfo object that
   has no declaration.  We however only need the addresses of such incomplete
   TypeInfo objects for static initialization.  */
```