### PR TITLE
Remove WrappedExp from the front and backend.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,17 @@
+2017-04-30  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-objfile.cc (start_function): Update signature.
+	(finish_function): Update signature.
+	(DeclVisitor::visit(FuncDeclaration)): Move function construction to
+	start_function.  Move function finalization to finish_function.
+	(set_function_end_locus): Remove function.
+	(d_finish_function): Remove function.
+	(build_simple_function_decl): Don't set frontend body.
+	(build_simple_function): Update signature.  Use start/finish function
+	to compile the body.
+	(emit_dso_registry_cdtor): Likewise.
+	* expr.cc (ExprVisitor::visit(WrappedExp)): Remove function.
+
 2017-04-29  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-diagnostic.cc (verror): Use xvasprintf.

--- a/gcc/d/d-objfile.h
+++ b/gcc/d/d-objfile.h
@@ -24,12 +24,10 @@ extern void set_input_location (Dsymbol *decl);
 
 extern void set_decl_location (tree t, const Loc& loc);
 extern void set_decl_location (tree t, Dsymbol *decl);
-extern void set_function_end_locus (const Loc& loc);
 
 extern void d_comdat_linkage (tree decl);
 
 extern void d_finish_symbol (tree sym);
-extern void d_finish_function (FuncDeclaration *f);
 extern void d_finish_module();
 extern void d_finish_compilation (tree *vec, int len);
 

--- a/gcc/d/dfrontend/expression.c
+++ b/gcc/d/dfrontend/expression.c
@@ -14545,16 +14545,6 @@ Expression *PrettyFuncInitExp::resolveLoc(Loc loc, Scope *sc)
 }
 
 /****************************************************************/
-#ifdef IN_GCC
-
-WrappedExp::WrappedExp(Loc loc, elem *e1, Type *type)
-    : Expression(loc, TOKcomma, sizeof(WrappedExp))
-{
-  this->e1 = e1;
-  this->type = type;
-}
-
-#endif
 
 Expression *extractOpDollarSideEffect(Scope *sc, UnaExp *ue)
 {

--- a/gcc/d/dfrontend/expression.h
+++ b/gcc/d/dfrontend/expression.h
@@ -51,7 +51,6 @@ class SliceExp;
 struct UnionExp;
 
 #ifdef IN_GCC
-typedef union tree_node elem;
 typedef union tree_node Symbol;
 #else
 struct Symbol;          // back end symbol
@@ -1653,18 +1652,5 @@ void sliceAssignStringFromString(StringExp *existingSE, StringExp *newstr, size_
 int sliceCmpStringWithString(StringExp *se1, StringExp *se2, size_t lo1, size_t lo2, size_t len);
 int sliceCmpStringWithArray(StringExp *se1, ArrayLiteralExp *ae2, size_t lo1, size_t lo2, size_t len);
 
-#ifdef IN_GCC
-/****************************************************************/
-
-class WrappedExp : public Expression
-{
-public:
-    elem *e1;
-
-    WrappedExp(Loc loc, elem *e1, Type *type);
-    void accept(Visitor *v) { v->visit(this); }
-};
-
-#endif
 
 #endif /* DMD_EXPRESSION_H */

--- a/gcc/d/dfrontend/hdrgen.c
+++ b/gcc/d/dfrontend/hdrgen.c
@@ -3184,13 +3184,6 @@ public:
             s->accept(this);
         }
     }
-
-#ifdef IN_GCC
-    void visit(WrappedExp *e)
-    {
-        buf->writestring("<wrapped expression>");
-    }
-#endif
 };
 
 void toCBuffer(Statement *s, OutBuffer *buf, HdrGenState *hgs)

--- a/gcc/d/dfrontend/visitor.h
+++ b/gcc/d/dfrontend/visitor.h
@@ -283,9 +283,6 @@ class PrettyFuncInitExp;
 class ClassReferenceExp;
 class VoidInitExp;
 class ThrownExceptionExp;
-#ifdef IN_GCC
-class WrappedExp;
-#endif
 
 class TemplateParameter;
 class TemplateTypeParameter;
@@ -575,9 +572,6 @@ public:
     virtual void visit(ClassReferenceExp *e) { visit((Expression *)e); }
     virtual void visit(VoidInitExp *e) { visit((Expression *)e); }
     virtual void visit(ThrownExceptionExp *e) { visit((Expression *)e); }
-#ifdef IN_GCC
-    virtual void visit(WrappedExp *e) { visit((Expression *)e); }
-#endif
 
     virtual void visit(TemplateParameter *) { assert(0); }
     virtual void visit(TemplateTypeParameter *tp) { visit((TemplateParameter *)tp); }

--- a/gcc/d/expr.cc
+++ b/gcc/d/expr.cc
@@ -2980,13 +2980,6 @@ public:
     this->result_ = var;
   }
 
-  /* Return expression tree for WrappedExp.  */
-
-  void visit (WrappedExp *e)
-  {
-    this->result_ = e->e1;
-  }
-
   /* These expressions are mainly just a placeholders in the frontend.
      We shouldn't see them here.  */
 


### PR DESCRIPTION
Moved the setting-up and tearing-down of functions to `start_function` and `finish_function`.

Now emitting a simple function can be boiled down to just:
```
tree old_context = start_function (fd);
rest_of_decl_compilation (get_symbol_decl (fd), 1, 0);
add_stmt (my_body);
finish_function (old_context);
```