### PR TITLE
Fix SPARC64 builds (re-apply patch for gcc-7-20161127)

### DIFF
--- a/gcc/d/d-target.cc
+++ b/gcc/d/d-target.cc
@@ -25,6 +25,7 @@ along with GCC; see the file COPYING3.  If not see
 #include "dfrontend/target.h"
 
 #include "tree.h"
+#include "memmodel.h"
 #include "fold-const.h"
 #include "stor-layout.h"
 #include "tm.h"


### PR DESCRIPTION
Merging as obvious, and pushing into gdc-7 branch.