### PR TITLE
Remove SH5 support from patches

### DIFF
--- a/gcc/d/dfrontend/cond.c
+++ b/gcc/d/dfrontend/cond.c
@@ -208,7 +208,6 @@ static bool isReserved(const char *ident)
         "HPPA",
         "HPPA64",
         "SH",
-        "SH64",
         "Alpha",
         "Alpha_SoftFloat",
         "Alpha_HardFloat",

--- a/gcc/d/patches/patch-versym-cpu-8.x
+++ b/gcc/d/patches/patch-versym-cpu-8.x
@@ -34,7 +34,6 @@ for all supported architectures. And these where appropriate:
 * S390
 * S390X
 * SH
-* SH64
 * SPARC
 * SPARC64
 * SPARC_V8Plus
@@ -300,7 +299,7 @@ for all supported architectures. And these where appropriate:
                              | MASK_OPT_HTM | MASK_OPT_VX)
 --- a/gcc/config/sh/sh.h
 +++ b/gcc/config/sh/sh.h
-@@ -31,6 +31,22 @@ extern int code_for_indirect_jump_scratch;
+@@ -31,6 +31,19 @@ extern int code_for_indirect_jump_scratch;
  
  #define TARGET_CPU_CPP_BUILTINS() sh_cpu_cpp_builtins (pfile)
  
@@ -308,10 +307,7 @@ for all supported architectures. And these where appropriate:
 +#define TARGET_CPU_D_BUILTINS()			\
 +  do						\
 +    {						\
-+      if (TARGET_SHMEDIA64)			\
-+	builtin_define ("SH64");		\
-+      else					\
-+	builtin_define ("SH");			\
++      builtin_define ("SH");			\
 +						\
 +      if (TARGET_FPU_ANY)			\
 +	builtin_define ("D_HardFloat");		\


### PR DESCRIPTION
The `SHMEDIA64` macro was removed during the gcc-7 stage1, along with removal of the sh5 support.