### PR TITLE
Refactor and reformat d-lang.cc

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,17 @@
+2017-05-21  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-attribs.c (handle_sentinel_attribute): Remove function.
+	(ignore_attribute): Remove function.
+	(d_langhook_common_attribute_table): Remove sentinel and tm regparm
+	from common attribute table.
+	(d_langhook_format_attribute_table): Remove variable.
+	* d-lang.cc (LANG_HOOKS_BUILTIN_FUNCTION_EXT_SCOPE): Remove macro.
+	(LANG_HOOKS_FORMAT_ATTRIBUTE_TABLE): Remove macro.
+	(d_post_options): Don't set flag_unit_at_a_time.
+	(d_nametype): Remove function.
+	* types.cc (TypeVisitor::visit(TypeBasic)): Set TYPE_NAME.
+	(TypeVisitor::visit(TypeVector)): Likewise.
+
 2017-05-20  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* Make-lang.in (D_OBJS): Remove d-objfile.o.  Add modules.o.

--- a/gcc/d/d-attribs.c
+++ b/gcc/d/d-attribs.c
@@ -48,13 +48,11 @@ static tree handle_pure_attribute (tree *, tree, tree, int, bool *);
 static tree handle_novops_attribute (tree *, tree, tree, int, bool *);
 static tree handle_nonnull_attribute (tree *, tree, tree, int, bool *);
 static tree handle_nothrow_attribute (tree *, tree, tree, int, bool *);
-static tree handle_sentinel_attribute (tree *, tree, tree, int, bool *);
 static tree handle_type_generic_attribute (tree *, tree, tree, int, bool *);
 static tree handle_transaction_pure_attribute (tree *, tree, tree, int, bool *);
 static tree handle_returns_twice_attribute (tree *, tree, tree, int, bool *);
 static tree handle_fnspec_attribute (tree *, tree, tree, int, bool *);
 static tree handle_weakref_attribute (tree *, tree, tree, int, bool *);
-static tree ignore_attribute (tree *, tree, tree, int, bool *);
 
 /* D attribute handlers for user defined attributes.  */
 static tree d_handle_noinline_attribute (tree *, tree, tree, int, bool *);
@@ -90,8 +88,6 @@ const attribute_spec d_langhook_common_attribute_table[] =
 			      handle_nonnull_attribute, false },
   { "nothrow",                0, 0, true,  false, false,
 			      handle_nothrow_attribute, false },
-  { "sentinel",               0, 1, false, true, true,
-			      handle_sentinel_attribute, false },
   { "transaction_pure",       0, 0, false, true, true,
 			      handle_transaction_pure_attribute, false },
   { "no vops",                0, 0, true,  false, false,
@@ -100,8 +96,6 @@ const attribute_spec d_langhook_common_attribute_table[] =
 			      handle_type_generic_attribute, false },
   { "fn spec",                1, 1, false, true, true,
 			      handle_fnspec_attribute, false },
-  { "*tm regparm",            0, 0, false, true, true,
-			      ignore_attribute, false },
   { "weakref",                0, 1, true,  false, false,
 			      handle_weakref_attribute, false },
   { NULL,                     0, 0, false, false, false, NULL, false }
@@ -130,21 +124,6 @@ const attribute_spec d_langhook_attribute_table[] =
     { "weak",                   0, 0, true,  false, false,
 				d_handle_weak_attribute, false },
     { NULL,                     0, 0, false, false, false, NULL, false }
-};
-
-
-/* Give the specifications for the format attributes, used by C and all
-   descendants.  */
-
-const attribute_spec d_langhook_format_attribute_table[] =
-{
-  /* { name, min_len, max_len, decl_req, type_req, fn_type_req, handler,
-       affects_type_identity } */
-  { "format",                 3, 3, false, true,  true,
-			      ignore_attribute, false },
-  { "format_arg",             1, 1, false, true,  true,
-			      ignore_attribute, false },
-  { NULL,                     0, 0, false, false, false, NULL, false }
 };
 
 
@@ -500,26 +479,6 @@ handle_nothrow_attribute (tree *node, tree ARG_UNUSED (name),
   return NULL_TREE;
 }
 
-/* Handle a "sentinel" attribute.  */
-
-static tree
-handle_sentinel_attribute (tree *node, tree ARG_UNUSED (name), tree args,
-			   int ARG_UNUSED (flags),
-			   bool * ARG_UNUSED (no_add_attrs))
-{
-  gcc_assert (stdarg_p (*node));
-
-  if (args)
-    {
-      tree position = TREE_VALUE (args);
-      gcc_assert (TREE_CODE (position) == INTEGER_CST);
-      if (tree_int_cst_lt (position, integer_zero_node))
-	gcc_unreachable ();
-    }
-
-  return NULL_TREE;
-}
-
 /* Handle a "type_generic" attribute.  */
 
 static tree
@@ -595,18 +554,6 @@ handle_weakref_attribute (tree *node, tree ARG_UNUSED (name),
      the list of weak decls, which isn't helpful.  */
   DECL_WEAK (*node) = 1;
 
-  return NULL_TREE;
-}
-
-/* Ignore the given attribute.  Used when this attribute may be usefully
-   overridden by the target, but is not used generically.  */
-
-static tree
-ignore_attribute (tree * ARG_UNUSED (node), tree ARG_UNUSED (name),
-		  tree ARG_UNUSED (args), int ARG_UNUSED (flags),
-		  bool *no_add_attrs)
-{
-  *no_add_attrs = true;
   return NULL_TREE;
 }
 

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -1,21 +1,19 @@
-// d-lang.cc -- D frontend for GCC.
-// Copyright (C) 2011-2015 Free Software Foundation, Inc.
+/* d-lang.cc -- Language-dependent hooks for D.
+   Copyright (C) 2011-2017 Free Software Foundation, Inc.
 
-// GCC is free software; you can redistribute it and/or modify it under
-// the terms of the GNU General Public License as published by the Free
-// Software Foundation; either version 3, or (at your option) any later
-// version.
+GCC is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3, or (at your option)
+any later version.
 
-// GCC is distributed in the hope that it will be useful, but WITHOUT ANY
-// WARRANTY; without even the implied warranty of MERCHANTABILITY or
-// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
-// for more details.
+GCC is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
-// You should have received a copy of the GNU General Public License
-// along with GCC; see the file COPYING3.  If not see
-// <http://www.gnu.org/licenses/>.
-
-// d-lang.cc: Implementation of back-end callbacks and data structures
+You should have received a copy of the GNU General Public License
+along with GCC; see the file COPYING3.  If not see
+<http://www.gnu.org/licenses/>.  */
 
 #include "config.h"
 #include "system.h"
@@ -31,8 +29,6 @@
 #include "dfrontend/lexer.h"
 #include "dfrontend/module.h"
 #include "dfrontend/scope.h"
-#include "dfrontend/statement.h"
-#include "dfrontend/root.h"
 #include "dfrontend/target.h"
 
 #include "opts.h"
@@ -57,82 +53,8 @@
 #include "d-dmd-gcc.h"
 #include "id.h"
 
-static char lang_name[6] = "GNU D";
 
-/* Lang Hooks */
-#undef LANG_HOOKS_NAME
-#undef LANG_HOOKS_INIT
-#undef LANG_HOOKS_INIT_TS
-#undef LANG_HOOKS_INIT_OPTIONS
-#undef LANG_HOOKS_INIT_OPTIONS_STRUCT
-#undef LANG_HOOKS_OPTION_LANG_MASK
-#undef LANG_HOOKS_HANDLE_OPTION
-#undef LANG_HOOKS_POST_OPTIONS
-#undef LANG_HOOKS_PARSE_FILE
-#undef LANG_HOOKS_COMMON_ATTRIBUTE_TABLE
-#undef LANG_HOOKS_ATTRIBUTE_TABLE
-#undef LANG_HOOKS_FORMAT_ATTRIBUTE_TABLE
-#undef LANG_HOOKS_GET_ALIAS_SET
-#undef LANG_HOOKS_TYPES_COMPATIBLE_P
-#undef LANG_HOOKS_BUILTIN_FUNCTION
-#undef LANG_HOOKS_BUILTIN_FUNCTION_EXT_SCOPE
-#undef LANG_HOOKS_REGISTER_BUILTIN_TYPE
-#undef LANG_HOOKS_FINISH_INCOMPLETE_DECL
-#undef LANG_HOOKS_GIMPLIFY_EXPR
-#undef LANG_HOOKS_CLASSIFY_RECORD
-#undef LANG_HOOKS_TREE_SIZE
-#undef LANG_HOOKS_PRINT_XNODE
-#undef LANG_HOOKS_DUP_LANG_SPECIFIC_DECL
-#undef LANG_HOOKS_EH_PERSONALITY
-#undef LANG_HOOKS_EH_RUNTIME_TYPE
-
-
-#define LANG_HOOKS_NAME				lang_name
-#define LANG_HOOKS_INIT				d_init
-#define LANG_HOOKS_INIT_TS			d_init_ts
-#define LANG_HOOKS_INIT_OPTIONS			d_init_options
-#define LANG_HOOKS_INIT_OPTIONS_STRUCT		d_init_options_struct
-#define LANG_HOOKS_OPTION_LANG_MASK		d_option_lang_mask
-#define LANG_HOOKS_HANDLE_OPTION		d_handle_option
-#define LANG_HOOKS_POST_OPTIONS			d_post_options
-#define LANG_HOOKS_PARSE_FILE			d_parse_file
-#define LANG_HOOKS_COMMON_ATTRIBUTE_TABLE       d_langhook_common_attribute_table
-#define LANG_HOOKS_ATTRIBUTE_TABLE              d_langhook_attribute_table
-#define LANG_HOOKS_FORMAT_ATTRIBUTE_TABLE	d_langhook_format_attribute_table
-#define LANG_HOOKS_GET_ALIAS_SET		d_get_alias_set
-#define LANG_HOOKS_TYPES_COMPATIBLE_P		d_types_compatible_p
-#define LANG_HOOKS_BUILTIN_FUNCTION		d_builtin_function
-#define LANG_HOOKS_BUILTIN_FUNCTION_EXT_SCOPE	d_builtin_function
-#define LANG_HOOKS_REGISTER_BUILTIN_TYPE	d_register_builtin_type
-#define LANG_HOOKS_FINISH_INCOMPLETE_DECL	d_finish_incomplete_decl
-#define LANG_HOOKS_GIMPLIFY_EXPR		d_gimplify_expr
-#define LANG_HOOKS_CLASSIFY_RECORD		d_classify_record
-#define LANG_HOOKS_TREE_SIZE			d_tree_size
-#define LANG_HOOKS_PRINT_XNODE			d_print_xnode
-#define LANG_HOOKS_DUP_LANG_SPECIFIC_DECL	d_dup_lang_specific_decl
-#define LANG_HOOKS_EH_PERSONALITY		d_eh_personality
-#define LANG_HOOKS_EH_RUNTIME_TYPE		d_build_eh_type_type
-
-/* Lang Hooks for decls */
-#undef LANG_HOOKS_PUSHDECL
-#undef LANG_HOOKS_GETDECLS
-#undef LANG_HOOKS_GLOBAL_BINDINGS_P
-
-#define LANG_HOOKS_PUSHDECL			d_pushdecl
-#define LANG_HOOKS_GETDECLS			d_getdecls
-#define LANG_HOOKS_GLOBAL_BINDINGS_P		d_global_bindings_p
-
-/* Lang Hooks for types */
-#undef LANG_HOOKS_TYPE_FOR_MODE
-#undef LANG_HOOKS_TYPE_FOR_SIZE
-#undef LANG_HOOKS_TYPE_PROMOTES_TO
-
-#define LANG_HOOKS_TYPE_FOR_MODE		d_type_for_mode
-#define LANG_HOOKS_TYPE_FOR_SIZE		d_type_for_size
-#define LANG_HOOKS_TYPE_PROMOTES_TO		d_type_promotes_to
-
-
-/* Array of d type/decl nodes.  */
+/* Array of D frontend type/decl nodes.  */
 tree d_global_trees[DTI_MAX];
 
 /* Options handled by the compiler that are separate from the frontend.  */
@@ -169,9 +91,10 @@ static GTY(()) tree global_context;
 /* Array of all global declarations to pass back to the middle-end.  */
 static GTY(()) vec<tree, va_gc> *global_declarations;
 
-
-/* Adds TARGET to the make dependencies target buffer.
+/* Support for GCC-style command-line make dependency generation.
+   Adds TARGET to the make dependencies target buffer.
    QUOTED is true if the string should be quoted.  */
+
 static void
 deps_add_target (const char *target, bool quoted)
 {
@@ -218,6 +141,7 @@ deps_add_target (const char *target, bool quoted)
 
 /* Write out all dependencies of a given MODULE to the specified BUFFER.
    COLMAX is the number of columns to word-wrap at (0 means don't wrap).  */
+
 static void
 deps_write (Module *module, OutBuffer *buffer, unsigned colmax = 72)
 {
@@ -324,16 +248,19 @@ deps_write (Module *module, OutBuffer *buffer, unsigned colmax = 72)
     }
 }
 
-/* Common initialization before calling option handlers.  */
+/* Implements the lang_hooks.init_options routine for language D.
+   This initializes the global state for the D frontend before calling
+   the option handlers.  */
+
 static void
-d_init_options(unsigned int, cl_decoded_option *decoded_options)
+d_init_options (unsigned int, cl_decoded_option *decoded_options)
 {
-  // Set default values
-  global._init();
+  /* Set default values.  */
+  global._init ();
 
-  global.compiler.vendor = lang_name;
+  global.compiler.vendor = lang_hooks.name;
 
-  global.params.argv0 = xstrdup(decoded_options[0].arg);
+  global.params.argv0 = xstrdup (decoded_options[0].arg);
   global.params.link = true;
   global.params.useAssert = true;
   global.params.useInvariants = true;
@@ -349,13 +276,13 @@ d_init_options(unsigned int, cl_decoded_option *decoded_options)
   global.params.betterC = false;
   global.params.allInst = false;
 
-  global.params.linkswitches = new Strings();
-  global.params.libfiles = new Strings();
-  global.params.objfiles = new Strings();
-  global.params.ddocfiles = new Strings();
+  global.params.linkswitches = new Strings ();
+  global.params.libfiles = new Strings ();
+  global.params.objfiles = new Strings ();
+  global.params.ddocfiles = new Strings ();
 
-  global.params.imppath = new Strings();
-  global.params.fileImppath = new Strings();
+  global.params.imppath = new Strings ();
+  global.params.fileImppath = new Strings ();
   global.params.modFileAliasStrings = new Strings ();
 
   /* Extra GDC-specific options.  */
@@ -371,37 +298,46 @@ d_init_options(unsigned int, cl_decoded_option *decoded_options)
   d_option.stdinc = true;
 }
 
-/* Initialize options structure OPTS.  */
+/* Implements the lang_hooks.init_options_struct routine for language D.
+   Initializes the options structure OPTS.  */
+
 static void
-d_init_options_struct(gcc_options *opts)
+d_init_options_struct (gcc_options *opts)
 {
-  // GCC options
+  /* GCC options.  */
   opts->x_flag_exceptions = 1;
 
-  // Avoid range issues for complex multiply and divide.
+  /* Avoid range issues for complex multiply and divide.  */
   opts->x_flag_complex_method = 2;
 
-  // Unlike C, there is no global 'errno' variable.
+  /* Unlike C, there is no global 'errno' variable.  */
   opts->x_flag_errno_math = 0;
   opts->frontend_set_flag_errno_math = true;
 
-  // Keep in synch with existing -fbounds-check flag.
+  /* Keep in sync with existing -fbounds-check flag.  */
   opts->x_flag_bounds_check = global.params.useArrayBounds;
 
-  // D says that signed overflow is precisely defined.
+  /* D says that signed overflow is precisely defined.  */
   opts->x_flag_wrapv = 1;
 }
 
-/* Return language mask for option parsing.  */
+/* Implements the lang_hooks.lang_mask routine for language D.
+   Returns language mask for option parsing.  */
+
 static unsigned int
-d_option_lang_mask()
+d_option_lang_mask (void)
 {
   return CL_D;
 }
 
+/* Callback for TARGET_CPU_D_BUILTINS and TARGET_OS_D_BUILTINS.
+   Adds IDENT to the list of predefined version identifiers.  */
+
 static void
-d_add_builtin_version(const char* ident)
+d_add_builtin_version (const char* ident)
 {
+  /* For now, we need to tell the D frontend what platform is being targetted.
+     This should be removed once the frontend has been fixed.  */
   if (strcmp (ident, "linux") == 0)
     global.params.isLinux = true;
   else if (strcmp (ident, "OSX") == 0)
@@ -420,36 +356,38 @@ d_add_builtin_version(const char* ident)
   VersionCondition::addPredefinedGlobalIdent (ident);
 }
 
-static bool
-d_init()
-{
-  Lexer::initLexer();
-  Type::_init();
-  Id::initialize();
-  Module::_init();
-  Expression::_init();
-  initPrecedence();
-  initTraitsStringTable();
+/* Implements the lang_hooks.init routine for language D.  */
 
-  // Backend init.
-  global_binding_level = ggc_cleared_alloc<binding_level>();
+static bool
+d_init (void)
+{
+  Lexer::initLexer ();
+  Type::_init ();
+  Id::initialize ();
+  Module::_init ();
+  Expression::_init ();
+  initPrecedence ();
+  initTraitsStringTable ();
+
+  /* Backend init.  */
+  global_binding_level = ggc_cleared_alloc<binding_level> ();
   current_binding_level = global_binding_level;
 
-  // This allows the code in d-builtins.c to not have to worry about
-  // converting (C signed char *) to (D char *) for string arguments of
-  // built-in functions.
-  // Parameter (signed_char = false) specifies whether char is signed.
+  /* This allows the code in d-builtins.cc to not have to worry about
+     converting (C signed char *) to (D char *) for string arguments of
+     built-in functions.  The parameter (signed_char = false) specifies
+     whether char is signed.  */
   build_common_tree_nodes (false);
 
-  d_init_builtins();
+  d_init_builtins ();
 
   if (flag_exceptions)
-    using_eh_for_cleanups();
+    using_eh_for_cleanups ();
 
-  // This is the C main, not the D main.
+  /* This is the C main, not the D main.  */
   main_identifier_node = get_identifier ("main");
 
-  Target::_init();
+  Target::_init ();
 
 #ifndef TARGET_CPU_D_BUILTINS
 # define TARGET_CPU_D_BUILTINS()
@@ -459,10 +397,10 @@ d_init()
 # define TARGET_OS_D_BUILTINS()
 #endif
 
-# define builtin_define(TXT) d_add_builtin_version(TXT)
+# define builtin_define(TXT) d_add_builtin_version (TXT)
 
-  TARGET_CPU_D_BUILTINS();
-  TARGET_OS_D_BUILTINS();
+  TARGET_CPU_D_BUILTINS ();
+  TARGET_OS_D_BUILTINS ();
 
   VersionCondition::addPredefinedGlobalIdent ("GNU");
   VersionCondition::addPredefinedGlobalIdent ("D_Version2");
@@ -474,12 +412,12 @@ d_init()
 
   if (targetm_common.except_unwind_info (&global_options) == UI_SJLJ)
     VersionCondition::addPredefinedGlobalIdent ("GNU_SjLj_Exceptions");
-  else if(targetm_common.except_unwind_info (&global_options) == UI_SEH)
+  else if (targetm_common.except_unwind_info (&global_options) == UI_SEH)
     VersionCondition::addPredefinedGlobalIdent ("GNU_SEH_Exceptions");
-  else if(targetm_common.except_unwind_info (&global_options) == UI_DWARF2)
+  else if (targetm_common.except_unwind_info (&global_options) == UI_DWARF2)
     VersionCondition::addPredefinedGlobalIdent ("GNU_DWARF2_Exceptions");
 
-  if(!targetm.have_tls)
+  if (!targetm.have_tls)
     VersionCondition::addPredefinedGlobalIdent ("GNU_EMUTLS");
 
 #ifdef STACK_GROWS_DOWNWARD
@@ -493,10 +431,9 @@ d_init()
   if (global.params.isLP64)
     VersionCondition::addPredefinedGlobalIdent ("D_LP64");
 
-  /* Setting global.params.cov forces module info generation which is
-     not needed for thee GCC coverage implementation.  Instead, just
-     test flag_test_coverage while leaving global.params.cov unset. */
-  //if (global.params.cov)
+  /* Setting `global.params.cov' forces module info generation which is
+     not needed for the GCC coverage implementation.  Instead, just
+     test flag_test_coverage while leaving `global.params.cov' unset. */
   if (flag_test_coverage)
     VersionCondition::addPredefinedGlobalIdent ("D_Coverage");
   if (flag_pic)
@@ -506,27 +443,31 @@ d_init()
   if (global.params.useUnitTests)
     VersionCondition::addPredefinedGlobalIdent ("unittest");
   if (global.params.useAssert)
-    VersionCondition::addPredefinedGlobalIdent("assert");
+    VersionCondition::addPredefinedGlobalIdent ("assert");
   if (global.params.useArrayBounds == BOUNDSCHECKoff)
-    VersionCondition::addPredefinedGlobalIdent("D_NoBoundsChecks");
+    VersionCondition::addPredefinedGlobalIdent ("D_NoBoundsChecks");
 
   VersionCondition::addPredefinedGlobalIdent ("all");
 
   /* Insert all library-configured identifiers and import paths.  */
-  add_import_paths(d_option.prefix, d_option.multilib, d_option.stdinc);
+  add_import_paths (d_option.prefix, d_option.multilib, d_option.stdinc);
 
   return 1;
 }
 
+/* Implements the lang_hooks.init_ts routine for language D.  */
+
 void
-d_init_ts()
+d_init_ts (void)
 {
   MARK_TS_TYPED (IASM_EXPR);
   MARK_TS_TYPED (FLOAT_MOD_EXPR);
   MARK_TS_TYPED (UNSIGNED_RSHIFT_EXPR);
 }
 
-//
+/* Implements the lang_hooks.handle_option routine for language D.
+   Handles D specific options.  Return false if we didn't do anything.  */
+
 static bool
 d_handle_option (size_t scode, const char *arg, int value,
 		 int kind ATTRIBUTE_UNUSED,
@@ -563,17 +504,17 @@ d_handle_option (size_t scode, const char *arg, int value,
     case OPT_fdebug_:
       if (ISDIGIT (arg[0]))
 	{
-	  int level = integral_argument(arg);
+	  int level = integral_argument (arg);
 	  if (level != -1)
 	    {
-	      DebugCondition::setGlobalLevel(level);
+	      DebugCondition::setGlobalLevel (level);
 	      break;
 	    }
 	}
 
-      if (Identifier::isValidIdentifier(CONST_CAST (char *, arg)))
+      if (Identifier::isValidIdentifier (CONST_CAST (char *, arg)))
 	{
-	  DebugCondition::addGlobalIdent(arg);
+	  DebugCondition::addGlobalIdent (arg);
 	  break;
 	}
 
@@ -715,7 +656,7 @@ d_handle_option (size_t scode, const char *arg, int value,
     case OPT_fversion_:
       if (ISDIGIT (arg[0]))
 	{
-	  int level = integral_argument(arg);
+	  int level = integral_argument (arg);
 	  if (level != -1)
 	    {
 	      VersionCondition::setGlobalLevel (level);
@@ -741,11 +682,11 @@ d_handle_option (size_t scode, const char *arg, int value,
       break;
 
     case OPT_I:
-      global.params.imppath->push(arg); // %% not sure if we can keep the arg or not
+      global.params.imppath->push (arg);
       break;
 
     case OPT_J:
-      global.params.fileImppath->push(arg);
+      global.params.fileImppath->push (arg);
       break;
 
     case OPT_MM:
@@ -831,6 +772,10 @@ d_handle_option (size_t scode, const char *arg, int value,
   return result;
 }
 
+/* Implements the lang_hooks.post_options routine for language D.
+   Deal with any options that imply the turning on/off of features.
+   FN is the main input filename passed on the command line.  */
+
 bool
 d_post_options (const char ** fn)
 {
@@ -842,11 +787,7 @@ d_post_options (const char ** fn)
   /* The front end considers the first input file to be the main one.  */
   *fn = filename;
 
-  // If we are given more than one input file, we must use unit-at-a-time mode.
-  if (num_in_fnames > 1)
-    flag_unit_at_a_time = 1;
-
-  // Release mode doesn't turn off bounds checking for safe functions.
+  /* Release mode doesn't turn off bounds checking for safe functions.  */
   if (global.params.useArrayBounds == BOUNDSCHECKdefault)
     {
       global.params.useArrayBounds = global.params.release
@@ -872,11 +813,11 @@ d_post_options (const char ** fn)
 	global.params.useSwitchError = false;
     }
 
-  // Error about use of deprecated features.
+  /* Error about use of deprecated features.  */
   if (global.params.useDeprecated == 2 && global.params.warnings == 1)
     global.params.useDeprecated = 0;
 
-  // Make -fmax-errors visible to frontend's diagnostic machinery.
+  /* Make -fmax-errors visible to frontend's diagnostic machinery.  */
   if (global_options_set.x_flag_max_errors)
     global.errorLimit = flag_max_errors;
 
@@ -893,49 +834,52 @@ d_post_options (const char ** fn)
     global.params.hdrStripPlainFunctions = false;
 
   global.params.obj = !flag_syntax_only;
-  // Has no effect yet.
+
+  /* Has no effect yet.  */
   global.params.pic = flag_pic != 0;
 
   return false;
 }
 
-// Return TRUE if an operand OP of a given TYPE being copied has no data.
-// The middle-end does a similar check with zero sized types.
+/* Return TRUE if an operand OP of a given TYPE being copied has no data.
+   The middle-end does a similar check with zero sized types.  */
+
 static bool
-empty_modify_p(tree type, tree op)
+empty_modify_p (tree type, tree op)
 {
   tree_code code = TREE_CODE (op);
   switch (code)
     {
     case COMPOUND_EXPR:
-      return empty_modify_p(type, TREE_OPERAND (op, 1));
+      return empty_modify_p (type, TREE_OPERAND (op, 1));
 
     case CONSTRUCTOR:
-      // Non-empty construcors are valid.
+      /* Non-empty construcors are valid.  */
       if (CONSTRUCTOR_NELTS (op) != 0 || TREE_CLOBBER_P (op))
 	return false;
       break;
 
     case CALL_EXPR:
-      // Leave nrvo alone because it isn't a copy.
+      /* Leave nrvo alone because it isn't a copy.  */
       if (CALL_EXPR_RETURN_SLOT_OPT (op))
 	return false;
       break;
 
     default:
-      // If the operand doesn't have a simple form.
-      if (!is_gimple_lvalue(op) && !INDIRECT_REF_P (op))
+      /* If the operand doesn't have a simple form.  */
+      if (!is_gimple_lvalue (op) && !INDIRECT_REF_P (op))
 	return false;
       break;
     }
 
-  return empty_aggregate_p(type);
+  return empty_aggregate_p (type);
 }
 
-// Gimplification of D specific expression trees.
+/* Implements the lang_hooks.gimplify_expr routine for language D.
+   Do gimplification of D specific expression trees in EXPR_P.  */
 
 int
-d_gimplify_expr(tree *expr_p, gimple_seq *pre_p ATTRIBUTE_UNUSED,
+d_gimplify_expr (tree *expr_p, gimple_seq *pre_p ATTRIBUTE_UNUSED,
 		gimple_seq *post_p ATTRIBUTE_UNUSED)
 {
   tree_code code = TREE_CODE (*expr_p);
@@ -950,31 +894,31 @@ d_gimplify_expr(tree *expr_p, gimple_seq *pre_p ATTRIBUTE_UNUSED,
       op0 = TREE_OPERAND (*expr_p, 0);
       op1 = TREE_OPERAND (*expr_p, 1);
 
-      if (!error_operand_p(op0) && !error_operand_p(op1)
+      if (!error_operand_p (op0) && !error_operand_p (op1)
 	  && (AGGREGATE_TYPE_P (TREE_TYPE (op0))
 	      || AGGREGATE_TYPE_P (TREE_TYPE (op1)))
-	  && !useless_type_conversion_p(TREE_TYPE (op1), TREE_TYPE (op0)))
+	  && !useless_type_conversion_p (TREE_TYPE (op1), TREE_TYPE (op0)))
 	{
-	  // If the back end isn't clever enough to know that the lhs and rhs
-	  // types are the same, add an explicit conversion.
-	  TREE_OPERAND (*expr_p, 1) = build1(VIEW_CONVERT_EXPR,
-					     TREE_TYPE (op0), op1);
+	  /* If the back end isn't clever enough to know that the lhs and rhs
+	     types are the same, add an explicit conversion.  */
+	  TREE_OPERAND (*expr_p, 1) = build1 (VIEW_CONVERT_EXPR,
+					      TREE_TYPE (op0), op1);
 	  ret = GS_OK;
 	}
-      else if (empty_modify_p(TREE_TYPE (op0), op1))
+      else if (empty_modify_p (TREE_TYPE (op0), op1))
 	{
-	  // Remove any copies of empty aggregates.  Also drop volatile
-	  // loads on the RHS to avoid infinite recursion from
-	  // gimplify_expr trying to load the value.
-	  gimplify_expr(&TREE_OPERAND (*expr_p, 0), pre_p, post_p,
-			is_gimple_lvalue, fb_lvalue);
+	  /* Remove any copies of empty aggregates.  Also drop volatile
+	     loads on the RHS to avoid infinite recursion from
+	     gimplify_expr trying to load the value.  */
+	  gimplify_expr (&TREE_OPERAND (*expr_p, 0), pre_p, post_p,
+			 is_gimple_lvalue, fb_lvalue);
 	  if (TREE_SIDE_EFFECTS (op1))
 	    {
 	      if (TREE_THIS_VOLATILE (op1)
 		  && (REFERENCE_CLASS_P (op1) || DECL_P (op1)))
-		op1 = build_fold_addr_expr(op1);
+		op1 = build_fold_addr_expr (op1);
 
-	      gimplify_and_add(op1, pre_p);
+	      gimplify_and_add (op1, pre_p);
 	    }
 	  *expr_p = TREE_OPERAND (*expr_p, 0);
 	  ret = GS_OK;
@@ -983,29 +927,29 @@ d_gimplify_expr(tree *expr_p, gimple_seq *pre_p ATTRIBUTE_UNUSED,
 
     case ADDR_EXPR:
       op0 = TREE_OPERAND (*expr_p, 0);
-      // Constructors are not lvalues, so make them one.
+      /* Constructors are not lvalues, so make them one.  */
       if (TREE_CODE (op0) == CONSTRUCTOR)
 	{
-	  TREE_OPERAND (*expr_p, 0) = build_target_expr(op0);
+	  TREE_OPERAND (*expr_p, 0) = build_target_expr (op0);
 	  ret = GS_OK;
 	}
       break;
 
     case UNSIGNED_RSHIFT_EXPR:
-      // Convert op0 to an unsigned type.
+      /* Convert op0 to an unsigned type.  */
       op0 = TREE_OPERAND (*expr_p, 0);
       op1 = TREE_OPERAND (*expr_p, 1);
 
-      type = d_unsigned_type(TREE_TYPE (op0));
+      type = d_unsigned_type (TREE_TYPE (op0));
 
-      *expr_p = convert(TREE_TYPE (*expr_p),
-			build2(RSHIFT_EXPR, type, convert(type, op0), op1));
+      *expr_p = convert (TREE_TYPE (*expr_p),
+			 build2 (RSHIFT_EXPR, type, convert (type, op0), op1));
       ret = GS_OK;
       break;
 
     case FLOAT_MOD_EXPR:
     case IASM_EXPR:
-      gcc_unreachable();
+      gcc_unreachable ();
 
     default:
       break;
@@ -1014,21 +958,10 @@ d_gimplify_expr(tree *expr_p, gimple_seq *pre_p ATTRIBUTE_UNUSED,
   return ret;
 }
 
-
-static void
-d_nametype (Type *t)
-{
-  tree type = build_ctype(t);
-  tree ident = get_identifier (t->toChars());
-  tree decl = build_decl (BUILTINS_LOCATION, TYPE_DECL, ident, type);
-  TYPE_NAME (type) = decl;
-  debug_hooks->type_decl (decl, 0);
-}
-
-// Generate C main() in response to seeing D main().
-// This used to be in libdruntime, but contained a reference to _Dmain which
-// didn't work when druntime was made into a shared library and was linked
-// to a program, such as a C++ program, that didn't have a _Dmain.
+/* Generate C main() in response to seeing D main().
+   This used to be in libdruntime, but contained a reference to _Dmain which
+   didn't work when druntime was made into a shared library and was linked
+   to a program, such as a C++ program, that didn't have a _Dmain.  */
 
 void
 genCmain (Scope *sc)
@@ -1036,46 +969,42 @@ genCmain (Scope *sc)
   if (entrypoint)
     return;
 
-  // The D code to be generated is provided by __entrypoint.di
-  Module *m = Module::load (Loc(), NULL, Id::entrypoint);
+  /* The D code to be generated is provided by __entrypoint.di.  */
+  Module *m = Module::load (Loc (), NULL, Id::entrypoint);
   m->importedFrom = m;
   m->importAll (NULL);
-  m->semantic(NULL);
-  m->semantic2(NULL);
-  m->semantic3(NULL);
+  m->semantic (NULL);
+  m->semantic2 (NULL);
+  m->semantic3 (NULL);
 
-  // We are emitting this straight to object file.
+  /* We are emitting this straight to object file.  */
   entrypoint = m;
   rootmodule = sc->_module;
 }
 
+/* Implements the lang_hooks.parse_file routine for language D.  */
+
 void
-d_parse_file()
+d_parse_file (void)
 {
   if (global.params.verbose)
     {
-      fprintf(global.stdmsg, "binary    %s\n", global.params.argv0);
-      fprintf(global.stdmsg, "version   %s\n", global.version);
+      fprintf (global.stdmsg, "binary    %s\n", global.params.argv0);
+      fprintf (global.stdmsg, "version   %s\n", global.version);
     }
 
-  // Start the main input file, if the debug writer wants it.
+  /* Start the main input file, if the debug writer wants it.  */
   if (debug_hooks->start_end_main_source_file)
     debug_hooks->start_source_file (0, main_input_filename);
 
-  for (TY ty = (TY) 0; ty < TMAX; ty = (TY) (ty + 1))
-    {
-      if (Type::basic[ty] && ty != Terror)
-	d_nametype(Type::basic[ty]);
-    }
-
-  // Create Modules
+  /* Create Module's for all sources we will load.  */
   Modules modules;
-  modules.reserve(num_in_fnames);
+  modules.reserve (num_in_fnames);
 
   /* In this mode, the first file name is supposed to be a duplicate
      of one of the input files.  */
-  if (d_option.fonly && strcmp(d_option.fonly, main_input_filename) != 0)
-    error("-fonly= argument is different from first input file name");
+  if (d_option.fonly && strcmp (d_option.fonly, main_input_filename) != 0)
+    error ("-fonly= argument is different from first input file name");
 
   for (size_t i = 0; i < num_in_fnames; i++)
     {
@@ -1122,33 +1051,33 @@ d_parse_file()
 	}
     }
 
-  // Read files
+  /* Read all D source files.  */
   for (size_t i = 0; i < modules.dim; i++)
     {
       Module *m = modules[i];
-      m->read(Loc());
+      m->read (Loc ());
     }
 
-  // Parse files
+  /* Parse all D source files.  */
   for (size_t i = 0; i < modules.dim; i++)
     {
       Module *m = modules[i];
 
       if (global.params.verbose)
-	fprintf(global.stdmsg, "parse     %s\n", m->toChars());
+	fprintf (global.stdmsg, "parse     %s\n", m->toChars ());
 
       if (!Module::rootModule)
 	Module::rootModule = m;
 
       m->importedFrom = m;
-      m->parse();
-      Target::loadModule(m);
+      m->parse ();
+      Target::loadModule (m);
 
       if (m->isDocFile)
 	{
-	  gendocfile(m);
-	  // Remove m from list of modules
-	  modules.remove(i);
+	  gendocfile (m);
+	  /* Remove M from list of modules.  */
+	  modules.remove (i);
 	  i--;
 	}
     }
@@ -1158,11 +1087,9 @@ d_parse_file()
 
   if (global.params.doHdrGeneration)
     {
-      /* Generate 'header' import files.
-       * Since 'header' import files must be independent of command
-       * line switches and what else is imported, they are generated
-       * before any semantic analysis.
-       */
+      /* Generate 'header' import files.  Since 'header' import files must be
+	 independent of command line switches and what else is imported, they
+	 are generated before any semantic analysis.  */
       for (size_t i = 0; i < modules.dim; i++)
 	{
 	  Module *m = modules[i];
@@ -1170,97 +1097,97 @@ d_parse_file()
 	    continue;
 
 	  if (global.params.verbose)
-	    fprintf(global.stdmsg, "import    %s\n", m->toChars());
+	    fprintf (global.stdmsg, "import    %s\n", m->toChars ());
 
-	  genhdrfile(m);
+	  genhdrfile (m);
 	}
     }
 
   if (global.errors)
     goto had_errors;
 
-  // Load all unconditional imports for better symbol resolving
+  /* Load all unconditional imports for better symbol resolving.  */
   for (size_t i = 0; i < modules.dim; i++)
     {
       Module *m = modules[i];
 
       if (global.params.verbose)
-	fprintf(global.stdmsg, "importall %s\n", m->toChars());
+	fprintf (global.stdmsg, "importall %s\n", m->toChars ());
 
-      m->importAll(NULL);
+      m->importAll (NULL);
     }
 
   if (global.errors)
     goto had_errors;
 
-  // Do semantic analysis
+  /* Do semantic analysis.  */
   for (size_t i = 0; i < modules.dim; i++)
     {
       Module *m = modules[i];
 
       if (global.params.verbose)
-	fprintf(global.stdmsg, "semantic  %s\n", m->toChars());
+	fprintf (global.stdmsg, "semantic  %s\n", m->toChars ());
 
-      m->semantic(NULL);
+      m->semantic (NULL);
     }
 
-  // Do deferred semantic analysis
+  /* Do deferred semantic analysis.  */
   Module::dprogress = 1;
-  Module::runDeferredSemantic();
+  Module::runDeferredSemantic ();
 
   if (Module::deferred.dim)
     {
       for (size_t i = 0; i < Module::deferred.dim; i++)
 	{
 	  Dsymbol *sd = Module::deferred[i];
-	  sd->error("unable to resolve forward reference in definition");
+	  sd->error ("unable to resolve forward reference in definition");
 	}
     }
 
-  // Process all built-in modules or functions now for CTFE.
+  /* Process all built-in modules or functions now for CTFE.  */
   while (builtin_modules.dim != 0)
     {
-      Module *m = builtin_modules.pop();
-      d_maybe_set_builtin(m);
+      Module *m = builtin_modules.pop ();
+      d_maybe_set_builtin (m);
     }
 
-  // Do pass 2 semantic analysis
+  /* Do pass 2 semantic analysis.  */
   for (size_t i = 0; i < modules.dim; i++)
     {
       Module *m = modules[i];
 
       if (global.params.verbose)
-	fprintf(global.stdmsg, "semantic2 %s\n", m->toChars());
+	fprintf (global.stdmsg, "semantic2 %s\n", m->toChars ());
 
-      m->semantic2(NULL);
+      m->semantic2 (NULL);
     }
 
-  Module::runDeferredSemantic2();
+  Module::runDeferredSemantic2 ();
 
   if (global.errors)
     goto had_errors;
 
-  // Do pass 3 semantic analysis
+  /* Do pass 3 semantic analysis.  */
   for (size_t i = 0; i < modules.dim; i++)
     {
       Module *m = modules[i];
 
       if (global.params.verbose)
-	fprintf(global.stdmsg, "semantic3 %s\n", m->toChars());
+	fprintf (global.stdmsg, "semantic3 %s\n", m->toChars ());
 
-      m->semantic3(NULL);
+      m->semantic3 (NULL);
     }
 
-  Module::runDeferredSemantic3();
+  Module::runDeferredSemantic3 ();
 
-  // Check again, incase semantic3 pass loaded any more modules.
+  /* Check again, incase semantic3 pass loaded any more modules.  */
   while (builtin_modules.dim != 0)
     {
-      Module *m = builtin_modules.pop();
-      d_maybe_set_builtin(m);
+      Module *m = builtin_modules.pop ();
+      d_maybe_set_builtin (m);
     }
 
-  // Do not attempt to generate output files if errors or warnings occurred
+  /* Do not attempt to generate output files if errors or warnings occurred.  */
   if (global.errors || global.warnings)
     goto had_errors;
 
@@ -1273,13 +1200,13 @@ d_parse_file()
 
       if (global.params.moduleDepsFile)
 	{
-	  File fdeps(global.params.moduleDepsFile);
-	  fdeps.setbuffer((void *) buf->data, buf->offset);
+	  File fdeps (global.params.moduleDepsFile);
+	  fdeps.setbuffer ((void *) buf->data, buf->offset);
 	  fdeps.ref = 1;
-	  writeFile(Loc(), &fdeps);
+	  writeFile (Loc (), &fdeps);
 	}
       else
-	fprintf(global.stdmsg, "%.*s", (int) buf->offset, (char *) buf->data);
+	fprintf (global.stdmsg, "%.*s", (int) buf->offset, (char *) buf->data);
     }
 
   /* Make dependencies.  */
@@ -1309,7 +1236,7 @@ d_parse_file()
   if (global.params.doJsonGeneration)
     {
       OutBuffer buf;
-      json_generate(&buf, &modules);
+      json_generate (&buf, &modules);
 
       const char *name = global.params.jsonfilename;
 
@@ -1318,7 +1245,7 @@ d_parse_file()
 	  File fjson (FileName::defaultExt (name, global.json_ext));
 	  fjson.setbuffer ((void *) buf.data, buf.offset);
 	  fjson.ref = 1;
-	  writeFile(Loc(), &fjson);
+	  writeFile (Loc (), &fjson);
 	}
       else
 	fprintf (global.stdmsg, "%.*s", (int) buf.offset, (char *) buf.data);
@@ -1330,7 +1257,7 @@ d_parse_file()
       for (size_t i = 0; i < modules.dim; i++)
 	{
 	  Module *m = modules[i];
-	  gendocfile(m);
+	  gendocfile (m);
 	}
     }
 
@@ -1358,7 +1285,7 @@ d_parse_file()
 	continue;
 
       if (global.params.verbose)
-	fprintf(global.stdmsg, "code      %s\n", m->toChars());
+	fprintf (global.stdmsg, "code      %s\n", m->toChars ());
 
       if (!flag_syntax_only)
 	{
@@ -1369,21 +1296,24 @@ d_parse_file()
 	}
     }
 
-  // And end the main input file, if the debug writer wants it.
+  /* And end the main input file, if the debug writer wants it.  */
   if (debug_hooks->start_end_main_source_file)
     debug_hooks->end_source_file (0);
 
  had_errors:
-  // Add D frontend error count to GCC error count to to exit with error status
+  /* Add the D frontend error count to the GCC error count to correctly
+     exit with an error status.  */
   errorcount += (global.errors + global.warnings);
 
-  // Write out globals.
+  /* Write out globals.  */
   d_finish_compilation (vec_safe_address (global_declarations),
 			vec_safe_length (global_declarations));
 }
 
+/* Implements the lang_hooks.types.type_for_mode routine for language D.  */
+
 static tree
-d_type_for_mode(machine_mode mode, int unsignedp)
+d_type_for_mode (machine_mode mode, int unsignedp)
 {
   if (mode == QImode)
     return unsignedp ? ubyte_type_node : byte_type_node;
@@ -1397,130 +1327,134 @@ d_type_for_mode(machine_mode mode, int unsignedp)
   if (mode == DImode)
     return unsignedp ? ulong_type_node : long_type_node;
 
-  if (mode == TYPE_MODE(cent_type_node))
+  if (mode == TYPE_MODE (cent_type_node))
     return unsignedp ? ucent_type_node : cent_type_node;
 
-  if (mode == TYPE_MODE(float_type_node))
+  if (mode == TYPE_MODE (float_type_node))
     return float_type_node;
 
-  if (mode == TYPE_MODE(double_type_node))
+  if (mode == TYPE_MODE (double_type_node))
     return double_type_node;
 
-  if (mode == TYPE_MODE(long_double_type_node))
+  if (mode == TYPE_MODE (long_double_type_node))
     return long_double_type_node;
 
-  if (mode == TYPE_MODE(build_pointer_type(char8_type_node)))
-    return build_pointer_type(char8_type_node);
+  if (mode == TYPE_MODE (build_pointer_type (char8_type_node)))
+    return build_pointer_type (char8_type_node);
 
-  if (mode == TYPE_MODE(build_pointer_type(int_type_node)))
-    return build_pointer_type(int_type_node);
+  if (mode == TYPE_MODE (build_pointer_type (int_type_node)))
+    return build_pointer_type (int_type_node);
 
-  if (COMPLEX_MODE_P(mode))
+  if (COMPLEX_MODE_P (mode))
     {
       machine_mode inner_mode;
       tree inner_type;
 
-      if (mode == TYPE_MODE(complex_float_type_node))
+      if (mode == TYPE_MODE (complex_float_type_node))
 	return complex_float_type_node;
-      if (mode == TYPE_MODE(complex_double_type_node))
+      if (mode == TYPE_MODE (complex_double_type_node))
 	return complex_double_type_node;
-      if (mode == TYPE_MODE(complex_long_double_type_node))
+      if (mode == TYPE_MODE (complex_long_double_type_node))
 	return complex_long_double_type_node;
 
-      inner_mode = (machine_mode) GET_MODE_INNER(mode);
-      inner_type = d_type_for_mode(inner_mode, unsignedp);
+      inner_mode = (machine_mode) GET_MODE_INNER (mode);
+      inner_type = d_type_for_mode (inner_mode, unsignedp);
       if (inner_type != NULL_TREE)
-	return build_complex_type(inner_type);
+	return build_complex_type (inner_type);
     }
-  else if (VECTOR_MODE_P(mode))
+  else if (VECTOR_MODE_P (mode))
     {
-      machine_mode inner_mode = (machine_mode) GET_MODE_INNER(mode);
-      tree inner_type = d_type_for_mode(inner_mode, unsignedp);
+      machine_mode inner_mode = (machine_mode) GET_MODE_INNER (mode);
+      tree inner_type = d_type_for_mode (inner_mode, unsignedp);
       if (inner_type != NULL_TREE)
-	return build_vector_type_for_mode(inner_type, mode);
+	return build_vector_type_for_mode (inner_type, mode);
     }
 
   return 0;
 }
 
+/* Implements the lang_hooks.types.type_for_size routine for language D.  */
+
 static tree
-d_type_for_size(unsigned bits, int unsignedp)
+d_type_for_size (unsigned bits, int unsignedp)
 {
-  if (bits <= TYPE_PRECISION(byte_type_node))
+  if (bits <= TYPE_PRECISION (byte_type_node))
     return unsignedp ? ubyte_type_node : byte_type_node;
 
-  if (bits <= TYPE_PRECISION(short_type_node))
+  if (bits <= TYPE_PRECISION (short_type_node))
     return unsignedp ? ushort_type_node : short_type_node;
 
-  if (bits <= TYPE_PRECISION(int_type_node))
+  if (bits <= TYPE_PRECISION (int_type_node))
     return unsignedp ? uint_type_node : int_type_node;
 
-  if (bits <= TYPE_PRECISION(long_type_node))
+  if (bits <= TYPE_PRECISION (long_type_node))
     return unsignedp ? ulong_type_node : long_type_node;
 
-  if (bits <= TYPE_PRECISION(cent_type_node))
+  if (bits <= TYPE_PRECISION (cent_type_node))
     return unsignedp ? ucent_type_node : cent_type_node;
 
   return 0;
 }
 
+/* Return the signed or unsigned version of TYPE, an integral type, the
+   signedness being specified by UNSIGNEDP.  */
+
 static tree
-d_signed_or_unsigned_type(int unsignedp, tree type)
+d_signed_or_unsigned_type (int unsignedp, tree type)
 {
-  if (!INTEGRAL_TYPE_P(type)
-      || TYPE_UNSIGNED(type) == (unsigned) unsignedp)
+  if (TYPE_UNSIGNED (type) == (unsigned) unsignedp)
     return type;
 
-  if (TYPE_PRECISION(type) == TYPE_PRECISION(cent_type_node))
+  if (TYPE_PRECISION (type) == TYPE_PRECISION (cent_type_node))
     return unsignedp ? ucent_type_node : cent_type_node;
 
-  if (TYPE_PRECISION(type) == TYPE_PRECISION(long_type_node))
+  if (TYPE_PRECISION (type) == TYPE_PRECISION (long_type_node))
     return unsignedp ? ulong_type_node : long_type_node;
 
-  if (TYPE_PRECISION(type) == TYPE_PRECISION(int_type_node))
+  if (TYPE_PRECISION (type) == TYPE_PRECISION (int_type_node))
     return unsignedp ? uint_type_node : int_type_node;
 
-  if (TYPE_PRECISION(type) == TYPE_PRECISION(short_type_node))
+  if (TYPE_PRECISION (type) == TYPE_PRECISION (short_type_node))
     return unsignedp ? ushort_type_node : short_type_node;
 
-  if (TYPE_PRECISION(type) == TYPE_PRECISION(byte_type_node))
+  if (TYPE_PRECISION (type) == TYPE_PRECISION (byte_type_node))
     return unsignedp ? ubyte_type_node : byte_type_node;
 
-  return type;
+  return signed_or_unsigned_type_for (unsignedp, type);
 }
+
+/* Return the unsigned version of TYPE, an integral type.  */
 
 tree
-d_unsigned_type(tree type)
+d_unsigned_type (tree type)
 {
-  return d_signed_or_unsigned_type(1, type);
+  return d_signed_or_unsigned_type (1, type);
 }
+
+/* Return the signed version of TYPE, an integral type.  */
 
 tree
-d_signed_type(tree type)
+d_signed_type (tree type)
 {
-  return d_signed_or_unsigned_type(0, type);
+  return d_signed_or_unsigned_type (0, type);
 }
 
-// All promotions for variable arguments are handled by the frontend.
+/* Implements the lang_hooks.types.type_promotes_to routine for language D.
+   All promotions for variable arguments are handled by the D frontend.  */
 
 static tree
-d_type_promotes_to(tree type)
+d_type_promotes_to (tree type)
 {
   return type;
 }
 
-
-// This is called by the backend before parsing.  Need to make this do
-// something or lang_hooks.clear_binding_stack (lhd_clear_binding_stack)
-// loops forever.
+/* Implements the lang_hooks.decls.global_bindings_p routine for language D.
+   Return true if we are in the global binding level.  */
 
 static bool
-d_global_bindings_p()
+d_global_bindings_p (void)
 {
-  if (current_binding_level == global_binding_level)
-    return true;
-
-  return !global_binding_level;
+  return (current_binding_level == global_binding_level);
 }
 
 /* Return global_context, but create it first if need be.  */
@@ -1537,7 +1471,8 @@ get_global_context (void)
   return global_context;
 }
 
-/* Record DECL as belonging to the current lexical scope.  */
+/* Implements the lang_hooks.decls.pushdecl routine for language D.
+   Record DECL as belonging to the current lexical scope.  */
 
 tree
 d_pushdecl (tree decl)
@@ -1554,7 +1489,7 @@ d_pushdecl (tree decl)
 
   /* Put decls on list in reverse order.  */
   if (TREE_STATIC (decl) || d_global_bindings_p ())
-    vec_safe_push(global_declarations, decl);
+    vec_safe_push (global_declarations, decl);
   else
     {
       TREE_CHAIN (decl) = current_binding_level->names;
@@ -1564,10 +1499,11 @@ d_pushdecl (tree decl)
   return decl;
 }
 
-// Return the list of declarations of the current level.
+/* Implements the lang_hooks.decls.getdecls routine for language D.
+   Return the list of declarations of the current level.  */
 
 static tree
-d_getdecls()
+d_getdecls (void)
 {
   if (current_binding_level)
     return current_binding_level->names;
@@ -1576,14 +1512,15 @@ d_getdecls()
 }
 
 
-// Get the alias set corresponding to a type or expression.
-// Return -1 if we don't do anything special.
+/* Implements the lang_hooks.get_alias_set routine for language D.
+   Get the alias set corresponding the type or expression T.
+   Return -1 if we don't do anything special.  */
 
 static alias_set_type
 d_get_alias_set (tree t)
 {
-  // Permit type-punning when accessing a union, provided the access
-  // is directly through the union.
+  /* Permit type-punning when accessing a union, provided the access
+     is directly through the union.  */
   for (tree u = t; handled_component_p (u); u = TREE_OPERAND (u, 0))
     {
       if (TREE_CODE (u) == COMPONENT_REF
@@ -1591,36 +1528,41 @@ d_get_alias_set (tree t)
 	return 0;
     }
 
-  // That's all the expressions we handle.
+  /* That's all the expressions we handle.  */
   if (!TYPE_P (t))
     return get_alias_set (TREE_TYPE (t));
 
-  // For now in D, assume everything aliases everything else,
-  // until we define some solid rules.
+  /* For now in D, assume everything aliases everything else,
+     until we define some solid rules.  */
   return 0;
 }
+
+/* Implements the lang_hooks.types_compatible_p routine for language D.
+   Compares two types for equivalence in the D programming language.
+   This routine should only return 1 if it is sure, even though the frontend
+   should have already ensured that all types are compatible before handing
+   over the parsed ASTs to the code generator.  */
 
 static int
-d_types_compatible_p (tree t1, tree t2)
+d_types_compatible_p (tree x, tree y)
 {
-  /* Is compatible if types are equivalent */
-  if (TYPE_MAIN_VARIANT (t1) == TYPE_MAIN_VARIANT (t2))
-    return 1;
+  Type *tx = TYPE_LANG_FRONTEND (x);
+  Type *ty = TYPE_LANG_FRONTEND (y);
 
-  /* Is compatible if aggregates are same type or share the same
-     attributes. The frontend should have already ensured that types
-     aren't wildly different anyway... */
-  if (AGGREGATE_TYPE_P (t1) && AGGREGATE_TYPE_P (t2)
-      && TREE_CODE (t1) == TREE_CODE (t2))
+  /* Try validating the types in the frontend first.  */
+  if (tx != NULL && ty != NULL)
     {
-      if (TREE_CODE (t1) == ARRAY_TYPE)
-	return (TREE_TYPE (t1) == TREE_TYPE (t2));
-
-      return (TYPE_ATTRIBUTES (t1) == TYPE_ATTRIBUTES (t2));
+      if (tx->implicitConvTo (ty) || ty->implicitConvTo (tx))
+	return true;
     }
-  /* else */
-  return 0;
+
+  /* Fallback on using type kind and size comparison.  E.g: all dynamic arrays
+     are distinct types in D, but are VIEW_CONVERT compatible.  */
+  return (TREE_CODE (x) == TREE_CODE (y)
+	  && TYPE_SIZE (x) == TYPE_SIZE (y));
 }
+
+/* Implements the lang_hooks.finish_incomplete_decl routine for language D.  */
 
 static void
 d_finish_incomplete_decl (tree decl)
@@ -1629,9 +1571,8 @@ d_finish_incomplete_decl (tree decl)
     {
       /* D allows zero-length declarations.  Such a declaration ends up with
 	 DECL_SIZE (t) == NULL_TREE which is what the backend function
-	 assembler_variable checks.  This could change in later versions...
-
-	 Maybe all of these variables should be aliased to one symbol... */
+	 assembler_variable checks.  This could change in later versions, or
+	 maybe all of these variables should be aliased to one symbol. */
       if (DECL_SIZE (decl) == 0)
 	{
 	  DECL_SIZE (decl) = bitsize_zero_node;
@@ -1640,21 +1581,21 @@ d_finish_incomplete_decl (tree decl)
     }
 }
 
-
-// Return the true debug type for TYPE.
+/* Implements the lang_hooks.types.classify_record routine for language D.
+   Return the true debug type for TYPE.  */
 
 static classify_record
 d_classify_record (tree type)
 {
-  Type *dtype = TYPE_LANG_FRONTEND (type);
+  Type *t = TYPE_LANG_FRONTEND (type);
 
-  if (dtype && dtype->ty == Tclass)
+  if (t && t->ty == Tclass)
     {
-      TypeClass *tclass = (TypeClass *) dtype;
+      TypeClass *tc = (TypeClass *) t;
 
-      // extern(C++) interfaces get emitted as classes.
-      if (tclass->sym->isInterfaceDeclaration()
-	  && !tclass->sym->isCPPinterface())
+      /* extern(C++) interfaces get emitted as classes.  */
+      if (tc->sym->isInterfaceDeclaration ()
+	  && !tc->sym->isCPPinterface ())
 	return RECORD_IS_INTERFACE;
 
       return RECORD_IS_CLASS;
@@ -1663,7 +1604,8 @@ d_classify_record (tree type)
   return RECORD_IS_STRUCT;
 }
 
-/* Determine the size of our tcc_constant or tcc_exceptional nodes.  */
+/* Implements the lang_hooks.tree_size routine for language D.
+   Determine the size of our tcc_constant or tcc_exceptional nodes.  */
 
 static size_t
 d_tree_size (tree_code code)
@@ -1678,7 +1620,8 @@ d_tree_size (tree_code code)
     }
 }
 
-/*  */
+/* Implements the lang_hooks.print_xnode routine for language D.  */
+
 static void
 d_print_xnode (FILE *file, tree node, int indent)
 {
@@ -1732,7 +1675,8 @@ build_lang_decl (Declaration *d)
   return ld;
 }
 
-/* Replace the DECL_LANG_SPECIFIC field of NODE with a copy.  */
+/* Implements the lang_hooks.dup_lang_specific_decl routine for language D.
+   Replace the DECL_LANG_SPECIFIC field of NODE with a copy.  */
 
 static void
 d_dup_lang_specific_decl (tree node)
@@ -1745,7 +1689,8 @@ d_dup_lang_specific_decl (tree node)
   DECL_LANG_SPECIFIC (node) = ld;
 }
 
-// This preserves trees we create from the garbage collector.
+/* This preserves trees we create from the garbage collector.  */
+
 static GTY(()) tree d_keep_list = NULL_TREE;
 
 void
@@ -1754,11 +1699,13 @@ d_keep (tree t)
   d_keep_list = tree_cons (NULL_TREE, t, d_keep_list);
 }
 
+/* Implements the lang_hooks.eh_personality routine for language D.
+   Return the GDC personality function decl.  */
+
 static GTY(()) tree d_eh_personality_decl;
 
-/* Return the GDC personality function decl.  */
 static tree
-d_eh_personality()
+d_eh_personality (void)
 {
   if (!d_eh_personality_decl)
     {
@@ -1768,16 +1715,18 @@ d_eh_personality()
   return d_eh_personality_decl;
 }
 
+/* Implements the lang_hooks.eh_runtime_type routine for language D.  */
+
 static tree
-d_build_eh_type_type (tree type)
+d_build_eh_runtime_type (tree type)
 {
-  Type *dtype = TYPE_LANG_FRONTEND (type);
+  Type *t = TYPE_LANG_FRONTEND (type);
 
-  if (dtype)
-    dtype = dtype->toBasetype ();
+  if (t != NULL)
+    t = t->toBasetype ();
 
-  gcc_assert (dtype && dtype->ty == Tclass);
-  ClassDeclaration *cd = ((TypeClass *) dtype)->sym;
+  gcc_assert (t != NULL && t->ty == Tclass);
+  ClassDeclaration *cd = ((TypeClass *) t)->sym;
   tree decl;
 
   if (cd->cpp)
@@ -1788,6 +1737,67 @@ d_build_eh_type_type (tree type)
   return convert (ptr_type_node, build_address (decl));
 }
 
+/* Definitions for our language-specific hooks.  */
+
+#undef LANG_HOOKS_NAME
+#undef LANG_HOOKS_INIT
+#undef LANG_HOOKS_INIT_TS
+#undef LANG_HOOKS_INIT_OPTIONS
+#undef LANG_HOOKS_INIT_OPTIONS_STRUCT
+#undef LANG_HOOKS_OPTION_LANG_MASK
+#undef LANG_HOOKS_HANDLE_OPTION
+#undef LANG_HOOKS_POST_OPTIONS
+#undef LANG_HOOKS_PARSE_FILE
+#undef LANG_HOOKS_COMMON_ATTRIBUTE_TABLE
+#undef LANG_HOOKS_ATTRIBUTE_TABLE
+#undef LANG_HOOKS_GET_ALIAS_SET
+#undef LANG_HOOKS_TYPES_COMPATIBLE_P
+#undef LANG_HOOKS_BUILTIN_FUNCTION
+#undef LANG_HOOKS_REGISTER_BUILTIN_TYPE
+#undef LANG_HOOKS_FINISH_INCOMPLETE_DECL
+#undef LANG_HOOKS_GIMPLIFY_EXPR
+#undef LANG_HOOKS_CLASSIFY_RECORD
+#undef LANG_HOOKS_TREE_SIZE
+#undef LANG_HOOKS_PRINT_XNODE
+#undef LANG_HOOKS_DUP_LANG_SPECIFIC_DECL
+#undef LANG_HOOKS_EH_PERSONALITY
+#undef LANG_HOOKS_EH_RUNTIME_TYPE
+#undef LANG_HOOKS_PUSHDECL
+#undef LANG_HOOKS_GETDECLS
+#undef LANG_HOOKS_GLOBAL_BINDINGS_P
+#undef LANG_HOOKS_TYPE_FOR_MODE
+#undef LANG_HOOKS_TYPE_FOR_SIZE
+#undef LANG_HOOKS_TYPE_PROMOTES_TO
+
+#define LANG_HOOKS_NAME			    "GNU D"
+#define LANG_HOOKS_INIT			    d_init
+#define LANG_HOOKS_INIT_TS		    d_init_ts
+#define LANG_HOOKS_INIT_OPTIONS		    d_init_options
+#define LANG_HOOKS_INIT_OPTIONS_STRUCT	    d_init_options_struct
+#define LANG_HOOKS_OPTION_LANG_MASK	    d_option_lang_mask
+#define LANG_HOOKS_HANDLE_OPTION	    d_handle_option
+#define LANG_HOOKS_POST_OPTIONS		    d_post_options
+#define LANG_HOOKS_PARSE_FILE		    d_parse_file
+#define LANG_HOOKS_COMMON_ATTRIBUTE_TABLE   d_langhook_common_attribute_table
+#define LANG_HOOKS_ATTRIBUTE_TABLE          d_langhook_attribute_table
+#define LANG_HOOKS_GET_ALIAS_SET	    d_get_alias_set
+#define LANG_HOOKS_TYPES_COMPATIBLE_P	    d_types_compatible_p
+#define LANG_HOOKS_BUILTIN_FUNCTION	    d_builtin_function
+#define LANG_HOOKS_REGISTER_BUILTIN_TYPE    d_register_builtin_type
+#define LANG_HOOKS_FINISH_INCOMPLETE_DECL   d_finish_incomplete_decl
+#define LANG_HOOKS_GIMPLIFY_EXPR	    d_gimplify_expr
+#define LANG_HOOKS_CLASSIFY_RECORD	    d_classify_record
+#define LANG_HOOKS_TREE_SIZE		    d_tree_size
+#define LANG_HOOKS_PRINT_XNODE		    d_print_xnode
+#define LANG_HOOKS_DUP_LANG_SPECIFIC_DECL   d_dup_lang_specific_decl
+#define LANG_HOOKS_EH_PERSONALITY	    d_eh_personality
+#define LANG_HOOKS_EH_RUNTIME_TYPE	    d_build_eh_runtime_type
+#define LANG_HOOKS_PUSHDECL		    d_pushdecl
+#define LANG_HOOKS_GETDECLS		    d_getdecls
+#define LANG_HOOKS_GLOBAL_BINDINGS_P	    d_global_bindings_p
+#define LANG_HOOKS_TYPE_FOR_MODE	    d_type_for_mode
+#define LANG_HOOKS_TYPE_FOR_SIZE	    d_type_for_size
+#define LANG_HOOKS_TYPE_PROMOTES_TO	    d_type_promotes_to
 
 struct lang_hooks lang_hooks = LANG_HOOKS_INITIALIZER;
 

--- a/gcc/d/d-spec.c
+++ b/gcc/d/d-spec.c
@@ -290,9 +290,9 @@ lang_specific_driver (cl_decoded_option **in_decoded_options,
 #endif
 
   /* Make sure to have room for the trailing NULL argument.
-   * needstdcxx might add -lstdcxx
-   * libphobos adds -Bstatic -lphobos -ldruntime -Bdynamic
-   * only_source adds 1 more arg, also maybe add -o */
+     - needstdcxx might add `-lstdcxx'
+     - libphobos adds `-Bstatic -lphobos -ldruntime -Bdynamic'
+     - only_source adds 1 more arg, also maybe add `-o'.  */
   num_args = argc + need_stdcxx + shared_libgcc + (library > 0) * 4 + 2;
   new_decoded_options = XNEWVEC (cl_decoded_option, num_args);
 

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -412,7 +412,6 @@ extern tree build_attributes (Expressions *);
 /* In d-builtins.cc.  */
 extern const attribute_spec d_langhook_attribute_table[];
 extern const attribute_spec d_langhook_common_attribute_table[];
-extern const attribute_spec d_langhook_format_attribute_table[];
 
 extern tree d_builtin_function (tree);
 extern void d_init_builtins (void);

--- a/gcc/d/types.cc
+++ b/gcc/d/types.cc
@@ -585,6 +585,8 @@ public:
       case Tdchar:	  t->ctype = char32_type_node; break;
       default:		  gcc_unreachable ();
       }
+
+    TYPE_NAME (t->ctype) = get_identifier (t->toChars());
   }
 
 
@@ -648,6 +650,7 @@ public:
       inner = build_ctype (Type::tuns8);
 
     t->ctype = build_vector_type (inner, nunits);
+    TYPE_NAME (t->ctype) = get_identifier (t->toChars());
     layout_type (t->ctype);
   }
 


### PR DESCRIPTION
Removes the format attributes table.  Since GCC-4.8, warnings have been silenced for attributes marked `ATTR_FLAG_BUILT_IN`, and so these aren't strictly needed any more.  Same goes for other attributes that are not handled by the gcc backend.

The other common attributes remain as they either have a desired side-effect (sets a tree flag) or may be used by the backend (their absence means they will not be found when `lookup_attribute` is called).