### PR TITLE
Bug 186: Wrong value with struct/union + this construction

### DIFF
--- a/gcc/testsuite/gdc.test/runnable/gdc.d
+++ b/gcc/testsuite/gdc.test/runnable/gdc.d
@@ -863,6 +863,61 @@ void test183()
 
 /******************************************/
 
+// Bug 186
+
+struct S186
+{
+    union
+    {
+        struct
+        {
+            ubyte fieldA;
+            byte  fieldB = -1;
+            byte fieldC = -1;
+        }
+        size_t _complete;
+    }
+
+    this(size_t complete)
+    {
+        this._complete = complete;
+    }
+}
+
+void check186(in S186 obj, byte fieldB)
+{
+    assert(obj.fieldA == 2);
+    assert(obj.fieldB == 0);
+    assert(obj.fieldC == 0);
+    assert(obj._complete == 2);
+    assert(fieldB == 0);
+}
+
+void test186a(size_t val)
+{
+    S186 obj = S186(val);
+    check186(obj, obj.fieldB);
+
+    assert(obj.fieldA == 2);
+    assert(obj.fieldB == 0);
+    assert(obj.fieldC == 0);
+    assert(obj._complete == 2);
+
+    obj = S186(val);
+    check186(obj, obj.fieldB);
+
+    assert(obj.fieldA == 2);
+    assert(obj.fieldB == 0);
+    assert(obj.fieldC == 0);
+    assert(obj._complete == 2);
+}
+
+void test186()
+{
+    test186a(2);
+}
+/******************************************/
+
 // Bug 187
 
 align(1) struct S187b
@@ -1200,6 +1255,7 @@ void main()
     test133();
     test141();
     test179();
+    test186();
     test187();
     test196();
     test198();


### PR DESCRIPTION
Similar to #187, however this probably was fixed properly when joining the old toDt and toElem passes into one.  Which does explicit field initialization (`{.foo=123}`) instead of a flat list of values and offsets.

Also like #187, I don't think I could ever reproduce this locally either.  Just adding a test case anyway, because struct var construction and struct var assignment are two different kinds of operations in the codegen (the former is first initialized with `S.init` and it's object passed to `S.__ctor`, the latter is a call to `S.__ctor` with a new temporary/literal).

https://bugzilla.gdcproject.org/show_bug.cgi?id=186