### PR TITLE
Bug 204: SEGV when generating gimple thunk for bodyless function

### DIFF
--- a/gcc/testsuite/gdc.test/compilable/gdc204.d
+++ b/gcc/testsuite/gdc.test/compilable/gdc204.d
@@ -1,0 +1,11 @@
+// PERMUTE_ARGS:
+
+interface I204
+{
+      void f();
+}
+
+class C204 : I204
+{
+      void f();
+}


### PR DESCRIPTION
I suspect this was fixed in #409 - adding test for it.