### PR TITLE
Allow all vector types to be included in builtins module.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2017-06-10  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-builtins.cc (build_frontend_type): Allow all vector types to be
+	included in builtins module.
+
 2017-06-09  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* types.cc (TypeVisitor::visit(TypeStruct)): Let struct alignment

--- a/gcc/d/d-builtins.cc
+++ b/gcc/d/d-builtins.cc
@@ -200,11 +200,6 @@ build_frontend_type (tree type)
 	  if (dtype->nextOf ()->isTypeBasic () == NULL)
 	    break;
 
-	  /* Support only 64bit, 128bit, and 256bit vectors for now.  */
-	  unsigned size = dtype->size ();
-	  if (size != 8 && size != 16 && size != 32)
-	    break;
-
 	  dtype = (new TypeVector (Loc (), dtype))->addMod (mod);
 	  builtin_converted_decls.safe_push (builtin_data (dtype, type));
 	  return dtype;


### PR DESCRIPTION
Originally, we were constrained by the frontend including a hard coded check for these fixed sizes.  Now the check is handled by `Target::checkVectorType` on our side, so this can be relaxed (the backend should never give us anything that it can't support).

On x86_64, this means all 512-bit vector builtins will now be exposed.

https://gist.github.com/ibuclaw/0334d3eb6b314b1644cdedddb510c6ca