### PR TITLE
Bug 218: ICE: in make_ssa_name_fn, at tree-ssanames.c:151

### DIFF
--- a/gcc/testsuite/gdc.test/compilable/gdc218.d
+++ b/gcc/testsuite/gdc.test/compilable/gdc218.d
@@ -1,0 +1,38 @@
+struct S218a
+{
+    this(int* pdata_)
+    {
+        pdata = pdata_;
+    }
+
+    void opIndexAssign(int, size_t) { }
+    int* pdata;
+};
+
+struct S218
+{
+    S218a getS218a()
+    {
+        return S218a(data.ptr);
+    }
+
+    int[] data;
+    int[] tab2;
+};
+
+S218 f()
+{
+    S218 r;
+
+    for(int i = 0; i < 1; ++i)
+        r.getS218a()[0] = 0;
+
+    return r;
+}
+
+S218 var;
+
+static this()
+{
+    var = f();
+}


### PR DESCRIPTION
Another CNR bug, adding test anyway, as it may have been fixed unwittingly, or was a backend bug from an earlier gcc version.

https://bugzilla.gdcproject.org/show_bug.cgi?id=218