### PR TITLE
Don't call invariant() on interface objects

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2017-06-15  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* expr.cc (ExprVisitor::visit(AssertExp)): Don't call invariant on
+	interface objects.
+
 2017-06-12  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* expr.cc (ExprVisitor::visit(DelegateExp)): Convert object to right


### PR DESCRIPTION
- Remove the special condition branch for COM classes.
- Don't convert interfaces to `Object`.  No idea why that was there, suspect it goes back to 2004.
- Refactor, remove logic duplication.