### PR TITLE
Testsuite clean-up / improvements

### DIFF
--- a/gcc/testsuite/gdc.test/compilable/gdc170.d
+++ b/gcc/testsuite/gdc.test/compilable/gdc170.d
@@ -1,5 +1,3 @@
-// EXTRA_FILES: imports/gdc170a.d
-
 import imports.gdc170a;
 
 void main()

--- a/gcc/testsuite/gdc.test/compilable/gdc256.d
+++ b/gcc/testsuite/gdc.test/compilable/gdc256.d
@@ -1,4 +1,4 @@
-// EXTRA_FILES: imports/gdc256a.d imports/gdcpkg256/package.d
+// REQUIRED_ARGS: -Icompilable/imports
 module gdc256;
 
 import imports.gdcpkg256 : gdc256a;

--- a/gcc/testsuite/gdc.test/compilable/test11225a.d
+++ b/gcc/testsuite/gdc.test/compilable/test11225a.d
@@ -1,4 +1,3 @@
-// EXTRA_FILES: imports/test11225b.d imports/test11225c.d
 /*
 TEST_OUTPUT:
 ---

--- a/gcc/testsuite/gdc.test/compilable/test6395.d
+++ b/gcc/testsuite/gdc.test/compilable/test6395.d
@@ -1,6 +1,5 @@
 // REQUIRED_ARGS: -c -Icompilable/extra-files
 // EXTRA_SOURCES: b6395.d
-// EXTRA_FILES: extra-files/c6395.d
 
 // 6395
 

--- a/gcc/testsuite/gdc.test/compilable/test7190.d
+++ b/gcc/testsuite/gdc.test/compilable/test7190.d
@@ -1,6 +1,5 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -c -Icompilable/extra-files
-// EXTRA_FILES: extra-files/example7190/controllers/HomeController.d extra-files/example7190/models/HomeModel.d extra-files/serenity7190/core/Controller.d extra-files/serenity7190/core/Model.d
 
 import example7190.controllers.HomeController;
 import example7190.models.HomeModel;

--- a/gcc/testsuite/gdc.test/compilable/test9057.d
+++ b/gcc/testsuite/gdc.test/compilable/test9057.d
@@ -1,6 +1,5 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -c -Icompilable/extra-files
-// EXTRA_FILES: extra-files/imp9057.d extra-files/imp9057_2.d
 
 struct Bug9057(T)
 {

--- a/gcc/testsuite/gdc.test/compilable/testDIP37.d
+++ b/gcc/testsuite/gdc.test/compilable/testDIP37.d
@@ -1,6 +1,5 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -c -Icompilable/extra-files
-// EXTRA_FILES: extra-files/pkgDIP37/datetime/common.d extra-files/pkgDIP37/datetime/package.d
 
 void test1()
 {

--- a/gcc/testsuite/gdc.test/compilable/testDIP37_10302.d
+++ b/gcc/testsuite/gdc.test/compilable/testDIP37_10302.d
@@ -1,7 +1,6 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -c -Icompilable/extra-files
 // EXTRA_SOURCES: extra-files/pkgDIP37_10302/liba.d extra-files/pkgDIP37_10302/libb.d
-// EXTRA_FILES: extra-files/pkgDIP37_10302/package.d
 
 module test;
 import pkgDIP37_10302;

--- a/gcc/testsuite/gdc.test/compilable/testDIP37_10354.d
+++ b/gcc/testsuite/gdc.test/compilable/testDIP37_10354.d
@@ -1,6 +1,5 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -o- -Icompilable/extra-files
-// EXTRA_FILES: extra-files/pkgDIP37_10354/mbar.d extra-files/pkgDIP37_10354/mfoo.d extra-files/pkgDIP37_10354/package.d
 
 module testDIP37_10354;
 import pkgDIP37_10354.mfoo;

--- a/gcc/testsuite/gdc.test/d_do_test.exp
+++ b/gcc/testsuite/gdc.test/d_do_test.exp
@@ -22,16 +22,16 @@ load_lib gdc-dg.exp
 # Convert DMD arguments to GDC equivalent
 #
 
-proc gdc-convert-args { args } {
+proc gdc-convert-args { base args } {
     set out ""
 
     foreach arg [split [lindex $args 0] " "] {
         # List of switches kept in ASCII collated order.
         if { [regexp -- {^-I([\w+/-]+)} $arg pattern path] } {
-            lappend out "-I$path"
+            lappend out "-I$base/$path"
 
         } elseif { [regexp -- {^-J([\w+/-]+)} $arg pattern path] } {
-            lappend out "-J$path"
+            lappend out "-J$base/$path"
 
         } elseif [string match "-allinst" $arg] {
             lappend out "-femit-templates"
@@ -154,7 +154,7 @@ proc gdc-copy-extra { base extra } {
 #   EXECUTE_ARGS:       Parameters to add to the execution of the test.
 #   EXTRA_SOURCES:      List of extra sources to build and link along with
 #                       the test.
-#   EXTRA_FILES:        List of extra files to copy for the test.
+#   EXTRA_FILES:        List of extra files to copy for the test runs.
 #   PERMUTE_ARGS:       The set of arguments to permute in multiple compiler
 #                       invocations.  An empty set means only one permutation
 #                       with no arguments.
@@ -201,7 +201,7 @@ proc dmd2dg { base test } {
 
         } elseif [regexp -- {PERMUTE_ARGS\s*:\s*(.*)} $copy_line match args] {
             # PERMUTE_ARGS is handled by gdc-do-test.
-            set PERMUTE_ARGS [gdc-convert-args $args]
+            set PERMUTE_ARGS [gdc-convert-args $base $args]
             regsub -- {PERMUTE_ARGS.*$} $copy_line "" out_line
 
         } elseif [regexp -- {EXECUTE_ARGS\s*:\s*(.*)} $copy_line match args] {
@@ -213,7 +213,7 @@ proc dmd2dg { base test } {
 
         } elseif [regexp -- {REQUIRED_ARGS\s*:\s*(.*)} $copy_line match args] {
             # Convert all listed arguments to from dmd to gdc-style.
-            set new_option "{ dg-additional-options \"[gdc-convert-args $args]\" }"
+            set new_option "{ dg-additional-options \"[gdc-convert-args $base $args]\" }"
             regsub -- {REQUIRED_ARGS.*$} $copy_line $new_option out_line
 
         } elseif [regexp -- {EXTRA_SOURCES\s*:\s*(.*)} $copy_line match sources] {
@@ -337,10 +337,8 @@ proc gdc-do-test { } {
         if { [lsearch "d" $ext] == -1 } {
             continue
         }
-
         # Convert to DG test.
-        set imports [file dirname $test]
-        set imports [format "-I%s -I%s/imports" $imports $imports]
+        set imports [format "-I%s/%s" $base $dir]
         set filename [dmd2dg $base $dir/$name.$ext]
 
         if { $dir == "runnable" } {

--- a/gcc/testsuite/gdc.test/d_do_test.exp
+++ b/gcc/testsuite/gdc.test/d_do_test.exp
@@ -18,7 +18,10 @@
 # Load support procs.
 load_lib gdc-dg.exp
 
+#
 # Convert DMD arguments to GDC equivalent
+#
+
 proc gdc-convert-args { args } {
     set out ""
 
@@ -34,7 +37,7 @@ proc gdc-convert-args { args } {
             lappend out "-femit-templates"
 
         } elseif { [string match "-boundscheck" $arg]
-                 || [ string match "-boundscheck=on" $arg] } {
+                 || [string match "-boundscheck=on" $arg] } {
             lappend out "-fbounds-check"
 
         } elseif { [string match "-boundscheck=off" $arg]
@@ -122,18 +125,17 @@ proc gdc-convert-args { args } {
 
 proc gdc-copy-extra { base extra } {
     # Split base, folder/file.
-    set type [file dirname $extra ]
+    set type [file dirname $extra]
 
     # print "Filename: $base - $extra"
 
     set fdin [open $base/$extra r]
     fconfigure $fdin -encoding binary
 
-    file mkdir [file dirname $extra ]
-    set fdout [ open $extra w]
+    file mkdir $type
+    set fdout [open $extra w]
     fconfigure $fdout -encoding binary
 
-    # print "[file dirname $test ]"
     while { [gets $fdin copy_line] >= 0 } {
         set out_line $copy_line
         puts $fdout $out_line
@@ -145,8 +147,23 @@ proc gdc-copy-extra { base extra } {
     return $extra
 }
 
-
+#
 # Translate DMD test directives to dejagnu equivalent.
+#
+#   COMPILE_SEPARATELY: Not handled.
+#   EXECUTE_ARGS:       Parameters to add to the execution of the test.
+#   EXTRA_SOURCES:      List of extra sources to build and link along with
+#                       the test.
+#   EXTRA_FILES:        List of extra files to copy for the test.
+#   PERMUTE_ARGS:       The set of arguments to permute in multiple compiler
+#                       invocations.  An empty set means only one permutation
+#                       with no arguments.
+#   TEST_OUTPUT:        The output expected from the compilation.
+#   POST_SCRIPT:        Not handled.
+#   REQUIRED_ARGS:      Arguments to add to the compiler command line.
+#   DISABLED:           Not handled.
+#
+
 proc dmd2dg { base test } {
     global DEFAULT_DFLAGS
     global PERMUTE_ARGS
@@ -163,27 +180,24 @@ proc dmd2dg { base test } {
     set fdin [open $base/$test r]
     #fconfigure $fdin -encoding binary
 
-    file mkdir [file dirname $test]
-    set fdout [ open $test w]
+    file mkdir $type
+    set fdout [open $test w]
     #fconfigure $fdout -encoding binary
-
-    # print "[file dirname $test ]"
 
     # Add specific options for test type
 
-    # DMD's testsuite is exteremly verbose.
-    #  dg-prune-ouput generates pass.
+    # DMD's testsuite is extremely verbose, compiler messages from constructs
+    # such as pragma(msg, ...) would otherwise cause tests to fail.
     set out_line "// { dg-prune-output .* }"
     puts $fdout $out_line
 
-    # Since GCC 6-20160131 blank lines are not allowed in the
-    # output by default.
+    # Since GCC 6-20160131 blank lines are not allowed in the output by default.
     dg-allow-blank-lines-in-output { 1 }
 
     # Compilable files are successful if an output is generated.
     # Fail compilable are successful if an output is not generated.
     # Runnable must compile, link, and return 0 to be successful by default.
-    switch [ file dirname $test ] {
+    switch [file dirname $test] {
         compilable {
             set out_line "// { dg-final { output-exists } }"
             puts $fdout $out_line
@@ -193,7 +207,6 @@ proc dmd2dg { base test } {
             set out_line "// { dg-final { output-exists-not } }"
             puts $fdout $out_line
         }
-
     }
 
     while { [gets $fdin copy_line] >= 0 } {
@@ -318,12 +331,12 @@ proc gdc-do-test { } {
         regexp -- "(.*)/(.+)/(.+)\.(.+)$" $test match base dir name ext
 
         # Skip invalid test directory
-        if {[lsearch "runnable compilable fail_compilation" $dir] == -1} {
+        if { [lsearch "runnable compilable fail_compilation" $dir] == -1 } {
             continue
         }
 
         # Skip invalid test extensions
-        if {[lsearch "d" $ext] == -1} {
+        if { [lsearch "d" $ext] == -1 } {
             continue
         }
 
@@ -332,7 +345,7 @@ proc gdc-do-test { } {
         set imports [format "-I%s -I%s/imports" $imports $imports]
         set filename [dmd2dg $base $dir/$name.$ext]
 
-        if {$dir == "runnable"} {
+        if { $dir == "runnable" } {
             append PERMUTE_ARGS " $SHARED_OPTION"
         }
         set options [gdc-permute-options $PERMUTE_ARGS]

--- a/gcc/testsuite/gdc.test/d_do_test.exp
+++ b/gcc/testsuite/gdc.test/d_do_test.exp
@@ -187,66 +187,64 @@ proc dmd2dg { base test } {
     while { [gets $fdin copy_line] >= 0 } {
         set out_line $copy_line
 
-        # PERMUTE_ARGS.  Must be handled separately
-        if [regexp -- {PERMUTE_ARGS\s*:\s*(.*)} $copy_line match args] {
-            set PERMUTE_ARGS [gdc-convert-args $args]
-            continue
-        }
-
-        # COMPILE_SEPARATELY. Not handled.
         if [regexp -- {COMPILE_SEPARATELY} $copy_line] {
-            continue
-        }
+            # COMPILE_SEPARATELY is not handled.
+            regsub -- {COMPILE_SEPARATELY.*$} $copy_line "" out_line
 
-        # POST_SCRIPT. not handled
-        if [regexp -- {POST_SCRIPT} $copy_line] {
-            continue
-        }
+        } elseif [regexp -- {DISABLED} $copy_line] {
+            # DISABLED is not handled.
+            regsub -- {DISABLED.*$} $copy_line "" out_line
 
-        # Can be handled with dg directives.
+        } elseif [regexp -- {POST_SCRIPT} $copy_line] {
+            # POST_SCRIPT is not handled
+            regsub -- {POST_SCRIPT.*$} $copy_line "" out_line
 
-        # Handle EXECUTE_ARGS option.
-        if [regexp -- {EXECUTE_ARGS\s*:\s*(.*)} $copy_line match args] {
+        } elseif [regexp -- {PERMUTE_ARGS\s*:\s*(.*)} $copy_line match args] {
+            # PERMUTE_ARGS is handled by gdc-do-test.
+            set PERMUTE_ARGS [gdc-convert-args $args]
+            regsub -- {PERMUTE_ARGS.*$} $copy_line "" out_line
+
+        } elseif [regexp -- {EXECUTE_ARGS\s*:\s*(.*)} $copy_line match args] {
+            # EXECUTE_ARGS is handled by gdc_load.
             foreach arg $args {
                 lappend EXECUTE_ARGS $arg
             }
-            continue
-        }
+            regsub -- {EXECUTE_ARGS.*$} $copy_line "" out_line
 
-        # Handle EXTRA_SOURCES option
-        if [regexp -- {EXTRA_SOURCES\s*:\s*(.*)} $copy_line match sources] {
-            # Iterate imports and convert
+        } elseif [regexp -- {REQUIRED_ARGS\s*:\s*(.*)} $copy_line match args] {
+            # Convert all listed arguments to from dmd to gdc-style.
+            set new_option "{ dg-additional-options \"[gdc-convert-args $args]\" }"
+            regsub -- {REQUIRED_ARGS.*$} $copy_line $new_option out_line
+
+        } elseif [regexp -- {EXTRA_SOURCES\s*:\s*(.*)} $copy_line match sources] {
+            # Copy all sources to the testsuite build directory.
             foreach import $sources {
                 # print "Import: $base $type/$import"
                 gdc-copy-extra $base "$type/$import"
             }
-            set out_line "// { dg-additional-sources \"$sources\" }"
-        }
+            set new_option "{ dg-additional-sources \"$sources\" }"
+            regsub -- {EXTRA_SOURCES.*$} $copy_line $new_option out_line
 
-        # Handle EXTRA_CPP_SOURCES option
-        if [regexp -- {EXTRA_CPP_SOURCES\s*:\s*(.*)} $copy_line match sources] {
-            # Iterate imports and convert
+        } elseif [regexp -- {EXTRA_CPP_SOURCES\s*:\s*(.*)} $copy_line match sources] {
+            # Copy all sources to the testsuite build directory.
             foreach import $sources {
                 # print "Import: $base $type/$import"
                 gdc-copy-extra $base "$type/$import"
             }
-            set out_line "// { dg-additional-sources \"$sources\" }"
-        }
+            set new_option "{ dg-additional-sources \"$sources\" }"
+            regsub -- {EXTRA_CPP_SOURCES.*$} $copy_line $new_option out_line
 
-        # Handle EXTRA_FILES option
-        if [regexp -- {EXTRA_FILES\s*:\s*(.*)} $copy_line match files] {
-            # Iterate imports and convert
+        } elseif [regexp -- {EXTRA_FILES\s*:\s*(.*)} $copy_line match files] {
+            # Copy all sources to the testsuite build directory.
             foreach import $files {
                 # print "Import: $base $type/$import"
                 gdc-copy-extra $base "$type/$import"
             }
-            set out_line "// { dg-additional-files \"$files\" }"
+            set new_option "{ dg-additional-files \"$files\" }"
+            regsub -- {EXTRA_FILES.*$} $copy_line $new_option out_line
+
         }
 
-        # REQUIRED_ARGS.
-        if [regexp -- {REQUIRED_ARGS\s*:\s*(.*)} $copy_line match args] {
-            set out_line "// { dg-additional-options \"[gdc-convert-args $args]\" }"
-        }
         puts $fdout $out_line
     }
 

--- a/gcc/testsuite/gdc.test/d_do_test.exp
+++ b/gcc/testsuite/gdc.test/d_do_test.exp
@@ -184,31 +184,6 @@ proc dmd2dg { base test } {
     set fdout [open $test w]
     #fconfigure $fdout -encoding binary
 
-    # Add specific options for test type
-
-    # DMD's testsuite is extremely verbose, compiler messages from constructs
-    # such as pragma(msg, ...) would otherwise cause tests to fail.
-    set out_line "// { dg-prune-output .* }"
-    puts $fdout $out_line
-
-    # Since GCC 6-20160131 blank lines are not allowed in the output by default.
-    dg-allow-blank-lines-in-output { 1 }
-
-    # Compilable files are successful if an output is generated.
-    # Fail compilable are successful if an output is not generated.
-    # Runnable must compile, link, and return 0 to be successful by default.
-    switch [file dirname $test] {
-        compilable {
-            set out_line "// { dg-final { output-exists } }"
-            puts $fdout $out_line
-        }
-
-        fail_compilation {
-            set out_line "// { dg-final { output-exists-not } }"
-            puts $fdout $out_line
-        }
-    }
-
     while { [gets $fdin copy_line] >= 0 } {
         set out_line $copy_line
 
@@ -273,6 +248,31 @@ proc dmd2dg { base test } {
             set out_line "// { dg-additional-options \"[gdc-convert-args $args]\" }"
         }
         puts $fdout $out_line
+    }
+
+    # Add specific options for test type
+
+    # DMD's testsuite is extremely verbose, compiler messages from constructs
+    # such as pragma(msg, ...) would otherwise cause tests to fail.
+    set out_line "// { dg-prune-output .* }"
+    puts $fdout $out_line
+
+    # Since GCC 6-20160131 blank lines are not allowed in the output by default.
+    dg-allow-blank-lines-in-output { 1 }
+
+    # Compilable files are successful if an output is generated.
+    # Fail compilable are successful if an output is not generated.
+    # Runnable must compile, link, and return 0 to be successful by default.
+    switch [file dirname $test] {
+        compilable {
+            set out_line "// { dg-final { output-exists } }"
+            puts $fdout $out_line
+        }
+
+        fail_compilation {
+            set out_line "// { dg-final { output-exists-not } }"
+            puts $fdout $out_line
+        }
     }
 
     close $fdin

--- a/gcc/testsuite/gdc.test/fail_compilation/ice11513a.d
+++ b/gcc/testsuite/gdc.test/fail_compilation/ice11513a.d
@@ -1,4 +1,3 @@
-// EXTRA_FILES: imports/ice11513x.d
 /*
 TEST_OUTPUT:
 ---

--- a/gcc/testsuite/gdc.test/fail_compilation/ice11513b.d
+++ b/gcc/testsuite/gdc.test/fail_compilation/ice11513b.d
@@ -1,4 +1,3 @@
-// EXTRA_FILES: imports/ice11513y.d
 /*
 TEST_OUTPUT:
 ---

--- a/gcc/testsuite/gdc.test/fail_compilation/ice7782.d
+++ b/gcc/testsuite/gdc.test/fail_compilation/ice7782.d
@@ -1,4 +1,3 @@
-// EXTRA_FILES: imports/ice7782range.d imports/ice7782algorithm.d
 import imports.ice7782algorithm;
 import imports.ice7782range. imports.ice7782math;
 

--- a/gcc/testsuite/lib/gdc-dg.exp
+++ b/gcc/testsuite/lib/gdc-dg.exp
@@ -16,7 +16,7 @@
 
 load_lib gcc-dg.exp
 
-# Define go callbacks for dg.exp.
+# Define gdc callbacks for dg.exp.
 
 proc gdc-dg-test { prog do_what extra_tool_flags } {
     set result \
@@ -34,8 +34,11 @@ proc gdc-dg-prune { system text } {
 
 # Utility routines.
 
+#
 # Modified dg-runtest that can cycle through a list of optimization options
 # as c-torture does.
+#
+
 proc gdc-dg-runtest { testcases default-extra-flags } {
     global runtests
     global TORTURE_OPTIONS

--- a/gcc/testsuite/lib/gdc.exp
+++ b/gcc/testsuite/lib/gdc.exp
@@ -17,6 +17,7 @@
 #
 # gdc support library routines
 #
+
 load_lib prune.exp
 load_lib gcc-defs.exp
 load_lib timeout.exp
@@ -25,7 +26,6 @@ load_lib target-libpath.exp
 #
 # GDC_UNDER_TEST is the compiler under test.
 #
-
 
 set gdc_compile_options ""
 


### PR DESCRIPTION
- Set dg options in-place of where the dmd-style options are.
- Append additional options at the end of the file, not the beginning.
- Add testsuite base path in translated `-I` and `-J` options.
- Remove most cases of using `EXTRA_FILES` - all what's left are files that are read by runnable tests.

This means we don't interfere with `#!/bin/rdmd` tests, and should allow a possible feature where we use `dg-error` or `dg-warning` to check that compiler diagnostic messages match what is in `TEST_OUTPUT`.