### PR TITLE
Use diagnostic_report_diagnostic directly, remove xvasprintf.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,15 @@
+2017-06-17  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-diagnostic.cc (expand_format): New function.
+	(d_diagnostic_report_diagnostic): New function.
+	(error, verror): Update format attributes.  Use function
+	d_diagnostic_report_diagnostic instead of xvasprintf.
+	(errorSupplemental, verrorSupplemental): Likewise.
+	(warning, vwarning): Likewise.
+	(warningSupplemental, vwarningSupplemental): Likewise.
+	(deprecation, vdeprecation): Likewise.
+	(deprecationSupplemental, vdeprecationSupplemental): Likewise.
+
 2017-06-15  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* expr.cc (ExprVisitor::visit(AssertExp)): Don't call invariant on


### PR DESCRIPTION
Using `xvasprinf()` bypassed gcc i18n translation of diagnostic messages.

This is intended for errors or warnings from gdc itself, not so much errors from the dmd frontend.  Reason being that it will eventually be switched to D, therefore not picked up by the gettext scan.

If turns out that `pp_format` doesn't support padded format conversions (`%08x`).  So added a routine to strip those out.  Whilst I was there, also added support for recognizing the new ``"`code %s highlight`"`` quotes that are now present in DMD.  These are translated to `"%<code %s highlight%>"`, which is treated as a quoted string.