### PR TITLE
Issue 4682: FPE caused by integer division overflow

### DIFF
--- a/gcc/d/dfrontend/constfold.c
+++ b/gcc/d/dfrontend/constfold.c
@@ -450,7 +450,24 @@ UnionExp Div(Type *type, Expression *e1, Expression *e2)
         if (n2 == 0)
         {
             e2->error("divide by 0");
-            n2 = 1;
+            new(&ue) ErrorExp();
+            return ue;
+        }
+        if (n2 == -1 && !type->isunsigned())
+        {
+            // Check for int.min / -1
+            if (n1 == 0xFFFFFFFF80000000UL && type->toBasetype()->ty != Tint64)
+            {
+                e2->error("integer overflow: int.min / -1");
+                new(&ue) ErrorExp();
+                return ue;
+            }
+            else if (n1 == 0x8000000000000000L) // long.min / -1
+            {
+                e2->error("integer overflow: long.min / -1");
+                new(&ue) ErrorExp();
+                return ue;
+            }
         }
         if (e1->type->isunsigned() || e2->type->isunsigned())
             n = ((dinteger_t) n1) / ((dinteger_t) n2);
@@ -505,20 +522,23 @@ UnionExp Mod(Type *type, Expression *e1, Expression *e2)
         if (n2 == 0)
         {
             e2->error("divide by 0");
-            n2 = 1;
+            new(&ue) ErrorExp();
+            return ue;
         }
         if (n2 == -1 && !type->isunsigned())
         {
             // Check for int.min % -1
             if (n1 == 0xFFFFFFFF80000000ULL && type->toBasetype()->ty != Tint64)
             {
-                e2->error("integer overflow: int.min % -1");
-                n2 = 1;
+                e2->error("integer overflow: int.min %% -1");
+                new(&ue) ErrorExp();
+                return ue;
             }
             else if (n1 == 0x8000000000000000LL) // long.min % -1
             {
-                e2->error("integer overflow: long.min % -1");
-                n2 = 1;
+                e2->error("integer overflow: long.min %% -1");
+                new(&ue) ErrorExp();
+                return ue;
             }
         }
         if (e1->type->isunsigned() || e2->type->isunsigned())

--- a/gcc/d/dfrontend/init.c
+++ b/gcc/d/dfrontend/init.c
@@ -890,6 +890,8 @@ Initializer *ExpInitializer::semantic(Scope *sc, Type *t, NeedInterpret needInte
         {
             exp = exp->implicitCastTo(sc, t);
         }
+        if (!global.gag && olderrors != global.errors)
+            return this;
         exp = exp->ctfeInterpret();
     }
     else

--- a/gcc/testsuite/gdc.test/fail_compilation/test4682.d
+++ b/gcc/testsuite/gdc.test/fail_compilation/test4682.d
@@ -1,0 +1,13 @@
+/*
+TEST_OUTPUT:
+----
+fail_compilation/test4682.d(10): Error: integer overflow: int.min / -1
+fail_compilation/test4682.d(11): Error: integer overflow: long.min / -1
+fail_compilation/test4682.d(12): Error: integer overflow: int.min % -1
+fail_compilation/test4682.d(13): Error: integer overflow: long.min % -1
+----
+*/
+auto a = int.min / -1;
+auto b = long.min / -1;
+auto c = int.min % -1;
+auto d = long.min % -1;

--- a/gcc/testsuite/gdc.test/fail_compilation/test4682a.d
+++ b/gcc/testsuite/gdc.test/fail_compilation/test4682a.d
@@ -1,0 +1,13 @@
+/*
+TEST_OUTPUT:
+----
+fail_compilation/test4682a.d(10): Error: divide by 0
+fail_compilation/test4682a.d(11): Error: divide by 0
+fail_compilation/test4682a.d(12): Error: divide by 0
+fail_compilation/test4682a.d(13): Error: divide by 0
+----
+*/
+auto a = int.min / 0;
+auto b = long.min / 0;
+auto c = int.min % 0;
+auto d = long.min % 0;


### PR DESCRIPTION
Picked up the wrong format from gettext.  The patch also comes with fix for an ICE, so included that as well.