### PR TITLE
Bug 171: Right shift broken with promotions

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2017-06-20  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* expr.cc (ExprVisitor::visit(BinAssignExp)): Strip promotions from
+	both signed and unsigned rshift assignments.
+
 2017-06-17  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-diagnostic.cc (expand_format): New function.

--- a/gcc/d/expr.cc
+++ b/gcc/d/expr.cc
@@ -862,19 +862,17 @@ public:
 	break;
 
       case TOKshrass:
-	code = RSHIFT_EXPR;
-	break;
-
       case TOKushrass:
-	/* The left operand of `>>>=' does not undergo integral promotions
-	   before shifting.  Strip off any just incase.  */
+	/* Use the original lhs type before it was promoted.  The left operand
+	   of `>>>=' does not undergo integral promotions before shifting.
+	   Strip off casts just incase anyway.  */
 	while (e1b->op == TOKcast)
 	  {
 	    CastExp *ce = (CastExp *) e1b;
 	    gcc_assert (same_type_p (ce->type, ce->to));
 	    e1b = ce->e1;
 	  }
-	code = UNSIGNED_RSHIFT_EXPR;
+	code = (e->op == TOKshrass) ? RSHIFT_EXPR : UNSIGNED_RSHIFT_EXPR;
 	break;
 
       default:

--- a/gcc/testsuite/gdc.test/runnable/gdc.d
+++ b/gcc/testsuite/gdc.test/runnable/gdc.d
@@ -770,6 +770,45 @@ void test142()
 
 /******************************************/
 
+// Bug 171
+
+void test171a()
+{
+    int count = 0;
+    short a = -1;
+    while (a != 0)
+    {
+        a >>>= 1;
+        count++;
+        assert(count <= 16);
+    }
+}
+
+void test171b()
+{
+    uint[3] lhs = [99, 201, 300],
+            rhs = [-1, 0, 0];
+    long t = 0;
+
+    for (int i = 0; i < 3; i++)
+    {
+        t += lhs[i];
+        t -= rhs[i];
+        lhs[i] = cast(uint) t;
+        t >>= uint.sizeof * 8;
+    }
+
+    assert(lhs == [100, 200, 300]);
+}
+
+void test171()
+{
+    test171a();
+    test171b();
+}
+
+/******************************************/
+
 // Bug 179
 
 struct S179a


### PR DESCRIPTION
Looks like another side of bug 171, this time affecting signed shift if the front-end decides to add promotions.

Also adding test from the original report, as it wasn't done so.

https://bugzilla.gdcproject.org/show_bug.cgi?id=171