### PR TITLE
Remove memset for global.params.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -3,6 +3,10 @@
 	* d-lang.cc (d_parse_file): Print all predefined version identifiers
 	if verbose.
 
+2017-06-24  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-frontend.cc (Global::_init): Remove memset for global.params.
+
 2017-06-20  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* expr.cc (ExprVisitor::visit(BinAssignExp)): Strip promotions from

--- a/gcc/d/d-frontend.cc
+++ b/gcc/d/d-frontend.cc
@@ -58,8 +58,6 @@ Global::_init (void)
 
   this->stdmsg = stderr;
   this->errorLimit = flag_max_errors;
-
-  memset (&this->params, 0, sizeof (Param));
 }
 
 /* Start gagging. Return the current number of gagged errors.  */


### PR DESCRIPTION
Because of `Strings runargs`, the Param struct is infact non-POD.  Using memset causes build failure in bootstrap due to new `-Wclass-memaccess` option (added to trunk last week).