### PR TITLE
Turn off ASM_VOLATILE_P on extended assembler statements only if pure

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,10 @@
 2017-06-25  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* toir.cc (IRVisitor::visit(ExtAsmStatement)): Set ASM_VOLATILE_P only
+	if statement is not marked with pure attribute.
+
+2017-06-25  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* d-lang.cc (d_parse_file): Print all predefined version identifiers
 	if verbose.
 

--- a/gcc/d/dfrontend/parse.c
+++ b/gcc/d/dfrontend/parse.c
@@ -5748,7 +5748,7 @@ Statement *Parser::parseStatement(int flags, const utf8_t** endPtr, Loc *pEndloc
                         // If the first token is a string, parse as extended asm.
                         if (! toklist)
                         {
-                            s = parseExtAsm();
+                            s = parseExtAsm(stc);
                             statements->push(s);
                             continue;
                         }
@@ -5963,7 +5963,7 @@ Lerror:
  *     asm { StringLiterals [ : InputOperands [ : OutputOperands [ : Clobbers [ : GotoLabels ] ] ] ] }
  */
 
-Statement *Parser::parseExtAsm()
+Statement *Parser::parseExtAsm(StorageClass stc)
 {
     Expressions *args = NULL;
     Identifiers *names = NULL;
@@ -6025,7 +6025,7 @@ Statement *Parser::parseExtAsm()
   Ldone:
     check(TOKsemicolon);
 
-    return new ExtAsmStatement(loc, insn, args, names,
+    return new ExtAsmStatement(loc, stc, insn, args, names,
                                constraints, outputargs, clobbers, labels);
 }
 #endif

--- a/gcc/d/dfrontend/parse.h
+++ b/gcc/d/dfrontend/parse.h
@@ -129,7 +129,7 @@ public:
     /** endPtr used for documented unittests */
     Statement *parseStatement(int flags, const utf8_t** endPtr = NULL, Loc *pEndloc = NULL);
 #ifdef IN_GCC
-    Statement *parseExtAsm();
+    Statement *parseExtAsm(StorageClass stc);
     int parseExtAsmOperands(Expressions *args, Identifiers *names, Expressions *constraints);
     Expressions *parseExtAsmClobbers();
     Identifiers *parseExtAsmGotoLabels();

--- a/gcc/d/dfrontend/statement.c
+++ b/gcc/d/dfrontend/statement.c
@@ -2037,12 +2037,13 @@ Statement *AsmStatement::syntaxCopy()
 #ifdef IN_GCC
 /************************ ExtAsmStatement ***************************************/
 
-ExtAsmStatement::ExtAsmStatement(Loc loc, Expression *insn,
+ExtAsmStatement::ExtAsmStatement(Loc loc, StorageClass stc, Expression *insn,
                                  Expressions *args, Identifiers *names,
                                  Expressions *constraints, int outputargs,
                                  Expressions *clobbers, Identifiers *labels)
         : Statement(loc)
 {
+    this->stc = stc;
     this->insn = insn;
     this->args = args;
     this->names = names;
@@ -2059,7 +2060,7 @@ Statement *ExtAsmStatement::syntaxCopy()
     Expressions *c_constraints = Expression::arraySyntaxCopy(constraints);
     Expressions *c_clobbers = Expression::arraySyntaxCopy(clobbers);
 
-    return new ExtAsmStatement(loc, insn->syntaxCopy(), c_args, names,
+    return new ExtAsmStatement(loc, stc, insn->syntaxCopy(), c_args, names,
                                c_constraints, outputargs, c_clobbers, labels);
 }
 

--- a/gcc/d/dfrontend/statement.h
+++ b/gcc/d/dfrontend/statement.h
@@ -739,6 +739,7 @@ public:
 class ExtAsmStatement : public Statement
 {
 public:
+    StorageClass stc;
     Expression *insn;
     Expressions *args;
     Identifiers *names;
@@ -748,9 +749,10 @@ public:
     Identifiers *labels;
     GotoStatements *gotos;
 
-    ExtAsmStatement(Loc loc, Expression *insn, Expressions *args,
-                    Identifiers *names, Expressions *constraints,
-                    int outputargs, Expressions *clobbers, Identifiers *labels);
+    ExtAsmStatement(Loc loc, StorageClass stc, Expression *insn,
+                    Expressions *args, Identifiers *names,
+                    Expressions *constraints, int outputargs,
+                    Expressions *clobbers, Identifiers *labels);
     Statement *syntaxCopy();
 
     void accept(Visitor *v) { v->visit(this); }

--- a/gcc/d/toir.cc
+++ b/gcc/d/toir.cc
@@ -1419,8 +1419,8 @@ public:
     if (s->args == NULL && s->clobbers == NULL)
       ASM_INPUT_P (exp) = 1;
 
-    /* Asm statements without outputs are treated as volatile.  */
-    ASM_VOLATILE_P (exp) = (s->outputargs == 0);
+    /* Asm statements are treated as volatile unless 'pure'.  */
+    ASM_VOLATILE_P (exp) = !(s->stc & STCpure);
 
     add_stmt (exp);
   }


### PR DESCRIPTION
This makes it so that:
```
asm { "syscall"
    : "=a" (result)
    : "a" (code), "D" (arg1), "S" (arg2), "d" (arg3);
}
```
Is marked as volatile (assumed to always have side effects), and so will not subjected to DCE by the optimizer.

Whereas:
```
asm pure { "syscall"
    : "=a" (result)
    : "a" (code), "D" (arg1), "S" (arg2), "d" (arg3);
}
```
Could be removed by the DCE if `result` is unused anywhere in the program.

---

I have no idea what I was thinking when I made the change
```
ASM_VOLATILE_P (exp) = (s->outputargs == 0)
```
in the 2.065 merge.  Then again, I'll probably say the same again a few years down the line when I look at this again.

What I'm certain is that asm statements were a little more awkward in to use gdc before https://dlang.org/changelog/2.067.0.html#asm-attributes.  And knowing the storage class information is certainly useful for us to know anyway.