### PR TITLE
Put the TypeInfo name field into a static var.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,13 @@
 2017-06-25  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-codegen.cc (d_array_string): Add staticp parameter.
+	(d_assert_call): Update call to d_array_string.
+	* d-tree.h (d_array_string): Updated signature.
+	* typeinfo.cc (TypeInfoVisitor::visit): Update calls to
+	d_array_string.
+
+2017-06-25  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* toir.cc (IRVisitor::visit(ExtAsmStatement)): Set ASM_VOLATILE_P only
 	if statement is not marked with pure attribute.
 

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -447,7 +447,7 @@ extern tree build_float_cst (const real_t &, Type *);
 extern tree d_array_length (tree);
 extern tree d_array_ptr (tree);
 extern tree d_array_value (tree, tree, tree);
-extern tree d_array_string (const char *);
+extern tree d_array_string (const char *, bool);
 extern tree get_array_length (tree, Type *);
 extern tree build_class_binfo (tree, ClassDeclaration *);
 extern tree build_interface_binfo (tree, ClassDeclaration *, unsigned &);

--- a/gcc/d/typeinfo.cc
+++ b/gcc/d/typeinfo.cc
@@ -530,7 +530,7 @@ public:
     this->layout_field (memtype);
 
     /* Name of the enum declaration.  */
-    this->layout_field (d_array_string (ed->toPrettyChars ()));
+    this->layout_field (d_array_string (ed->toPrettyChars (), true));
 
     /* Default initializer for enum.  */
     if (ed->members && !d->tinfo->isZeroInit ())
@@ -654,7 +654,7 @@ public:
     this->layout_field (build_typeinfo (ti->next));
 
     /* Mangled name of function declaration.  */
-    this->layout_field (d_array_string (d->tinfo->deco));
+    this->layout_field (d_array_string (d->tinfo->deco, true));
   }
 
   /* Layout of TypeInfo_Delegate is:
@@ -675,7 +675,7 @@ public:
     this->layout_field (build_typeinfo (ti->next));
 
     /* Mangled name of delegate declaration.  */
-    this->layout_field (d_array_string (d->tinfo->deco));
+    this->layout_field (d_array_string (d->tinfo->deco, true));
   }
 
   /* Layout of ClassInfo/TypeInfo_Class is:
@@ -723,7 +723,7 @@ public:
 	const char *name = cd->ident->toChars ();
 	if (!(strlen (name) > 9 && memcmp (name, "TypeInfo_", 9) == 0))
 	  name = cd->toPrettyChars ();
-	this->layout_field (d_array_string (name));
+	this->layout_field (d_array_string (name, true));
 
 	/* The vtable of the class declaration.  */
 	value = d_array_value (array_type_node, size_int (cd->vtbl.dim),
@@ -826,7 +826,7 @@ public:
 	this->layout_field (null_array_node);
 
 	/* Name of the interface declaration.  */
-	this->layout_field (d_array_string (cd->toPrettyChars ()));
+	this->layout_field (d_array_string (cd->toPrettyChars (), true));
 
 	/* No vtable for interface declaration.  */
 	this->layout_field (null_array_node);
@@ -959,7 +959,7 @@ public:
       }
 
     /* Name of the struct declaration.  */
-    this->layout_field (d_array_string (sd->toPrettyChars ()));
+    this->layout_field (d_array_string (sd->toPrettyChars (), true));
 
     /* Default initializer for struct.  */
     tree ptr = (sd->zeroInit) ? null_pointer_node :


### PR DESCRIPTION
Using https://issues.dlang.org/show_bug.cgi?id=14758 with the compiler switches:
```
$ gdc test.d object.d -fno-moduleinfo -Wl,--gc-sections -fdata-sections -ffunction-sections -nophoboslib -nostdlib -o test -Os
```

Before:
```
$ objdump -s -j .rodata a.out 

test:     file format elf64-x86-64

Contents of section .rodata:
 40065d 74657374 2e546573 74436c61 73733100  test.TestClass1.
 40066d 74657374 2e546573 74436c61 73733200  test.TestClass2.
 40067d 74657374 2e546573 74436c61 73733300  test.TestClass3.
 40068d 74657374 2e546573 74436c61 73733400  test.TestClass4.
 40069d 74657374 2e546573 74436c61 73733500  test.TestClass5.
 4006ad 74657374 2e546573 74436c61 73733600  test.TestClass6.
 4006bd 74657374 2e546573 74436c61 73733700  test.TestClass7.
 4006cd 74657374 2e546573 74436c61 73733800  test.TestClass8.
 4006dd 74657374 2e546573 74436c61 73733900  test.TestClass9.
 4006ed 48656c6c 6f0a00                      Hello..         
```
After:
```
$ objdump -s -j .rodata test

test:     file format elf64-x86-64

Contents of section .rodata:
 40010e 48656c6c 6f0a00                      Hello..   
```

@JinShil ^^