### PR TITLE
Don't default to "run" if cannot run executables in testsuite.

### DIFF
--- a/gcc/d/patches/patch-targetdm-8.x
+++ b/gcc/d/patches/patch-targetdm-8.x
@@ -1244,7 +1244,7 @@ The following OS versions are implemented:
 +#include "config.h"
 +#include "system.h"
 +#include "coretypes.h"
-+#include "tm.h
++#include "tm.h"
 +#include "d/d-target.h"
 +#include "d/d-target-def.h"
 +

--- a/gcc/testsuite/gdc.test/d_do_test.exp
+++ b/gcc/testsuite/gdc.test/d_do_test.exp
@@ -311,6 +311,11 @@ proc gdc-do-test { } {
         #set DEFAULT_DFLAGS "-O2"
     }
 
+    # Execute the runnable tests where possible.
+    set run_runnable [check_runtime can_execute_runnable {
+        int main() { return 0; }
+    }]
+
     # These are special options to use on testcase, and override DEFAULT_DFLAGS
     global PERMUTE_ARGS
 
@@ -350,7 +355,12 @@ proc gdc-do-test { } {
             runnable {
                 for { set i 0 } { $i<[llength $options] } { incr i } {
                     set TORTURE_OPTIONS [lindex $options $i]
-                    set dg-do-what-default "run"
+                    if { $run_runnable } {
+                        set dg-do-what-default "run"
+                    } else {
+                        #set dg-do-what-default "compile"
+                        set dg-do-what-default "assemble"
+                    }
                     gdc-dg-runtest $filename $imports
                 }
             }
@@ -358,6 +368,7 @@ proc gdc-do-test { } {
             compilable {
                 for { set i 0 } { $i<[llength $options] } { incr i } {
                     set TORTURE_OPTIONS [lindex $options $i]
+                    #set dg-do-what-default "compile"
                     set dg-do-what-default "assemble"
                     gdc-dg-runtest $filename "$imports"
                 }
@@ -367,7 +378,6 @@ proc gdc-do-test { } {
                 for { set i 0 } { $i<[llength $options] } { incr i } {
                     set TORTURE_OPTIONS [lindex $options $i]
                     set dg-do-what-default "assemble"
-                    #set dg-do-what-default "compile"
                     gdc-dg-runtest $filename $imports
                 }
             }

--- a/gcc/testsuite/lib/gdc.exp
+++ b/gcc/testsuite/lib/gdc.exp
@@ -118,53 +118,56 @@ proc gdc_link_flags { paths } {
     verbose "shared lib extension: $shlib_ext"
 
     if { $gccpath != "" } {
-      if { [file exists "${gccpath}/libphobos/src/.libs/libgphobos.a"] \
-           || [file exists "${gccpath}/libphobos/src/.libs/libgphobos.${shlib_ext}"] } {
-          append flags "-L${gccpath}/libphobos/src/.libs -B${gccpath}/libphobos/src "
-          append ld_library_path ":${gccpath}/libphobos/src/.libs"
-      }
-      if { [file exists "${gccpath}/libphobos/libdruntime/.libs/libgdruntime.a"] \
-           || [file exists "${gccpath}/libphobos/libdruntime/.libs/libgdruntime.${shlib_ext}"] } {
-          append flags "-L${gccpath}/libphobos/libdruntime/.libs "
-          append ld_library_path ":${gccpath}/libphobos/libdruntime/.libs"
-      }
-      # Static linking is default. If only the shared lib is available adjust
-      # flags to always use it. If both are available, set SHARED_OPTION which
-      # will be added to PERMUTE_ARGS
-      if { [file exists "${gccpath}/libphobos/libdruntime/.libs/libgdruntime.${shlib_ext}"] } {
-          if { [file exists "${gccpath}/libphobos/libdruntime/.libs/libgdruntime.a"] } {
-              set SHARED_OPTION "-shared-libphobos"
-          } else {
-              append flags "-shared-libphobos "
-          }
-      }
-      if [file exists "${gccpath}/libiberty/libiberty.a"] {
-          append flags "-L${gccpath}/libiberty "
-      }
-      # For the tests that mix C++ and D, we should try and handle this better.
-      if { [file exists "${gccpath}/libstdc++-v3/src/.libs/libstdc++.a"] \
-           || [file exists "${gccpath}/libstdc++-v3/src/.libs/libstdc++.${shlib_ext}"] } {
-          append flags "-L${gccpath}/libstdc++-v3/src/.libs "
-          append ld_library_path ":${gccpath}/libstdc++-v3/src/.libs"
-      }
-      append ld_library_path [gcc-set-multilib-library-path $GDC_UNDER_TEST]
-    } else {
-      global tool_root_dir
+        # Path to libgphobos.spec.
+        append flags "-B${gccpath}/libphobos/src "
 
-      set libphobos [lookfor_file ${tool_root_dir} libgphobos]
-      if { $libphobos != "" } {
-          append flags "-L${libphobos} "
-          append ld_library_path ":${libphobos}"
-      }
-      set libdruntime [lookfor_file ${tool_root_dir} libgdruntime]
-      if { $libdruntime != "" } {
-          append flags "-L${libdruntime} "
-          append ld_library_path ":${libdruntime}"
-      }
-      set libiberty [lookfor_file ${tool_root_dir} libiberty]
-      if { $libiberty != "" } {
-          append flags "-L${libiberty} "
-      }
+        if { [file exists "${gccpath}/libphobos/src/.libs/libgphobos.a"] \
+             || [file exists "${gccpath}/libphobos/src/.libs/libgphobos.${shlib_ext}"] } {
+            append flags "-L${gccpath}/libphobos/src/.libs "
+            append ld_library_path ":${gccpath}/libphobos/src/.libs"
+        }
+        if { [file exists "${gccpath}/libphobos/libdruntime/.libs/libgdruntime.a"] \
+             || [file exists "${gccpath}/libphobos/libdruntime/.libs/libgdruntime.${shlib_ext}"] } {
+            append flags "-L${gccpath}/libphobos/libdruntime/.libs "
+            append ld_library_path ":${gccpath}/libphobos/libdruntime/.libs"
+        }
+        # Static linking is default. If only the shared lib is available adjust
+        # flags to always use it. If both are available, set SHARED_OPTION which
+        # will be added to PERMUTE_ARGS
+        if { [file exists "${gccpath}/libphobos/libdruntime/.libs/libgdruntime.${shlib_ext}"] } {
+            if { [file exists "${gccpath}/libphobos/libdruntime/.libs/libgdruntime.a"] } {
+                set SHARED_OPTION "-shared-libphobos"
+            } else {
+                append flags "-shared-libphobos "
+            }
+        }
+        if [file exists "${gccpath}/libiberty/libiberty.a"] {
+            append flags "-L${gccpath}/libiberty "
+        }
+        # For the tests that mix C++ and D, we should try and handle this better.
+        if { [file exists "${gccpath}/libstdc++-v3/src/.libs/libstdc++.a"] \
+             || [file exists "${gccpath}/libstdc++-v3/src/.libs/libstdc++.${shlib_ext}"] } {
+            append flags "-L${gccpath}/libstdc++-v3/src/.libs "
+            append ld_library_path ":${gccpath}/libstdc++-v3/src/.libs"
+        }
+        append ld_library_path [gcc-set-multilib-library-path $GDC_UNDER_TEST]
+    } else {
+        global tool_root_dir
+
+        set libphobos [lookfor_file ${tool_root_dir} libgphobos]
+        if { $libphobos != "" } {
+            append flags "-B${libphobos} -L${libphobos} "
+            append ld_library_path ":${libphobos}"
+        }
+        set libdruntime [lookfor_file ${tool_root_dir} libgdruntime]
+        if { $libdruntime != "" } {
+            append flags "-L${libdruntime} "
+            append ld_library_path ":${libdruntime}"
+        }
+        set libiberty [lookfor_file ${tool_root_dir} libiberty]
+        if { $libiberty != "" } {
+            append flags "-L${libiberty} "
+        }
     }
 
     set_ld_library_path_env_vars


### PR DESCRIPTION
Fixed patch for failing s390x targets.

Also updated the buildbot scripts so that building phobos may be skipped, which should allow for a few more to become green knock-wood (building phobos can be re-enabled later).