### PR TITLE
Fix version(linux) not emitted for PPC and Alpha

### DIFF
--- a/gcc/d/patches/patch-gcc-8.x
+++ b/gcc/d/patches/patch-gcc-8.x
@@ -2,6 +2,23 @@ This implements D language support in the GCC back end, and adds
 relevant documentation about the GDC front end.
 ---
 
+--- a/gcc/config/powerpcspe/powerpcspe.c
++++ b/gcc/config/powerpcspe/powerpcspe.c
+@@ -31921,11 +31921,12 @@ rs6000_output_function_epilogue (FILE *file,
+ 	 use language_string.
+ 	 C is 0.  Fortran is 1.  Pascal is 2.  Ada is 3.  C++ is 9.
+ 	 Java is 13.  Objective-C is 14.  Objective-C++ isn't assigned
+-	 a number, so for now use 9.  LTO, Go and JIT aren't assigned numbers
+-	 either, so for now use 0.  */
++	 a number, so for now use 9.  LTO, Go, D and JIT aren't assigned
++	 numbers either, so for now use 0.  */
+       if (lang_GNU_C ()
+ 	  || ! strcmp (language_string, "GNU GIMPLE")
+ 	  || ! strcmp (language_string, "GNU Go")
++	  || ! strcmp (language_string, "GNU D")
+ 	  || ! strcmp (language_string, "libgccjit"))
+ 	i = 0;
+       else if (! strcmp (language_string, "GNU F77")
 --- a/gcc/config/rs6000/rs6000.c
 +++ b/gcc/config/rs6000/rs6000.c
 @@ -31980,11 +31980,12 @@ rs6000_output_function_epilogue (FILE *file,

--- a/gcc/d/patches/patch-targetdm-8.x
+++ b/gcc/d/patches/patch-targetdm-8.x
@@ -492,6 +492,18 @@ The following OS versions are implemented:
  /* Run-time compilation parameters selecting different hardware subsets.  */
  
  /* Which processor to schedule for. The cpu attribute defines a list that
+--- a/gcc/config/alpha/linux.h
++++ b/gcc/config/alpha/linux.h
+@@ -33,6 +33,9 @@ along with GCC; see the file COPYING3.  If not see
+ 	  builtin_define ("_GNU_SOURCE");			\
+     } while (0)
+ 
++#define GNU_USER_TARGET_D_OS_VERSIONS()				\
++  builtin_version ("linux")
++
+ #undef LIB_SPEC
+ #define LIB_SPEC \
+   "%{pthread:-lpthread} \
 --- a/gcc/config/alpha/t-alpha
 +++ b/gcc/config/alpha/t-alpha
 @@ -16,4 +16,8 @@
@@ -1099,6 +1111,30 @@ The following OS versions are implemented:
 +      d_add_builtin_version ("D_SoftFloat");
 +    }
 +}
+--- a/gcc/config/powerpcspe/linux.h
++++ b/gcc/config/powerpcspe/linux.h
+@@ -57,6 +57,9 @@
+     }						\
+   while (0)
+ 
++#define GNU_USER_TARGET_D_OS_VERSIONS()		\
++  builtin_version ("linux")
++
+ #undef	CPP_OS_DEFAULT_SPEC
+ #define CPP_OS_DEFAULT_SPEC "%(cpp_os_linux)"
+ 
+--- a/gcc/config/powerpcspe/linux64.h
++++ b/gcc/config/powerpcspe/linux64.h
+@@ -391,6 +391,9 @@ extern int dot_symbols;
+     }							\
+   while (0)
+ 
++#define GNU_USER_TARGET_D_OS_VERSIONS()			\
++  builtin_version ("linux")
++
+ #undef  CPP_OS_DEFAULT_SPEC
+ #define CPP_OS_DEFAULT_SPEC "%(cpp_os_linux) %(include_extra)"
+ 
 --- a/gcc/config/powerpcspe/powerpcspe-protos.h
 +++ b/gcc/config/powerpcspe/powerpcspe-protos.h
 @@ -244,6 +244,9 @@ extern void rs6000_target_modify_macros (bool, HOST_WIDE_INT, HOST_WIDE_INT);
@@ -1184,6 +1220,30 @@ The following OS versions are implemented:
 +      d_add_builtin_version ("D_SoftFloat");
 +    }
 +}
+--- a/gcc/config/rs6000/linux.h
++++ b/gcc/config/rs6000/linux.h
+@@ -57,6 +57,9 @@
+     }						\
+   while (0)
+ 
++#define GNU_USER_TARGET_D_OS_VERSIONS()		\
++  builtin_version ("linux")
++
+ #undef	CPP_OS_DEFAULT_SPEC
+ #define CPP_OS_DEFAULT_SPEC "%(cpp_os_linux)"
+ 
+--- a/gcc/config/rs6000/linux64.h
++++ b/gcc/config/rs6000/linux64.h
+@@ -391,6 +391,9 @@ extern int dot_symbols;
+     }							\
+   while (0)
+ 
++#define GNU_USER_TARGET_D_OS_VERSIONS()			\
++  builtin_version ("linux")
++
+ #undef  CPP_OS_DEFAULT_SPEC
+ #define CPP_OS_DEFAULT_SPEC "%(cpp_os_linux) %(include_extra)"
+ 
 --- a/gcc/config/rs6000/rs6000-protos.h
 +++ b/gcc/config/rs6000/rs6000-protos.h
 @@ -244,6 +244,9 @@ extern void rs6000_target_modify_macros (bool, HOST_WIDE_INT, HOST_WIDE_INT);


### PR DESCRIPTION
These targets don't use `config/linux.h`, instead opting for a slight duplication of it privately.