### PR TITLE
Add support for MIPS32, SPARC64 and SystemZ architectures in stdc/math.d

### DIFF
--- a/libphobos/libdruntime/core/stdc/math.d
+++ b/libphobos/libdruntime/core/stdc/math.d
@@ -70,37 +70,58 @@ else version (CRuntime_Glibc)
     else version (ARM)
     {
         ///
-        enum int FP_ILOGB0        = -2147483647;
+        enum int FP_ILOGB0        = -int.max;
         ///
-        enum int FP_ILOGBNAN      = 2147483647;
+        enum int FP_ILOGBNAN      = int.max;
     }
     else version (AArch64)
     {
         ///
-        enum int FP_ILOGB0        = -2147483647;
+        enum int FP_ILOGB0        = -int.max;
         ///
-        enum int FP_ILOGBNAN      = 2147483647;
+        enum int FP_ILOGBNAN      = int.max;
+    }
+    else version (MIPS32)
+    {
+        ///
+        enum int FP_ILOGB0        = -int.max;
+        ///
+        enum int FP_ILOGBNAN      = int.max;
     }
     else version (MIPS64)
     {
         ///
-        enum int FP_ILOGB0        = -2147483647;
+        enum int FP_ILOGB0        = -int.max;
         ///
-        enum int FP_ILOGBNAN      = 2147483647;
+        enum int FP_ILOGBNAN      = int.max;
     }
     else version (PPC)
     {
         ///
-        enum int FP_ILOGB0        = -2147483647;
+        enum int FP_ILOGB0        = -int.max;
         ///
-        enum int FP_ILOGBNAN      = 2147483647;
+        enum int FP_ILOGBNAN      = int.max;
     }
     else version (PPC64)
     {
         ///
-        enum int FP_ILOGB0        = -2147483647;
+        enum int FP_ILOGB0        = -int.max;
         ///
-        enum int FP_ILOGBNAN      = 2147483647;
+        enum int FP_ILOGBNAN      = int.max;
+    }
+    else version (SPARC64)
+    {
+        ///
+        enum int FP_ILOGB0        = -int.max;
+        ///
+        enum int FP_ILOGBNAN      = int.max;
+    }
+    else version (SystemZ)
+    {
+        ///
+        enum int FP_ILOGB0        = -int.max;
+        ///
+        enum int FP_ILOGBNAN      = int.max;
     }
     else
     {


### PR DESCRIPTION
Also raised upstream.