### PR TITLE
Don't SEGV if object.d doesn't contain a module declaration.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,10 @@
+2017-07-11  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-target.cc (Target::loadModule): Check module identifier if a
+	declaration doesn't exist.
+	* typeinfo.cc (make_frontend_typeinfo): Use module location instead if
+	a declaration doesn't exist.
+
 2017-06-28  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-frontend.cc (CTFloat::hash): New function.

--- a/gcc/d/d-target.cc
+++ b/gcc/d/d-target.cc
@@ -317,12 +317,11 @@ void
 Target::loadModule (Module *m)
 {
   ModuleDeclaration *md = m->md;
-  if (!md || !md->id)
-    return;
 
-  if (!md->packages)
+  if (!md || !md->id || !md->packages)
     {
-      if (!strcmp (md->id->toChars (), "object"))
+      Identifier *id = (md && md->id) ? md->id : m->ident;
+      if (!strcmp (id->toChars (), "object"))
 	create_tinfo_types (m);
     }
   else if (md->packages->dim == 1)

--- a/gcc/d/typeinfo.cc
+++ b/gcc/d/typeinfo.cc
@@ -192,16 +192,14 @@ make_frontend_typeinfo (Module *mod, Identifier *ident,
   if (!base)
     base = Type::dtypeinfo;
 
-  gcc_assert (mod->md != NULL);
-
   /* Create object module in order to complete the semantic.  */
   if (!mod->_scope)
     mod->importAll (NULL);
 
   /* Assignment of global typeinfo variables is managed by the ClassDeclaration
      constructor, so only need to new the declaration here.  */
-  ClassDeclaration *tinfo = new ClassDeclaration (mod->md->loc, ident,
-						  NULL, true);
+  Loc loc = (mod->md) ? mod->md->loc : mod->loc;
+  ClassDeclaration *tinfo = new ClassDeclaration (loc, ident, NULL, true);
   tinfo->parent = mod;
   tinfo->semantic (mod->_scope);
   tinfo->baseClass = base;


### PR DESCRIPTION
Something that I stumbled across when testing the previous PR in a minimal environment.

If object.d doesn't contain an `md`, then `create_tinfo_types` is never called, and no stub `TypeInfo` is created.  The segv happened because no TypeInfo existed when it was expected to.