### PR TITLE
Backport changes to Target interface and fix d_types_compatible_p.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,26 @@
+2017-07-15  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-builtins.cc (d_build_d_type_nodes): Set TYPE_DYNAMIC_ARRAY on
+	array_type_node.
+	* d-codegen.cc (build_delegate_cst): Set TYPE_DELEGATE on internal
+	delegate constant types.
+	* d-frontend.h (cppTypeInfoMangle): Remove declaration.
+	(toCppMangleItanium): Add declaration.
+	(cppTypeInfoMangleItanium): Add declaration.
+	* d-lang.cc (d_types_compatible_p): Use type flags to determine
+	compatibility.  Return false instead of doing size comparison.
+	* d-target.cc (Target::toCppMangle): New function.
+	(Target::cppTypeInfoMangle): New function.
+	(Target::cppTypeMangle): New function.
+	(Target::systemLinkage): New function.
+	* d-tree.h (TYPE_DYNAMIC_ARRAY): New macro.
+	(TYPE_DELEGATE): New macro.
+	(TYPE_ASSOCIATIVE_ARRAY): New macro.
+	* typeinfo.cc (layout_cpp_typeinfo): Use Target::cppTypeInfoMangle.
+	* types.cc (TypeVisitor::visit(TypeDArray)): Set TYPE_DYNAMIC_ARRAY.
+	(TypeVisitor::visit(TypeAArray)): Set TYPE_ASSOCIATIVE_ARRAY.
+	(TypeVisitor::visit(TypeDelegate)): Set TYPE_DELEGATE.
+
 2017-07-11  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-target.cc (Target::loadModule): Check module identifier if a

--- a/gcc/d/d-builtins.cc
+++ b/gcc/d/d-builtins.cc
@@ -809,6 +809,7 @@ d_build_d_type_nodes (void)
   array_type_node = make_struct_type ("__builtin_void[]", 2,
 				      get_identifier ("length"), size_type_node,
 				      get_identifier ("ptr"), ptr_type_node);
+  TYPE_DYNAMIC_ARRAY (array_type_node) = 1;
 
   null_array_node = d_array_value (array_type_node, size_zero_node,
 				   null_pointer_node);

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -416,6 +416,7 @@ build_delegate_cst (tree method, tree object, Type *type)
       ctype = make_struct_type ("delegate()", 2,
 				get_identifier ("object"), TREE_TYPE (object),
 				get_identifier ("func"), TREE_TYPE (method));
+      TYPE_DELEGATE (ctype) = 1;
     }
 
   vec<constructor_elt, va_gc> *ce = NULL;

--- a/gcc/d/d-frontend.h
+++ b/gcc/d/d-frontend.h
@@ -31,12 +31,15 @@ struct OutBuffer;
 
 /* Used in typeinfo.cc.  */
 FuncDeclaration *search_toString (StructDeclaration *);
-const char *cppTypeInfoMangle (Dsymbol *);
 
 /* Used in d-lang.cc.  */
 void initTraitsStringTable (void);
 
 /* Used in intrinsics.cc.  */
-void mangleToBuffer(Type *t, OutBuffer *buf);
+void mangleToBuffer(Type *, OutBuffer *);
+
+/* Used in d-target.cc.  */
+const char *toCppMangleItanium(Dsymbol *);
+const char *cppTypeInfoMangleItanium(Dsymbol *);
 
 #endif  /* ! GCC_D_FRONTEND_H */

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -1469,17 +1469,30 @@ d_types_compatible_p (tree x, tree y)
   Type *tx = TYPE_LANG_FRONTEND (x);
   Type *ty = TYPE_LANG_FRONTEND (y);
 
-  /* Try validating the types in the frontend first.  */
+  /* Try validating the types in the frontend.  */
   if (tx != NULL && ty != NULL)
     {
+      /* Types are equivalent.  */
+      if (same_type_p (tx, ty))
+	return true;
+
+      /* Type system allows implicit conversion between.  */
       if (tx->implicitConvTo (ty) || ty->implicitConvTo (tx))
 	return true;
     }
 
-  /* Fallback on using type kind and size comparison.  E.g: all dynamic arrays
+  /* Fallback on using type flags for comparison.  E.g: all dynamic arrays
      are distinct types in D, but are VIEW_CONVERT compatible.  */
-  return (TREE_CODE (x) == TREE_CODE (y)
-	  && TYPE_SIZE (x) == TYPE_SIZE (y));
+  if (TYPE_DYNAMIC_ARRAY (x) && TYPE_DYNAMIC_ARRAY (y))
+    return true;
+
+  if (TYPE_DELEGATE (x) && TYPE_DELEGATE (y))
+    return true;
+
+  if (TYPE_ASSOCIATIVE_ARRAY (x) && TYPE_ASSOCIATIVE_ARRAY (y))
+    return true;
+
+  return false;
 }
 
 /* Implements the lang_hooks.finish_incomplete_decl routine for language D.  */

--- a/gcc/d/d-target.cc
+++ b/gcc/d/d-target.cc
@@ -19,6 +19,7 @@ along with GCC; see the file COPYING3.  If not see
 #include "system.h"
 #include "coretypes.h"
 
+#include "dfrontend/aggregate.h"
 #include "dfrontend/module.h"
 #include "dfrontend/mtype.h"
 #include "dfrontend/target.h"
@@ -32,6 +33,7 @@ along with GCC; see the file COPYING3.  If not see
 #include "target.h"
 
 #include "d-tree.h"
+#include "d-frontend.h"
 #include "d-target.h"
 
 /* Implements the Target interface defined by the front end.
@@ -372,4 +374,43 @@ Target::checkVectorType (int sz, Type *type)
 void
 Target::prefixName (OutBuffer *, LINK)
 {
+}
+
+/* Return the symbol mangling of S for C++ linkage. */
+
+const char *
+Target::toCppMangle (Dsymbol *s)
+{
+  return toCppMangleItanium (s);
+}
+
+/* Return the symbol mangling of CD for C++ linkage.  */
+
+const char *
+Target::cppTypeInfoMangle(ClassDeclaration *cd)
+{
+  return cppTypeInfoMangleItanium (cd);
+}
+
+/* For a vendor-specific type, return a string containing the C++ mangling.
+   In all other cases, return NULL.  */
+
+const char *
+Target::cppTypeMangle (Type *type)
+{
+    if (type->isTypeBasic () || type->ty == Tvector || type->ty == Tstruct)
+    {
+        tree ctype = build_ctype (type);
+        return targetm.mangle_type (ctype);
+    }
+
+    return NULL;
+}
+
+/* Return the default system linkage for the target.  */
+
+LINK
+Target::systemLinkage (void)
+{
+  return LINKc;
 }

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -52,6 +52,9 @@ typedef Array<Expression *> Expressions;
    1: TYPE_IMAGINARY_FLOAT (in REAL_TYPE).
       ANON_AGGR_TYPE_P (in RECORD_TYPE, UNION_TYPE).
    2: CLASS_TYPE_P (in RECORD_TYPE).
+   3: TYPE_DYNAMIC_ARRAY (in RECORD_TYPE).
+   4: TYPE_DELEGATE (in RECORD_TYPE).
+   5: TYPE_ASSOCIATIVE_ARRAY (in RECORD_TYPE).
 
    Usage of DECL_LANG_FLAG_?:
    0: D_DECL_ONE_ONLY
@@ -326,6 +329,18 @@ lang_tree_node
 /* True if the type is the underlying record for a class.  */
 #define CLASS_TYPE_P(NODE) \
   (TYPE_LANG_FLAG_2 (RECORD_TYPE_CHECK (NODE)))
+
+/* True if the type is a D dynamic array.  */
+#define TYPE_DYNAMIC_ARRAY(NODE) \
+  (TYPE_LANG_FLAG_3 (RECORD_TYPE_CHECK (NODE)))
+
+/* True if the type is a D delegate.  */
+#define TYPE_DELEGATE(NODE) \
+  (TYPE_LANG_FLAG_4 (RECORD_TYPE_CHECK (NODE)))
+
+/* True if the type is a D associative array.  */
+#define TYPE_ASSOCIATIVE_ARRAY(NODE) \
+  (TYPE_LANG_FLAG_5 (RECORD_TYPE_CHECK (NODE)))
 
 /* True if the symbol should be made "link one only".  This is used to
    defer calling make_decl_one_only() before the decl has been prepared.  */

--- a/gcc/d/dfrontend/attrib.c
+++ b/gcc/d/dfrontend/attrib.c
@@ -27,6 +27,7 @@
 #include "aggregate.h"
 #include "module.h"
 #include "parse.h"
+#include "target.h"
 #include "template.h"
 #include "utf.h"
 #include "mtype.h"
@@ -482,7 +483,7 @@ LinkDeclaration::LinkDeclaration(LINK p, Dsymbols *decl)
         : AttribDeclaration(decl)
 {
     //printf("LinkDeclaration(linkage = %d, decl = %p)\n", p, decl);
-    linkage = p;
+    linkage = (p == LINKsystem) ? Target::systemLinkage() : p;
 }
 
 Dsymbol *LinkDeclaration::syntaxCopy(Dsymbol *s)

--- a/gcc/d/dfrontend/cppmangle.c
+++ b/gcc/d/dfrontend/cppmangle.c
@@ -41,8 +41,6 @@ int Parameter_foreach(Parameters *parameters, ForeachDg dg, void *ctx, size_t *p
  * so nothing would be compatible anyway.
  */
 
-#if IN_GCC || TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
-
 /*
  * Follows Itanium C++ ABI 1.86
  */
@@ -605,7 +603,7 @@ public:
         }
         else
         {
-            t->error(Loc(), "Internal Compiler Error: unsupported type %s\n", t->toChars());
+            t->error(Loc(), "Internal Compiler Error: type %s can not be mapped to C++\n", t->toChars());
         }
         fatal(); //Fatal, because this error should be handled in frontend
 #endif
@@ -655,7 +653,7 @@ public:
             case Tint128:   c = 'n';        break;
             case Tuns128:   c = 'o';        break;
             case Tfloat64:  c = 'd';        break;
-            case Tfloat80:  c = (Target::realsize - Target::realpad == 16) ? 'g' : 'e'; break;
+            case Tfloat80:  c = 'e';        break;
             case Tbool:     c = 'b';        break;
             case Tchar:     c = 'c';        break;
             case Twchar:    c = 't';        break; // unsigned short
@@ -689,10 +687,17 @@ public:
         if (t->isConst())
             buf.writeByte('K');
 
-        if (p)
-            buf.writeByte(p);
-
-        buf.writeByte(c);
+        // Handle any target-specific basic types.
+        if (const char *tm = Target::cppTypeMangle(t))
+        {
+            buf.writestring(tm);
+        }
+        else
+        {
+            if (p)
+                buf.writeByte(p);
+            buf.writeByte(c);
+        }
     }
 
 
@@ -708,11 +713,20 @@ public:
         }
         if (t->isConst())
             buf.writeByte('K');
-        assert(t->basetype && t->basetype->ty == Tsarray);
-        assert(((TypeSArray *)t->basetype)->dim);
-        //buf.printf("Dv%llu_", ((TypeSArray *)t->basetype)->dim->toInteger());// -- Gnu ABI v.4
-        buf.writestring("U8__vector"); //-- Gnu ABI v.3
-        t->basetype->nextOf()->accept(this);
+
+        // Handle any target-specific vector types.
+        if (const char *tm = Target::cppTypeMangle(t))
+        {
+            buf.writestring(tm);
+        }
+        else
+        {
+            assert(t->basetype && t->basetype->ty == Tsarray);
+            assert(((TypeSArray *)t->basetype)->dim);
+            //buf.printf("Dv%llu_", ((TypeSArray *)t->basetype)->dim->toInteger());// -- Gnu ABI v.4
+            buf.writestring("U8__vector"); //-- Gnu ABI v.3
+            t->basetype->nextOf()->accept(this);
+        }
     }
 
     void visit(TypeSArray *t)
@@ -857,14 +871,22 @@ public:
         if (t->isConst())
             buf.writeByte('K');
 
-        if (!substitute(t->sym))
+        // Handle any target-specific struct types.
+        if (const char *tm = Target::cppTypeMangle(t))
         {
-            cpp_mangle_name(t->sym, t->isConst());
+            buf.writestring(tm);
         }
-
-        if (t->isImmutable() || t->isShared())
+        else
         {
-            visit((Type *)t);
+            if (!substitute(t->sym))
+            {
+                cpp_mangle_name(t->sym, t->isConst());
+            }
+
+            if (t->isImmutable() || t->isShared())
+            {
+                visit((Type *)t);
+            }
         }
 
         if (t->isConst())
@@ -927,21 +949,19 @@ public:
     }
 };
 
-char *toCppMangle(Dsymbol *s)
+const char *toCppMangleItanium(Dsymbol *s)
 {
-    //printf("toCppMangle(%s)\n", s->toChars());
+    //printf("toCppMangleItanium(%s)\n", s->toChars());
     CppMangleVisitor v;
     return v.mangleOf(s);
 }
 
-const char *cppTypeInfoMangle(Dsymbol *s)
+const char *cppTypeInfoMangleItanium(Dsymbol *s)
 {
-    //printf("cppTypeInfoMangle(%s)\n", s->toChars());
+    //printf("cppTypeInfoMangleItanium(%s)\n", s->toChars());
     CppMangleVisitor v;
     return v.mangle_typeinfo(s);
 }
-
-#elif TARGET_WINDOS
 
 // Windows DMC and Microsoft Visual C++ mangling
 #define VC_SAVED_TYPE_CNT 10
@@ -1000,7 +1020,7 @@ public:
         }
         else
         {
-            type->error(Loc(), "Internal Compiler Error: unsupported type %s\n", type->toChars());
+            type->error(Loc(), "Internal Compiler Error: type %s can not be mapped to C++\n", type->toChars());
         }
         fatal(); // Fatal, because this error should be handled in frontend
     }
@@ -1968,18 +1988,14 @@ private:
     }
 };
 
-char *toCppMangle(Dsymbol *s)
+const char *toCppMangleMSVC(Dsymbol *s)
 {
     VisualCPPMangler v(!global.params.mscoff);
     return v.mangleOf(s);
 }
 
-const char *cppTypeInfoMangle(Dsymbol *s)
+const char *cppTypeInfoMangleMSVC(Dsymbol *s)
 {
-    //printf("cppTypeInfoMangle(%s)\n", s->toChars());
+    //printf("cppTypeInfoMangleMSVC(%s)\n", s->toChars());
     assert(0);
 }
-
-#else
-#error "fix this"
-#endif

--- a/gcc/d/dfrontend/dmangle.c
+++ b/gcc/d/dfrontend/dmangle.c
@@ -21,6 +21,7 @@
 #include "aggregate.h"
 #include "mtype.h"
 #include "attrib.h"
+#include "target.h"
 #include "template.h"
 #include "id.h"
 #include "module.h"
@@ -28,7 +29,6 @@
 #include "expression.h"
 #include "utf.h"
 
-char *toCppMangle(Dsymbol *s);
 void mangleToBuffer(Type *t, OutBuffer *buf);
 typedef int (*ForeachDg)(void *ctx, size_t paramidx, Parameter *param);
 int Parameter_foreach(Parameters *parameters, ForeachDg dg, void *ctx, size_t *pn = NULL);
@@ -424,7 +424,7 @@ public:
                     return;
 
                 case LINKcpp:
-                    buf->writestring(toCppMangle(d));
+                    buf->writestring(Target::toCppMangle(d));
                     return;
 
                 case LINKdefault:

--- a/gcc/d/dfrontend/globals.h
+++ b/gcc/d/dfrontend/globals.h
@@ -301,6 +301,7 @@ enum LINK
     LINKwindows,
     LINKpascal,
     LINKobjc,
+    LINKsystem,
 };
 
 enum CPPMANGLE

--- a/gcc/d/dfrontend/hdrgen.c
+++ b/gcc/d/dfrontend/hdrgen.c
@@ -3349,6 +3349,7 @@ const char *linkageToChars(LINK linkage)
         case LINKwindows:   return "Windows";
         case LINKpascal:    return "Pascal";
         case LINKobjc:      return "Objective-C";
+        case LINKsystem:    return "System";
         default:            assert(0);
     }
     return NULL;    // never reached

--- a/gcc/d/dfrontend/parse.c
+++ b/gcc/d/dfrontend/parse.c
@@ -1352,7 +1352,7 @@ LINK Parser::parseLinkage(Identifiers **pidents, CPPMANGLE *pcppmangle)
         }
         else if (id == Id::System)
         {
-            link = global.params.isWindows ? LINKwindows : LINKc;
+            link = LINKsystem;
         }
         else
         {

--- a/gcc/d/dfrontend/target.h
+++ b/gcc/d/dfrontend/target.h
@@ -17,6 +17,8 @@
 // most or all target machine and target O/S specific information.
 #include "globals.h"
 
+class ClassDeclaration;
+class Dsymbol;
 class Expression;
 class Type;
 class Module;
@@ -69,6 +71,10 @@ struct Target
     // ABI and backend.
     static void loadModule(Module *m);
     static void prefixName(OutBuffer *buf, LINK linkage);
+    static const char *toCppMangle(Dsymbol *s);
+    static const char *cppTypeInfoMangle(ClassDeclaration *cd);
+    static const char *cppTypeMangle(Type *t);
+    static LINK systemLinkage();
 };
 
 #endif

--- a/gcc/d/typeinfo.cc
+++ b/gcc/d/typeinfo.cc
@@ -35,6 +35,7 @@ along with GCC; see the file COPYING3.  If not see
 
 #include "d-tree.h"
 #include "d-frontend.h"
+#include "d-target.h"
 #include "id.h"
 
 
@@ -1321,7 +1322,7 @@ layout_cpp_typeinfo (ClassDeclaration *cd)
 
   /* Let C++ do the RTTI generation, and just reference the symbol as
      extern, the knowing the underlying type is not required.  */
-  const char *ident = cppTypeInfoMangle (cd);
+  const char *ident = Target::cppTypeInfoMangle (cd);
   tree typeinfo = declare_extern_var (get_identifier (ident),
 				      unknown_type_node);
   TREE_READONLY (typeinfo) = 1;

--- a/gcc/d/types.cc
+++ b/gcc/d/types.cc
@@ -615,6 +615,7 @@ public:
 				 build_ctype (Type::tsize_t),
 				 get_identifier ("ptr"),
 				 build_pointer_type (build_ctype (t->next)));
+    TYPE_DYNAMIC_ARRAY (t->ctype) = 1;
     TYPE_LANG_SPECIFIC (t->ctype) = build_lang_type (t);
     d_keep (t->ctype);
   }
@@ -667,6 +668,7 @@ public:
        consist of a pointer to an opaque, implementation defined type.  */
     t->ctype = make_struct_type (t->toChars (), 1,
 				 get_identifier ("ptr"), ptr_type_node);
+    TYPE_ASSOCIATIVE_ARRAY (t->ctype) = 1;
     TYPE_LANG_SPECIFIC (t->ctype) = build_lang_type (t);
     d_keep (t->ctype);
   }
@@ -768,6 +770,7 @@ public:
 				 build_ctype (Type::tvoidptr),
 				 get_identifier ("funcptr"),
 				 build_pointer_type (dgtype));
+    TYPE_DELEGATE (t->ctype) = 1;
     TYPE_LANG_SPECIFIC (t->ctype) = build_lang_type (t);
     d_keep (t->ctype);
   }


### PR DESCRIPTION
After backporting C++-related changes, to which `Target::cppTypeMangle()` fixes https://bugzilla.gdcproject.org/show_bug.cgi?id=247, was found that `d_types_compatible_p` is a bit too relaxed in it's checking.  Compare type flags instead of type sizes to validate if two types are compatible.