### PR TITLE
Check that both types are RECORD_TYPE before doing flag comparison

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2017-07-18  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-lang.cc (d_types_compatible_p): Check that both types are
+	RECORD_TYPE before using record-specific flag comparison.
+
 2017-07-15  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-builtins.cc (d_build_d_type_nodes): Set TYPE_DYNAMIC_ARRAY on

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -1483,14 +1483,17 @@ d_types_compatible_p (tree x, tree y)
 
   /* Fallback on using type flags for comparison.  E.g: all dynamic arrays
      are distinct types in D, but are VIEW_CONVERT compatible.  */
-  if (TYPE_DYNAMIC_ARRAY (x) && TYPE_DYNAMIC_ARRAY (y))
-    return true;
+  if (TREE_CODE (x) == RECORD_TYPE && TREE_CODE (y) == RECORD_TYPE)
+    {
+      if (TYPE_DYNAMIC_ARRAY (x) && TYPE_DYNAMIC_ARRAY (y))
+	return true;
 
-  if (TYPE_DELEGATE (x) && TYPE_DELEGATE (y))
-    return true;
+      if (TYPE_DELEGATE (x) && TYPE_DELEGATE (y))
+	return true;
 
-  if (TYPE_ASSOCIATIVE_ARRAY (x) && TYPE_ASSOCIATIVE_ARRAY (y))
-    return true;
+      if (TYPE_ASSOCIATIVE_ARRAY (x) && TYPE_ASSOCIATIVE_ARRAY (y))
+	return true;
+    }
 
   return false;
 }


### PR DESCRIPTION
Because ARM's `arm_mangle_type` doesn't safe-guard this.

https://buildbot.dgnu.org/#/builders/8/builds/10/steps/2/logs/stdio

Well, I shouldn't have assumed that only aggregates land here anyway. :-)