### PR TITLE
Fix libphobos/unittest runner after adding libphobos_load

### DIFF
--- a/libphobos/testsuite/lib/libphobos-dg.exp
+++ b/libphobos/testsuite/lib/libphobos-dg.exp
@@ -54,7 +54,9 @@ if { [info procs libphobos_load] != [list] \
 
     proc libphobos_load { program args } {
         global libphobos_run_args
-        set args [concat "{$libphobos_run_args}"]
+        if { $libphobos_run_args != "" } {
+            set args [concat "{$libphobos_run_args}"]
+        }
         set result [eval [list prev_libphobos_load $program] $args ]
         return $result
     }


### PR DESCRIPTION
In the middle of implementing the other testsuite tests, I regressed on the original unittest runner.

Don't override `$args` parameter if the global `$libphobos_run_args` is empty - the unittester calls `libphobos_load` directly and so `$args` is already set.