### PR TITLE
Prepare for more fine-grain application of mark_needed

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -5,6 +5,23 @@
 
 2017-07-28  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-tree.h (D_DECL_ONE_ONLY): Remove macro accessor.
+	* decl.cc (DeclVisitor::visit(StructDeclaration)): Move call to
+	d_comdat_linkage here.
+	(DeclVisitor::visit(ClassDeclaration)): Likewise.
+	(DeclVisitor::visit(InterfaceDeclaration)): Likewise.
+	(DeclVisitor::visit(EnumDeclaration)): Likewise.
+	(get_symbol_decl): Move call to mark_needed here.
+	(declare_extern_var): Mark compiler generated symbols as needed.
+	(make_thunk): Remove copy of D_DECL_ONE_ONLY.
+	(get_vtable_decl): Don't call d_comdat_linkage.
+	(aggregate_initializer_decl): Likewise.
+	(enum_initializer_decl): Likewise.
+	* modules.cc (d_finish_compilation): Don't call mark_needed.
+	* typeinfo.cc (get_classinfo_decl): Don't call d_comdat_linkage.
+
+2017-07-28  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* d-spec.c (lang_specific_driver): Always add `-o' option when
 	compiling D sources.
 

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,14 @@
 2017-07-29  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-lang.cc (build_lang_decl): Handle compiler generated typeinfo that
+	also appear in code.
+	* d-tree.h (lang_identifier): Add decl_tree.
+	(IDENTIFIER_DECL_TREE): New macro.
+	* decl.cc (declare_extern_var): Re-use already generated decl if
+	called with the same identifier twice.
+
+2017-07-29  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* decl.cc (d_finish_decl): Replace ENABLE_TREE_CHECKING macro with
 	flag_checking.
 

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -1606,8 +1606,19 @@ build_lang_type (Type *t)
 struct lang_decl *
 build_lang_decl (Declaration *d)
 {
-  struct lang_decl *ld = ggc_cleared_alloc<struct lang_decl> ();
-  ld->decl = d;
+  /* For compiler generated runtime typeinfo, a lang_decl is allocated even if
+     there's no associated frontend symbol to refer to (yet).  If the symbol
+     appears later in the compilation, then the slot will be re-used.  */
+  if (d == NULL)
+    return ggc_cleared_alloc<struct lang_decl> ();
+
+  struct lang_decl *ld = (d->csym) ? DECL_LANG_SPECIFIC (d->csym) : NULL;
+  if (ld == NULL)
+    ld = ggc_cleared_alloc<struct lang_decl> ();
+
+  if (ld->decl == NULL)
+    ld->decl = d;
+
   return ld;
 }
 

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -57,8 +57,7 @@ typedef Array<Expression *> Expressions;
    5: TYPE_ASSOCIATIVE_ARRAY (in RECORD_TYPE).
 
    Usage of DECL_LANG_FLAG_?:
-   0: D_DECL_ONE_ONLY
-   1: LABEL_VARIABLE_CASE (in LABEL_DECL).  */
+   0: LABEL_VARIABLE_CASE (in LABEL_DECL).  */
 
 /* The kinds of scopes we recognise.  */
 
@@ -342,14 +341,9 @@ lang_tree_node
 #define TYPE_ASSOCIATIVE_ARRAY(NODE) \
   (TYPE_LANG_FLAG_5 (RECORD_TYPE_CHECK (NODE)))
 
-/* True if the symbol should be made "link one only".  This is used to
-   defer calling make_decl_one_only() before the decl has been prepared.  */
-#define D_DECL_ONE_ONLY(NODE) \
-  (DECL_LANG_FLAG_0 (NODE))
-
 /* True if the decl is a variable case label decl.  */
 #define LABEL_VARIABLE_CASE(NODE) \
-  (DECL_LANG_FLAG_1 (LABEL_DECL_CHECK (NODE)))
+  (DECL_LANG_FLAG_0 (LABEL_DECL_CHECK (NODE)))
 
 enum d_tree_index
 {

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -184,6 +184,9 @@ struct GTY(()) lang_identifier
   /* The identifier as the user sees it.  */
   tree pretty_ident;
 
+  /* The backend tree associated with this identifier.  */
+  tree decl_tree;
+
   /* The frontend Declaration associated with this identifier.  */
   Declaration * GTY((skip)) dsymbol;
 };
@@ -193,6 +196,9 @@ struct GTY(()) lang_identifier
 
 #define IDENTIFIER_PRETTY_NAME(NODE) \
   (IDENTIFIER_LANG_SPECIFIC (NODE)->pretty_ident)
+
+#define IDENTIFIER_DECL_TREE(NODE) \
+  (IDENTIFIER_LANG_SPECIFIC (NODE)->decl_tree)
 
 #define IDENTIFIER_DSYMBOL(NODE) \
   (IDENTIFIER_LANG_SPECIFIC (NODE)->dsymbol)

--- a/gcc/d/decl.cc
+++ b/gcc/d/decl.cc
@@ -1252,10 +1252,15 @@ get_symbol_decl (Declaration *decl)
 tree
 declare_extern_var (tree ident, tree type)
 {
+  /* If the VAR_DECL has already been declared, return it.  */
+  if (IDENTIFIER_DECL_TREE (ident))
+    return IDENTIFIER_DECL_TREE (ident);
+
   tree name = IDENTIFIER_PRETTY_NAME (ident)
     ? IDENTIFIER_PRETTY_NAME (ident) : ident;
   tree decl = build_decl (input_location, VAR_DECL, name, type);
 
+  IDENTIFIER_DECL_TREE (ident) = decl;
   d_keep (decl);
 
   SET_DECL_ASSEMBLER_NAME (decl, ident);

--- a/gcc/d/decl.cc
+++ b/gcc/d/decl.cc
@@ -319,6 +319,9 @@ public:
     d->sinit = aggregate_initializer_decl (d);
     DECL_INITIAL (d->sinit) = layout_struct_initializer (d);
 
+    if (d->isInstantiated ())
+      d_comdat_linkage (d->sinit);
+
     d_finish_decl (d->sinit);
 
     /* Put out the members.  */
@@ -369,11 +372,13 @@ public:
 
     /* Generate static initialiser.  */
     DECL_INITIAL (d->sinit) = layout_class_initializer (d);
+    d_comdat_linkage (d->sinit);
     d_finish_decl (d->sinit);
 
     /* Put out the TypeInfo.  */
     create_typeinfo (d->type, NULL);
     DECL_INITIAL (d->csym) = layout_classinfo (d);
+    d_comdat_linkage (d->csym);
     d_finish_decl (d->csym);
 
     /* Put out the vtbl[].  */
@@ -436,6 +441,7 @@ public:
 
     DECL_INITIAL (d->vtblsym)
       = build_constructor (TREE_TYPE (d->vtblsym), elms);
+    d_comdat_linkage (d->vtblsym);
     d_finish_decl (d->vtblsym);
 
     /* Add this decl to the current binding level.  */
@@ -471,7 +477,9 @@ public:
     /* Put out the TypeInfo.  */
     create_typeinfo (d->type, NULL);
     d->type->vtinfo->accept (this);
+
     DECL_INITIAL (d->csym) = layout_classinfo (d);
+    d_comdat_linkage (d->csym);
     d_finish_decl (d->csym);
 
     /* Add this decl to the current binding level.  */
@@ -506,6 +514,10 @@ public:
 	/* Generate static initialiser.  */
 	d->sinit = enum_initializer_decl (d);
 	DECL_INITIAL (d->sinit) = build_expr (tc->sym->defaultval, true);
+
+	if (d->isInstantiated ())
+	  d_comdat_linkage (d->sinit);
+
 	d_finish_decl (d->sinit);
 
 	/* Add this decl to the current binding level.  */
@@ -562,11 +574,11 @@ public:
       }
     else if (d->isDataseg () && !(d->storage_class & STCextern))
       {
-	tree s = get_symbol_decl (d);
+	tree t = get_symbol_decl (d);
 
 	/* Duplicated VarDeclarations map to the same symbol. Check if this
 	   is the one declaration which will be emitted.  */
-	tree ident = DECL_ASSEMBLER_NAME (s);
+	tree ident = DECL_ASSEMBLER_NAME (t);
 	if (IDENTIFIER_DSYMBOL (ident) && IDENTIFIER_DSYMBOL (ident) != d)
 	  return;
 
@@ -582,19 +594,19 @@ public:
 	if (d->_init && !d->_init->isVoidInitializer ())
 	  {
 	    Expression *e = d->_init->toExpression (d->type);
-	    DECL_INITIAL (s) = build_expr (e, true);
+	    DECL_INITIAL (t) = build_expr (e, true);
 	  }
 	else
 	  {
 	    if (d->type->ty == Tstruct)
 	      {
 		StructDeclaration *sd = ((TypeStruct *) d->type)->sym;
-		DECL_INITIAL (s) = layout_struct_initializer (sd);
+		DECL_INITIAL (t) = layout_struct_initializer (sd);
 	      }
 	    else
 	      {
 		Expression *e = d->type->defaultInitLiteral (d->loc);
-		DECL_INITIAL (s) = build_expr (e, true);
+		DECL_INITIAL (t) = build_expr (e, true);
 	      }
 	  }
 
@@ -602,7 +614,7 @@ public:
 	gcc_assert (!integer_zerop (size)
 		    || d->type->toBasetype ()->ty == Tsarray);
 
-	d_finish_decl (s);
+	d_finish_decl (t);
 
 	/* Maybe record the var against the current module.  */
 	register_module_decl (d);
@@ -641,9 +653,9 @@ public:
     if (speculative_type_p (d->tinfo))
       return;
 
-    tree s = get_typeinfo_decl (d);
-    DECL_INITIAL (s) = layout_typeinfo (d);
-    d_finish_decl (s);
+    tree t = get_typeinfo_decl (d);
+    DECL_INITIAL (t) = layout_typeinfo (d);
+    d_finish_decl (t);
   }
 
   /* Finish up a function declaration and compile it all the way
@@ -1108,8 +1120,9 @@ get_symbol_decl (Declaration *decl)
       /* Vector array operations are always compiler generated.  */
       if (fd->isArrayOp)
 	{
+	  TREE_PUBLIC (decl->csym) = 1;
 	  DECL_ARTIFICIAL (decl->csym) = 1;
-	  D_DECL_ONE_ONLY (decl->csym) = 1;
+	  d_comdat_linkage (decl->csym);
 	}
 
       /* And so are ensure and require contracts.  */
@@ -1161,13 +1174,15 @@ get_symbol_decl (Declaration *decl)
 
   if (decl->isDataseg () || decl->isCodeseg () || decl->isThreadlocal ())
     {
+      /* Set TREE_PUBLIC by default, but allow private template to override.  */
+      if (!fd || !fd->isNested ())
+	TREE_PUBLIC (decl->csym) = 1;
+
       /* Check if the declaration is a template, and whether it will be emitted
 	 in the current compilation or not.  */
       TemplateInstance *ti = decl->isInstantiated ();
       if (ti)
 	{
-	  D_DECL_ONE_ONLY (decl->csym) = 1;
-
 	  if (!DECL_EXTERNAL (decl->csym) && ti->needsCodegen ())
 	    {
 	      /* Warn about templates instantiated in this compilation.  */
@@ -1181,6 +1196,14 @@ get_symbol_decl (Declaration *decl)
 	    }
 	  else
 	    DECL_EXTERNAL (decl->csym) = 1;
+
+	  d_comdat_linkage (decl->csym);
+
+	  /* Normally the backend only emits COMDAT things when they are needed.
+	     If this decl is meant to be externally visible, then make sure that
+	     to mark it so that it is indeed needed.  */
+	  if (TREE_PUBLIC (decl->csym))
+	    mark_needed (decl->csym);
 	}
       else
 	{
@@ -1190,13 +1213,6 @@ get_symbol_decl (Declaration *decl)
 	  else
 	    DECL_EXTERNAL (decl->csym) = 1;
 	}
-
-      /* Set TREE_PUBLIC by default, but allow private template to override.  */
-      if (!fd || !fd->isNested ())
-	TREE_PUBLIC (decl->csym) = 1;
-
-      if (D_DECL_ONE_ONLY (decl->csym))
-	d_comdat_linkage (decl->csym);
     }
 
   /* Symbol is going in thread local storage.  */
@@ -1246,6 +1262,9 @@ declare_extern_var (tree ident, tree type)
   DECL_ARTIFICIAL (decl) = 1;
   TREE_STATIC (decl) = 1;
   TREE_PUBLIC (decl) = 1;
+
+  /* Mark it needed so we don't forget to emit it.  */
+  mark_needed (decl);
 
   /* The decl has not been defined -- yet.  */
   DECL_EXTERNAL (decl) = 1;
@@ -1660,8 +1679,6 @@ make_thunk (FuncDeclaration *decl, int offset)
   DECL_DECLARED_INLINE_P (thunk) = 0;
 
   DECL_VISIBILITY (thunk) = DECL_VISIBILITY (function);
-  /* Needed on some targets to avoid "causes a section type conflict".  */
-  D_DECL_ONE_ONLY (thunk) = D_DECL_ONE_ONLY (function);
   DECL_COMDAT (thunk) = DECL_COMDAT (function);
   DECL_WEAK (thunk) = DECL_WEAK (function);
 
@@ -1899,11 +1916,6 @@ get_vtable_decl (ClassDeclaration *decl)
   SET_DECL_ALIGN (decl->vtblsym, TARGET_VTABLE_ENTRY_ALIGN);
   DECL_USER_ALIGN (decl->vtblsym) = true;
 
-  /* Could move setting comdat linkage to the caller, who knows whether
-     this vtable is being emitted in this compilation.  */
-  if (decl->isInstantiated ())
-    d_comdat_linkage (decl->vtblsym);
-
   return decl->vtblsym;
 }
 
@@ -1969,11 +1981,6 @@ aggregate_initializer_decl (AggregateDeclaration *decl)
       DECL_USER_ALIGN (decl->sinit) = true;
     }
 
-  /* Could move setting comdat linkage to the caller, who knows whether
-     this initializer is being emitted in this compilation.  */
-  if (decl->isInstantiated ())
-    d_comdat_linkage (decl->sinit);
-
   return decl->sinit;
 }
 
@@ -2027,11 +2034,6 @@ enum_initializer_decl (EnumDeclaration *decl)
 
   DECL_CONTEXT (decl->sinit) = d_decl_context (decl);
   TREE_READONLY (decl->sinit) = 1;
-
-  /* Could move setting comdat linkage to the caller, who knows whether
-     this initializer is being emitted in this compilation.  */
-  if (decl->isInstantiated ())
-    d_comdat_linkage (decl->sinit);
 
   return decl->sinit;
 }

--- a/gcc/d/modules.cc
+++ b/gcc/d/modules.cc
@@ -828,13 +828,6 @@ d_finish_compilation (tree *vec, int len)
     {
       tree decl = vec[i];
       wrapup_global_declarations (&decl, 1);
-
-      /* We want the static symbol to be written.  */
-      if (TREE_PUBLIC (decl) && VAR_OR_FUNCTION_DECL_P (decl))
-	{
-	  if ((VAR_P (decl) && TREE_STATIC (decl)) || !DECL_ARTIFICIAL (decl))
-	    mark_needed (decl);
-	}
     }
 
   /* If the target does not directly support static constructors,

--- a/gcc/d/typeinfo.cc
+++ b/gcc/d/typeinfo.cc
@@ -1284,11 +1284,6 @@ get_classinfo_decl (ClassDeclaration *decl)
   /* ClassInfo cannot be const data, because we use the monitor on it.  */
   TREE_READONLY (decl->csym) = 0;
 
-  /* Could move setting comdat linkage to the caller, who knows whether
-     this classinfo is being emitted in this compilation.  */
-  if (decl->isInstantiated ())
-    d_comdat_linkage (decl->csym);
-
   return decl->csym;
 }
 

--- a/libphobos/testsuite/libphobos.shared/shared.exp
+++ b/libphobos/testsuite/libphobos.shared/shared.exp
@@ -39,7 +39,8 @@ proc shared_library { source destfile options } {
     global DEFAULT_DFLAGS
     global all_libraries
 
-    lappend options "additional_flags=$DEFAULT_DFLAGS -fpic -shared -shared-libphobos"
+    # Compiling with -fno-gnu-unique as tests call dlopen/dlclose multiple times on the same library.
+    lappend options "additional_flags=$DEFAULT_DFLAGS -fno-gnu-unique -fpic -shared -shared-libphobos"
 
     set comp_output [gdc_target_compile "$source" "$destfile" "executable" $options]
     if ![ string match "" $comp_output ] {


### PR DESCRIPTION
1. Move `d_comdat_linkage` from `get_xxx_decl` to `DeclVisitor`.
2. Move `mark_needed` from `d_finish_compilation` to `get_symbol_decl`/`declare_extern_var`.
3. Protect `declare_extern_var` from generating two different symbols for the same identifier.