### PR TITLE
Replace ENABLE_TREE_CHECKING macro with flag_checking.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2017-07-29  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* decl.cc (d_finish_decl): Replace ENABLE_TREE_CHECKING macro with
+	flag_checking.
+
 2017-07-28  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-spec.c (lang_specific_driver): Always add `-o' option when

--- a/gcc/d/decl.cc
+++ b/gcc/d/decl.cc
@@ -1404,8 +1404,7 @@ d_finish_decl (tree decl)
   DECL_EXTERNAL (decl) = 0;
   relayout_decl (decl);
 
-#ifdef ENABLE_TREE_CHECKING
-  if (DECL_INITIAL (decl) != NULL_TREE)
+  if (flag_checking && DECL_INITIAL (decl))
     {
       /* Initialiser must never be bigger than symbol size.  */
       dinteger_t tsize = int_size_in_bytes (TREE_TYPE (decl));
@@ -1422,7 +1421,6 @@ d_finish_decl (tree decl)
 			  tsize, dtsize);
 	}
     }
-#endif
 
   /* Add this decl to the current binding level.  */
   d_pushdecl (decl);


### PR DESCRIPTION
`flag_checking` has been around since 2015, and is accompanied with the `-fchecking` compiler switch.

The default value is also controlled by `--enable-checking`, so nothing really changes, just removing one extra ifdef.