### PR TITLE
Merge regression tests and fixes for 2.074

### DIFF
--- a/gcc/d/dfrontend/arrayop.c
+++ b/gcc/d/dfrontend/arrayop.c
@@ -323,7 +323,7 @@ void buildArrayIdent(Expression *e, OutBuffer *buf, Expressions *arguments)
             switch(e->op)
             {
             case TOKaddass: s = "Addass"; break;
-            case TOKminass: s = "Subass"; break;
+            case TOKminass: s = "Minass"; break;
             case TOKmulass: s = "Mulass"; break;
             case TOKdivass: s = "Divass"; break;
             case TOKmodass: s = "Modass"; break;
@@ -356,7 +356,7 @@ void buildArrayIdent(Expression *e, OutBuffer *buf, Expressions *arguments)
             switch(e->op)
             {
             case TOKadd: s = "Add"; break;
-            case TOKmin: s = "Sub"; break;
+            case TOKmin: s = "Min"; break;
             case TOKmul: s = "Mul"; break;
             case TOKdiv: s = "Div"; break;
             case TOKmod: s = "Mod"; break;

--- a/gcc/d/dfrontend/ctfeexpr.c
+++ b/gcc/d/dfrontend/ctfeexpr.c
@@ -1382,7 +1382,7 @@ int ctfeRawCmp(Loc loc, Expression *e1, Expression *e2)
         mem.xfree(used);
         return 0;
     }
-    error(loc, "CTFE internal error: bad compare");
+    error(loc, "CTFE internal error: bad compare of `%s` and `%s`", e1->toChars(), e2->toChars());
     assert(0);
     return 0;
 }
@@ -1879,7 +1879,8 @@ bool isCtfeValueValid(Expression *newval)
                tb->ty == Tpointer ||
                tb->ty == Tarray ||
                tb->ty == Taarray ||
-               tb->ty == Tclass;
+               tb->ty == Tclass ||
+               tb->ty == Tdelegate;
     }
 
     if (newval->op == TOKstring)

--- a/gcc/d/dfrontend/declaration.c
+++ b/gcc/d/dfrontend/declaration.c
@@ -2232,6 +2232,7 @@ TypeInfoDeclaration::TypeInfoDeclaration(Type *tinfo)
     storage_class = STCstatic | STCgshared;
     protection = Prot(PROTpublic);
     linkage = LINKc;
+    alignment = Target::ptrsize;
 }
 
 TypeInfoDeclaration *TypeInfoDeclaration::create(Type *tinfo)

--- a/gcc/d/dfrontend/dtemplate.c
+++ b/gcc/d/dfrontend/dtemplate.c
@@ -7466,10 +7466,13 @@ Dsymbols *TemplateInstance::appendToModuleMember()
         {
             static Dsymbol *getStrictEnclosing(TemplateInstance *ti)
             {
-                if (ti->enclosing)
-                    return ti->enclosing;
-                if (TemplateInstance *tix = ti->tempdecl->isInstantiated())
-                    return getStrictEnclosing(tix);
+                do
+                {
+                    if (ti->enclosing)
+                        return ti->enclosing;
+                    ti = ti->tempdecl->isInstantiated();
+                }
+                while (ti);
                 return NULL;
             }
         };

--- a/gcc/d/dfrontend/func.c
+++ b/gcc/d/dfrontend/func.c
@@ -1853,7 +1853,8 @@ void FuncDeclaration::semantic3(Scope *sc)
                         if (!nrvo_can)
                             exp = doCopyOrMove(sc2, exp);
 
-                        checkEscape(sc2, exp, false);
+                        if (tret->hasPointers())
+                            checkEscape(sc2, exp, false);
                     }
 
                     exp = checkGC(sc2, exp);

--- a/gcc/d/dfrontend/parse.c
+++ b/gcc/d/dfrontend/parse.c
@@ -6502,6 +6502,7 @@ bool Parser::isParameters(Token **pt)
             case TOKscope:
             case TOKfinal:
             case TOKauto:
+            case TOKreturn:
                 continue;
 
             case TOKconst:

--- a/gcc/testsuite/gdc.test/compilable/interpret3.d
+++ b/gcc/testsuite/gdc.test/compilable/interpret3.d
@@ -7677,3 +7677,15 @@ auto baz15998()
 
 static assert(bar15998a == [["", ""]]);
 static assert(bar15998b == [["", ""]]);
+
+/**************************************************/
+// https://issues.dlang.org/show_bug.cgi?id=17407
+
+bool foo17407()
+{
+    void delegate ( ) longest_convert;
+    return __traits(compiles, longest_convert = &doesNotExists);
+}
+
+static assert(!foo17407);
+

--- a/gcc/testsuite/gdc.test/fail_compilation/retscope.d
+++ b/gcc/testsuite/gdc.test/fail_compilation/retscope.d
@@ -450,3 +450,25 @@ fail_compilation/retscope.d(1311): Error: scope variable u2 assigned to ek with 
   ek = U13.sget(u1); // ok
 }
 
+/************************************************/
+
+// https://issues.dlang.org/show_bug.cgi?id=17117
+
+ref int foo21(return ref int s)
+{
+        return s;
+}
+
+int fail21()
+{
+        int s;
+        return foo21(s); // Error: escaping reference to local variable s
+}
+
+int test21()
+{
+        int s;
+        s = foo21(s);
+        return s;
+}
+

--- a/gcc/testsuite/gdc.test/runnable/testptrref.d
+++ b/gcc/testsuite/gdc.test/runnable/testptrref.d
@@ -1,0 +1,168 @@
+
+version(CRuntime_Microsoft)
+{
+    extern(C)
+    {
+        extern __gshared uint _DP_beg;
+        extern __gshared uint _DP_end;
+        extern __gshared uint _TP_beg;
+        extern __gshared uint _TP_end;
+        extern int _tls_start;
+        extern int _tls_end;
+    }
+    alias _DPbegin = _DP_beg;
+    alias _DPend = _DP_end;
+    alias _TPbegin = _TP_beg;
+    alias _TPend = _TP_end;
+    alias _tlsstart = _tls_start;
+    alias _tlsend = _tls_end;
+
+    __gshared void[] dataSection;
+    shared static this()
+    {
+        import core.internal.traits : externDFunc;
+        alias findImageSection = externDFunc!("rt.sections_win64.findImageSection",
+                                              void[] function(string name) nothrow @nogc);
+        dataSection = findImageSection(".data");
+    }
+    
+    version = ptrref_supported;
+}
+else version(Win32)
+{
+    extern(C)
+    {
+        extern __gshared void* _DPbegin;
+        extern __gshared void* _DPend;
+        extern __gshared uint _TPbegin;
+        extern __gshared uint _TPend;
+        extern int _tlsstart;
+        extern int _tlsend;
+    }
+    version = ptrref_supported;
+}
+
+struct Struct
+{
+    int x;
+    Struct* next;
+}
+
+class Class
+{
+    void* ptr;
+}
+
+struct Struc(T)
+{
+	static T vtls;
+	static __gshared T vgshared;
+}
+
+__gshared Struct* gsharedStrctPtr2 = new Struct(7, new Struct(8, null));
+
+int tlsInt;
+void* tlsVar;
+
+shared int sharedInt;
+shared void* sharedVar;
+__gshared void* gsharedVar;
+__gshared void* gsharedVar2;
+immutable int[] arr = [1, 2, 3];
+string tlsStr;
+
+__gshared Struct gsharedStrct;
+Struct[3] tlsStrcArr;
+Class tlsClss;
+
+// expression initializers
+string[] strArr = [ "a", "b" ];
+__gshared Class gsharedClss = new Class;
+__gshared Struct* gsharedStrctPtr = new Struct(7, new Struct(8, null));
+
+debug(PRINT) import core.stdc.stdio;
+
+void main()
+{
+    version(ptrref_supported)
+        testRefPtr();
+}
+
+version(ptrref_supported):
+
+bool findTlsPtr(const(void)* ptr)
+{    
+    debug(PRINT) printf("findTlsPtr %p\n", ptr);
+    for (uint* p = &_TPbegin; p < &_TPend; p++)
+    {
+        void* addr = cast(void*) &_tlsstart + *p;
+        debug(PRINT) printf("  try %p\n", addr);
+        assert(addr < &_tlsend);
+        if (addr == ptr)
+            return true;
+    }
+    return false;
+}
+
+bool findDataPtr(const(void)* ptr)
+{
+    debug(PRINT) printf("findDataPtr %p\n", ptr);
+    for (auto p = &_DPbegin; p < &_DPend; p++)
+    {
+        debug(PRINT) printf("  try %p\n", cast(void*) cast(size_t) *p);
+        version(CRuntime_Microsoft)
+            void* addr = dataSection.ptr + *p;
+        else
+            void* addr = *p;
+        
+        if (addr == ptr)
+            return true;
+    }
+    return false;
+}
+
+void testRefPtr()
+{
+    debug(PRINT) printf("&_DPbegin %p\n", &_DPbegin);
+    debug(PRINT) printf("&_DPend   %p\n", &_DPend);
+
+    assert(!findDataPtr(cast(void*)&sharedInt));
+    assert(!findTlsPtr(&tlsInt));
+
+    assert(findDataPtr(cast(void*)&sharedVar));
+    assert(findDataPtr(&gsharedVar));
+    assert(findDataPtr(&gsharedStrct.next));
+    assert(findDataPtr(&(gsharedClss)));
+    assert(findDataPtr(&(gsharedClss.ptr)));
+
+    assert(findTlsPtr(&tlsVar));
+    assert(findTlsPtr(&tlsClss));
+    assert(findTlsPtr(&tlsStrcArr[0].next));
+    assert(findTlsPtr(&tlsStrcArr[1].next));
+    assert(findTlsPtr(&tlsStrcArr[2].next));
+
+    assert(!findTlsPtr(cast(size_t*)&tlsStr)); // length
+    assert(findTlsPtr(cast(size_t*)&tlsStr + 1)); // ptr
+    
+    // monitor is manually managed
+    assert(!findDataPtr(cast(size_t*)cast(void*)Class.classinfo + 1));
+    assert(!findDataPtr(cast(size_t*)cast(void*)Class.classinfo + 1));
+
+    assert(!findDataPtr(&arr));
+    assert(!findTlsPtr(&arr));
+    assert(!findDataPtr(cast(size_t*)&arr + 1));
+    assert(!findTlsPtr(cast(size_t*)&arr + 1));
+    
+    assert(findDataPtr(cast(size_t*)&strArr[0] + 1)); // ptr in _DATA!
+    assert(findDataPtr(cast(size_t*)&strArr[1] + 1)); // ptr in _DATA!
+    strArr[1] = "c";
+
+    assert(findDataPtr(&gsharedStrctPtr));
+    assert(findDataPtr(&gsharedStrctPtr.next));
+    assert(findDataPtr(&gsharedStrctPtr.next.next));
+
+    assert(findDataPtr(&(Struc!(int*).vgshared)));
+    assert(!findDataPtr(&(Struc!(int).vgshared)));
+    assert(findTlsPtr(&(Struc!(int*).vtls)));
+    assert(!findTlsPtr(&(Struc!(int).vtls)));
+}

--- a/gcc/testsuite/gdc.test/runnable/testscope.d
+++ b/gcc/testsuite/gdc.test/runnable/testscope.d
@@ -269,6 +269,20 @@ void test16747() @safe
 
 /********************************************/
 
+byte typify13(T)(byte val) { return val; }
+alias INT8_C13  = typify13!byte;
+
+/********************************************/
+
+template test14(T)
+{
+    alias test14 = int;
+}
+
+test14!(char[] function(return char[])) x14;
+
+/********************************************/
+
 void main()
 {
     test1();


### PR DESCRIPTION
@MartinNowak - I suspect this is small because; one, I'm only looking at notable regressions in the changelogs; two, most of these patches I ported earlier at the beginning of the year.

I guess the next logical steps here would be:
1. Merge runtime library and cherry-pick all compiler regression fixes from 2.075.0
2. Switch over runtime library to the stable branch.
2. Sync the D2 testsuite from dmd/stable to gdc, porting relevant bug fixes.
3. ???
4. Switch frontend to D!