### PR TITLE
Handle push/pop of the current input_location in Visitor entrypoints.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,22 @@
+2017-08-06  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* decl.cc (DeclVisitor::visit): Don't set input_location.
+	(build_decl_tree): Handle set and restore of input_location.
+	(declare_local_var): Don't set input_location.
+	* expr.cc (build_expr): Handle set and restore of input_location.
+	* imports.cc (build_import_decl): Likewise.
+	* modules.cc (get_dso_registry_fn): Use UNKNOWN_LOCATION for
+	declaration of _d_dso_registry.
+	* runtime.cc (build_libcall_decl): Use UNKNOWN_LOCATION for
+	declaration of library functions.
+	* toir.cc (IRVisitor::visit): Don't set input_location.
+	(IRVisitor::build_stmt): New function.
+	(IRVisitor::do_jump): Update signature.
+	(build_function_body): Use IRVisitor::build_stmt.
+	* typeinfo.cc (layout_classinfo_interfaces): Don't set input_location.
+	* types.cc (layout_aggregate_members): Likewise.
+	(layout_aggregate_type): Likewise.
+
 2017-08-02  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* typeinfo.cc (SpeculativeTypeVisitor::visit(TypeClass)): Don't emit

--- a/gcc/d/decl.cc
+++ b/gcc/d/decl.cc
@@ -134,14 +134,7 @@ public:
     if (d->semanticRun >= PASSobj)
       return;
 
-    /* Set input location, empty DECL_SOURCE_FILE can crash debug generator.  */
-    if (d->loc.filename)
-      input_location = get_linemap (d->loc);
-    else
-      input_location = get_linemap (Loc ("<no_file>", 1, 0));
-
     build_module_tree (d);
-
     d->semanticRun = PASSobj;
   }
 
@@ -155,8 +148,6 @@ public:
        this is a renamed import.  */
     if (d->isstatic)
       return;
-
-    input_location = get_linemap (d->loc);
 
     /* Get the context of this import, this should never be null.  */
     tree context = d_module_context ();
@@ -788,7 +779,6 @@ public:
 
     DECL_ARGUMENTS (fndecl) = param_list;
     rest_of_decl_compilation (fndecl, 1, 0);
-    input_location = get_linemap (d->loc);
 
     /* If this is a member function that nested (possibly indirectly) in another
        function, construct an expession for this member function's static chain
@@ -893,8 +883,18 @@ public:
 void
 build_decl_tree (Dsymbol *d)
 {
+  location_t saved_location = input_location;
+
+  /* Set input location, empty DECL_SOURCE_FILE can crash debug generator.  */
+  if (d->loc.filename)
+    input_location = get_linemap (d->loc);
+  else
+    input_location = get_linemap (Loc ("<no_file>", 1, 0));
+
   DeclVisitor v = DeclVisitor ();
   d->accept (&v);
+
+  input_location = saved_location;
 }
 
 /* Return the decl for the symbol, create it if it doesn't already exist.  */
@@ -1290,7 +1290,6 @@ declare_local_var (VarDeclaration *var)
 
   gcc_assert (!TREE_STATIC (decl));
 
-  input_location = get_linemap (var->loc);
   d_pushdecl (decl);
   DECL_CONTEXT (decl) = current_function_decl;
 

--- a/gcc/d/expr.cc
+++ b/gcc/d/expr.cc
@@ -191,9 +191,8 @@ public:
   /* Visitor interfaces, each Expression class should have
      overridden the default.  */
 
-  void visit (Expression *e)
+  void visit (Expression *)
   {
-    input_location = get_linemap (e->loc);
     gcc_unreachable ();
   }
 
@@ -3033,8 +3032,12 @@ tree
 build_expr (Expression *e, bool const_p)
 {
   ExprVisitor v = ExprVisitor (const_p);
+  location_t saved_location = input_location;
+
+  input_location = get_linemap (e->loc);
   e->accept (&v);
   tree expr = v.result ();
+  input_location = saved_location;
 
   /* Check if initializer expression is valid constant.  */
   if (const_p && !initializer_constant_valid_p (expr, TREE_TYPE (expr)))

--- a/gcc/d/imports.cc
+++ b/gcc/d/imports.cc
@@ -189,8 +189,12 @@ build_import_decl (Dsymbol *d)
 {
   if (!d->isym)
     {
+      location_t saved_location = input_location;
       ImportVisitor v;
+
+      input_location = get_linemap (d->loc);
       d->accept (&v);
+      input_location = saved_location;
     }
 
   /* Not all visitors set 'isym'.  */

--- a/gcc/d/modules.cc
+++ b/gcc/d/modules.cc
@@ -308,7 +308,7 @@ get_dso_registry_fn (void)
   tree fntype = build_function_type_list (void_type_node,
 					  build_pointer_type (dso_type),
 					  NULL_TREE);
-  dso_registry_fn = build_decl (input_location, FUNCTION_DECL,
+  dso_registry_fn = build_decl (UNKNOWN_LOCATION, FUNCTION_DECL,
 				get_identifier ("_d_dso_registry"), fntype);
   TREE_PUBLIC (dso_registry_fn) = 1;
   DECL_EXTERNAL (dso_registry_fn) = 1;

--- a/gcc/d/runtime.cc
+++ b/gcc/d/runtime.cc
@@ -248,7 +248,7 @@ build_libcall_decl (const char *name, libcall_type return_type,
   else
     fntype = build_function_type_array (tret, nparams, args);
 
-  tree decl = build_decl (input_location, FUNCTION_DECL,
+  tree decl = build_decl (UNKNOWN_LOCATION, FUNCTION_DECL,
 			  get_identifier (name), fntype);
   DECL_EXTERNAL (decl) = 1;
   TREE_PUBLIC (decl) = 1;

--- a/gcc/d/toir.cc
+++ b/gcc/d/toir.cc
@@ -240,6 +240,17 @@ public:
     this->continue_label_ = NULL_TREE;
   }
 
+  /* Helper for generating code for the statement AST class S.
+     Sets up the location of the statement before lowering.  */
+
+  void build_stmt (Statement *s)
+  {
+    location_t saved_location = input_location;
+    input_location = get_linemap (s->loc);
+    s->accept (this);
+    input_location = saved_location;
+  }
+
   /* Start a new scope for a KIND statement.
      Each user-declared variable will have a binding contour that begins
      where the variable is declared and ends at it's containing scope.  */
@@ -322,11 +333,8 @@ public:
 
   /* Emit a goto expression to LABEL.  */
 
-  void do_jump (Statement *stmt, tree label)
+  void do_jump (tree label)
   {
-    if (stmt)
-      input_location = get_linemap (stmt->loc);
-
     add_stmt (fold_build1 (GOTO_EXPR, void_type_node, label));
     TREE_USED (label) = 1;
   }
@@ -417,7 +425,7 @@ public:
     else
       {
 	tree name = ident ? get_identifier (ident->toChars ()) : NULL_TREE;
-	tree decl = build_decl (input_location, LABEL_DECL,
+	tree decl = build_decl (get_linemap (s->loc), LABEL_DECL,
 				name, void_type_node);
 	DECL_CONTEXT (decl) = current_function_decl;
 	DECL_MODE (decl) = VOIDmode;
@@ -451,7 +459,7 @@ public:
 	TREE_VEC_ELT (vec, bc_break) = ent->label;
 
 	/* Build the continue label.  */
-	tree label = build_decl (input_location, LABEL_DECL,
+	tree label = build_decl (get_linemap (s->loc), LABEL_DECL,
 				 NULL_TREE, void_type_node);
 	DECL_CONTEXT (label) = current_function_decl;
 	DECL_MODE (label) = VOIDmode;
@@ -507,9 +515,8 @@ public:
 
   /* This should be overridden by each statement class.  */
 
-  void visit (Statement *s)
+  void visit (Statement *)
   {
-    input_location = get_linemap (s->loc);
     gcc_unreachable ();
   }
 
@@ -525,7 +532,6 @@ public:
 
   void visit (IfStatement *s)
   {
-    input_location = get_linemap (s->loc);
     this->start_scope (level_cond);
 
     /* Build the outer 'if' condition, which may produce temporaries
@@ -539,7 +545,7 @@ public:
     if (s->ifbody)
       {
 	push_stmt_list ();
-	s->ifbody->accept (this);
+	this->build_stmt (s->ifbody);
 	ifbody = pop_stmt_list ();
       }
 
@@ -547,12 +553,11 @@ public:
     if (s->elsebody)
       {
 	push_stmt_list ();
-	s->elsebody->accept (this);
+	this->build_stmt (s->elsebody);
 	elsebody = pop_stmt_list ();
       }
 
     /* Wrap up our constructed if condition into a COND_EXPR.  */
-    input_location = get_linemap (s->loc);
     tree cond = build_vcondition (ifcond, ifbody, elsebody);
     add_stmt (cond);
 
@@ -572,9 +577,8 @@ public:
      This visitor is not strictly required other than to enforce that
      these kinds of statements never reach here.  */
 
-  void visit (WhileStatement *s)
+  void visit (WhileStatement *)
   {
-    input_location = get_linemap (s->loc);
     gcc_unreachable ();
   }
 
@@ -583,20 +587,18 @@ public:
 
   void visit (DoStatement *s)
   {
-    input_location = get_linemap (s->loc);
     tree lbreak = this->push_break_label (s);
 
     this->start_scope (level_loop);
     if (s->_body)
       {
 	tree lcontinue = this->push_continue_label (s);
-	s->_body->accept (this);
+	this->build_stmt (s->_body);
 	this->pop_continue_label (lcontinue);
       }
 
     /* Build the outer 'while' condition, which may produce temporaries
        requiring scope destruction.  */
-    input_location = get_linemap (s->condition->loc);
     tree exitcond = convert_for_condition (build_expr_dtor (s->condition),
 					   s->condition->type);
     add_stmt (build_vcondition (exitcond, void_node,
@@ -604,7 +606,6 @@ public:
     TREE_USED (lbreak) = 1;
 
     tree body = this->end_scope ();
-    input_location = get_linemap (s->loc);
     add_stmt (build1 (LOOP_EXPR, void_type_node, body));
 
     this->pop_break_label (lbreak);
@@ -615,16 +616,14 @@ public:
 
   void visit (ForStatement *s)
   {
-    input_location = get_linemap (s->loc);
     tree lbreak = this->push_break_label (s);
     this->start_scope (level_loop);
 
     if (s->_init)
-      s->_init->accept (this);
+      this->build_stmt (s->_init);
 
     if (s->condition)
       {
-	input_location = get_linemap (s->condition->loc);
 	tree exitcond = convert_for_condition (build_expr_dtor (s->condition),
 					       s->condition->type);
 	add_stmt (build_vcondition (exitcond, void_node,
@@ -636,19 +635,17 @@ public:
     if (s->_body)
       {
 	tree lcontinue = this->push_continue_label (s);
-	s->_body->accept (this);
+	this->build_stmt (s->_body);
 	this->pop_continue_label (lcontinue);
       }
 
     if (s->increment)
       {
 	/* Force side effects?  */
-	input_location = get_linemap (s->increment->loc);
 	add_stmt (build_expr_dtor (s->increment));
       }
 
     tree body = this->end_scope ();
-    input_location = get_linemap (s->loc);
     add_stmt (build1 (LOOP_EXPR, void_type_node, body));
 
     this->pop_break_label (lbreak);
@@ -658,9 +655,8 @@ public:
      This visitor is not strictly required other than to enforce that
      these kinds of statements never reach here.  */
 
-  void visit (ForeachStatement *s)
+  void visit (ForeachStatement *)
   {
-    input_location = get_linemap (s->loc);
     gcc_unreachable ();
   }
 
@@ -668,9 +664,8 @@ public:
      loops.  This visitor is not strictly required other than to enforce that
      these kinds of statements never reach here.  */
 
-  void visit (ForeachRangeStatement *s)
+  void visit (ForeachRangeStatement *)
   {
-    input_location = get_linemap (s->loc);
     gcc_unreachable ();
   }
 
@@ -686,10 +681,10 @@ public:
 	LabelStatement *label = this->func_->searchLabel (s->ident)->statement;
 	gcc_assert (label != NULL);
 	Statement *stmt = label->statement->getRelatedLabeled ();
-	this->do_jump (s, this->lookup_bc_label (stmt, bc_break));
+	this->do_jump (this->lookup_bc_label (stmt, bc_break));
       }
     else
-      this->do_jump (s, this->break_label_);
+      this->do_jump (this->break_label_);
   }
 
   /* Jump to the associated continue label for the current loop.  If IDENT
@@ -701,11 +696,11 @@ public:
       {
 	LabelStatement *label = this->func_->searchLabel (s->ident)->statement;
 	gcc_assert (label != NULL);
-	this->do_jump (s, this->lookup_bc_label (label->statement,
-						 bc_continue));
+	this->do_jump (this->lookup_bc_label (label->statement,
+					      bc_continue));
       }
     else
-      this->do_jump (s, this->continue_label_);
+      this->do_jump (this->continue_label_);
   }
 
   /* A goto statement jumps to the statement identified by the given label.  */
@@ -715,13 +710,9 @@ public:
     gcc_assert (s->label->statement != NULL);
     gcc_assert (s->tf == s->label->statement->tf);
 
-    /* This makes the 'undefined label' error show up on the correct line.
-       The extra get_linemap in do_jump shouldn't cause a problem.  */
-    input_location = get_linemap (s->loc);
-
     /* If no label found, there was an error.  */
     tree label = this->lookup_label (s->label->statement, s->label->ident);
-    this->do_jump (s, label);
+    this->do_jump (label);
 
     /* Need to error if the goto is jumping into a try or catch block.  */
     this->check_goto (s, s->label->statement);
@@ -739,8 +730,6 @@ public:
     else
       sym = this->func_->searchLabel (s->ident);
 
-    input_location = get_linemap (s->loc);
-
     /* If no label found, there was an error.  */
     tree label = this->define_label (sym->statement, sym->ident);
     TREE_USED (label) = 1;
@@ -748,9 +737,9 @@ public:
     this->do_label (label);
 
     if (this->is_return_label (s->ident) && this->func_->fensure != NULL)
-      this->func_->fensure->accept (this);
+      this->build_stmt (this->func_->fensure);
     else if (s->statement)
-      s->statement->accept (this);
+      this->build_stmt (s->statement);
   }
 
   /* A switch statement goes to one of a collection of case statements
@@ -758,7 +747,6 @@ public:
 
   void visit (SwitchStatement *s)
   {
-    input_location = get_linemap (s->loc);
     this->start_scope (level_switch);
     tree lbreak = this->push_break_label (s);
 
@@ -870,7 +858,7 @@ public:
 	    /* The default label is the last 'else' block.  */
 	    if (s->hasVars)
 	      {
-		this->do_jump (NULL, defaultlabel);
+		this->do_jump (defaultlabel);
 		LABEL_VARIABLE_CASE (defaultlabel) = 1;
 	      }
 
@@ -881,7 +869,7 @@ public:
     /* Switch body goes in its own statement list.  */
     push_stmt_list ();
     if (s->_body)
-      s->_body->accept (this);
+      this->build_stmt (s->_body);
 
     tree casebody = pop_stmt_list ();
 
@@ -905,8 +893,6 @@ public:
 
   void visit (CaseStatement *s)
   {
-    input_location = get_linemap (s->loc);
-
     /* Emit the case label.  */
     tree label = this->define_label (s);
 
@@ -926,15 +912,13 @@ public:
 
     /* Now do the body.  */
     if (s->statement)
-      s->statement->accept (this);
+      this->build_stmt (s->statement);
   }
 
   /* Declare the default label associated with the current SwitchStatement.  */
 
   void visit (DefaultStatement *s)
   {
-    input_location = get_linemap (s->loc);
-
     /* Emit the default case label.  */
     tree label = this->define_label (s);
 
@@ -948,7 +932,7 @@ public:
 
     /* Now do the body.  */
     if (s->statement)
-      s->statement->accept (this);
+      this->build_stmt (s->statement);
   }
 
   /* Implements 'goto default' by jumping to the label associated with
@@ -957,7 +941,7 @@ public:
   void visit (GotoDefaultStatement *s)
   {
     tree label = this->lookup_label (s->sw->sdefault);
-    this->do_jump (s, label);
+    this->do_jump (label);
   }
 
   /* Implements 'goto case' by jumping to the label associated with the
@@ -966,7 +950,7 @@ public:
   void visit (GotoCaseStatement *s)
   {
     tree label = this->lookup_label (s->cs);
-    this->do_jump (s, label);
+    this->do_jump (label);
   }
 
   /* Throw a SwitchError exception, called when a switch statement has
@@ -974,7 +958,6 @@ public:
 
   void visit (SwitchErrorStatement *s)
   {
-    input_location = get_linemap (s->loc);
     add_stmt (d_assert_call (s->loc, LIBCALL_SWITCH_ERROR));
   }
 
@@ -983,8 +966,6 @@ public:
 
   void visit (ReturnStatement *s)
   {
-    input_location = get_linemap (s->loc);
-
     if (s->exp == NULL || s->exp->type->toBasetype ()->ty == Tvoid)
       {
 	/* Return has no value.  */
@@ -1021,7 +1002,6 @@ public:
   {
     if (s->exp)
       {
-	input_location = get_linemap (s->loc);
 	/* Expression may produce temporaries requiring scope destruction.  */
 	tree exp = build_expr_dtor (s->exp);
 	add_stmt (exp);
@@ -1040,7 +1020,7 @@ public:
 	Statement *statement = (*s->statements)[i];
 
 	if (statement != NULL)
-	  statement->accept (this);
+	  this->build_stmt (statement);
       }
   }
 
@@ -1063,15 +1043,14 @@ public:
 	if (statement != NULL)
 	  {
 	    tree lcontinue = this->push_continue_label (statement);
-	    statement->accept (this);
+	    this->build_stmt (statement);
 	    this->pop_continue_label (lcontinue);
 	  }
       }
 
-    this->do_jump (NULL, this->break_label_);
+    this->do_jump (this->break_label_);
 
     tree body = this->end_scope ();
-    input_location = get_linemap (s->loc);
     add_stmt (build1 (LOOP_EXPR, void_type_node, body));
 
     this->pop_break_label (lbreak);
@@ -1086,7 +1065,7 @@ public:
       return;
 
     this->start_scope (level_block);
-    s->statement->accept (this);
+    this->build_stmt (s->statement);
     this->finish_scope ();
   }
 
@@ -1095,7 +1074,6 @@ public:
 
   void visit (WithStatement *s)
   {
-    input_location = get_linemap (s->loc);
     this->start_scope (level_with);
 
     if (s->wthis)
@@ -1110,7 +1088,7 @@ public:
       }
 
     if (s->_body)
-      s->_body->accept (this);
+      this->build_stmt (s->_body);
 
     this->finish_scope ();
   }
@@ -1143,7 +1121,6 @@ public:
     else
       arg = build_nop (build_ctype (get_object_type ()), arg);
 
-    input_location = get_linemap (s->loc);
     add_stmt (build_libcall (LIBCALL_THROW, Type::tvoid, 1, arg));
   }
 
@@ -1153,11 +1130,9 @@ public:
 
   void visit (TryCatchStatement *s)
   {
-    input_location = get_linemap (s->loc);
-
     this->start_scope (level_try);
     if (s->_body)
-      s->_body->accept (this);
+      this->build_stmt (s->_body);
 
     tree trybody = this->end_scope ();
 
@@ -1170,7 +1145,6 @@ public:
 	  {
 	    Catch *vcatch = (*s->catches)[i];
 
-	    input_location = get_linemap (vcatch->loc);
 	    this->start_scope (level_catch);
 
 	    tree ehptr = builtin_decl_explicit (BUILT_IN_EH_POINTER);
@@ -1205,7 +1179,7 @@ public:
 	      }
 
 	    if (vcatch->handler)
-	      vcatch->handler->accept (this);
+	      this->build_stmt (vcatch->handler);
 
 	    tree catchbody = this->end_scope ();
 
@@ -1236,7 +1210,6 @@ public:
         catches = stmt_list;
       }
 
-    input_location = get_linemap (s->loc);
     add_stmt (build2 (TRY_CATCH_EXPR, void_type_node, trybody, catches));
   }
 
@@ -1246,20 +1219,18 @@ public:
 
   void visit (TryFinallyStatement *s)
   {
-    input_location = get_linemap (s->loc);
     this->start_scope (level_try);
     if (s->_body)
-      s->_body->accept (this);
+      this->build_stmt (s->_body);
 
     tree trybody = this->end_scope ();
 
     this->start_scope (level_finally);
     if (s->finalbody)
-      s->finalbody->accept (this);
+      this->build_stmt (s->finalbody);
 
     tree finally = this->end_scope ();
 
-    input_location = get_linemap (s->loc);
     add_stmt (build2 (TRY_FINALLY_EXPR, void_type_node, trybody, finally));
   }
 
@@ -1268,9 +1239,8 @@ public:
      This visitor is not strictly required other than to enforce that
      these kinds of statements never reach here.  */
 
-  void visit (SynchronizedStatement *s)
+  void visit (SynchronizedStatement *)
   {
-    input_location = get_linemap (s->loc);
     gcc_unreachable ();
   }
 
@@ -1278,9 +1248,8 @@ public:
      an assembly parser for each supported target.  Instead we leverage
      GCC extended assembler using the ExtAsmStatement class.  */
 
-  void visit (AsmStatement *s)
+  void visit (AsmStatement *)
   {
-    input_location = get_linemap (s->loc);
     sorry ("D inline assembler statements are not supported in GDC.");
   }
 
@@ -1294,8 +1263,6 @@ public:
     tree inputs = NULL_TREE;
     tree clobbers = NULL_TREE;
     tree labels = NULL_TREE;
-
-    input_location = get_linemap (s->loc);
 
     /* Collect all arguments, which may be input or output operands.  */
     if (s->args)
@@ -1413,7 +1380,7 @@ public:
 
     tree exp = build5 (ASM_EXPR, void_type_node, string,
 		       outputs, inputs, clobbers, labels);
-    SET_EXPR_LOCATION (exp, input_location);
+    SET_EXPR_LOCATION (exp, get_linemap (s->loc));
 
     /* If the extended syntax was not used, mark the ASM_EXPR.  */
     if (s->args == NULL && s->clobbers == NULL)
@@ -1443,11 +1410,11 @@ public:
 };
 
 /* Main entry point for the IRVisitor interface to generate
-   code for the statement AST class S.  */
+   code for the body of function FD.  */
 
 void
 build_function_body (FuncDeclaration *fd)
 {
   IRVisitor v = IRVisitor (fd);
-  fd->fbody->accept (&v);
+  v.build_stmt (fd->fbody);
 }

--- a/gcc/d/typeinfo.cc
+++ b/gcc/d/typeinfo.cc
@@ -1138,7 +1138,6 @@ layout_classinfo_interfaces (ClassDeclaration *decl)
 {
   tree type = tinfo_types[TK_CLASSINFO_TYPE];
   size_t structsize = int_size_in_bytes (type);
-  input_location = get_linemap (decl->loc);
 
   if (decl->vtblInterfaces->dim)
     {

--- a/gcc/d/types.cc
+++ b/gcc/d/types.cc
@@ -296,7 +296,6 @@ layout_aggregate_members (Dsymbols *members, tree context, bool inherited_p)
 	  if (var->isField ())
 	    {
 	      const char *ident = var->ident ? var->ident->toChars () : NULL;
-	      input_location = get_linemap (var->loc);
 	      tree field = create_field_decl (declaration_type (var), ident,
 					      inherited_p, inherited_p);
 	      insert_aggregate_field (context, field, var->offset);
@@ -329,10 +328,10 @@ layout_aggregate_members (Dsymbols *members, tree context, bool inherited_p)
 	  tree type = make_node (ad->isunion ? UNION_TYPE : RECORD_TYPE);
 	  ANON_AGGR_TYPE_P (type) = 1;
 	  d_keep (type);
-	  input_location = get_linemap (ad->loc);
 
 	  /* Build the type declaration.  */
-	  tree decl = build_decl (input_location, TYPE_DECL, ident, type);
+	  tree decl = build_decl (get_linemap (ad->loc),
+				  TYPE_DECL, ident, type);
 	  DECL_CONTEXT (decl) = context;
 	  DECL_ARTIFICIAL (decl) = 1;
 
@@ -395,7 +394,6 @@ layout_aggregate_type (AggregateDeclaration *decl, tree type,
 {
   ClassDeclaration *cd = base->isClassDeclaration ();
   bool inherited_p = (decl != base);
-  input_location = get_linemap (decl->loc);
 
   if (cd != NULL)
     {


### PR DESCRIPTION
After #467, I've noticed that debug line numbers tend to be a bit more jumpy around the place.  The interface itself may not be needed, as I've refactored things around to limit the places where updating `input_location` happen.