### PR TITLE
Do not send functions to backend in TypeInfoVisitor

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2017-08-23  Johannes Pfau  <johannespfau@gmail.com>
+
+	* typeinfo.cc (TypeInfoVisitor::visit(TypeInfoStructDeclaration)): Do
+	not send member functions to backend here.
+
 2017-08-19  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-convert.cc (convert_expr): Use build_zero_cst for casts from

--- a/gcc/d/typeinfo.cc
+++ b/gcc/d/typeinfo.cc
@@ -956,31 +956,6 @@ public:
     if (!sd->members)
       return;
 
-    /* Send member functions to backend here.  */
-    TemplateInstance *tinst = sd->isInstantiated ();
-    if (tinst && !tinst->needsCodegen ())
-      {
-	gcc_assert (tinst->minst || sd->requestTypeInfo);
-
-	if (sd->xeq && sd->xeq != StructDeclaration::xerreq)
-	  build_decl_tree (sd->xeq);
-
-	if (sd->xcmp && sd->xcmp != StructDeclaration::xerrcmp)
-	  build_decl_tree (sd->xcmp);
-
-	if (FuncDeclaration *ftostr = search_toString (sd))
-	  build_decl_tree (ftostr);
-
-	if (sd->xhash)
-	  build_decl_tree (sd->xhash);
-
-	if (sd->postblit)
-	  build_decl_tree (sd->postblit);
-
-	if (sd->dtor)
-	  build_decl_tree (sd->dtor);
-      }
-
     /* Name of the struct declaration.  */
     this->layout_string (sd->toPrettyChars ());
 


### PR DESCRIPTION
This can cause problems with the die pruning in dwarf2out.c.
See https://github.com/D-Programming-GDC/GDC/pull/542#issuecomment-323479916