### PR TITLE
Remove aarch64 from target in dg link tests

### DIFF
--- a/gcc/testsuite/gdc.dg/link.d
+++ b/gcc/testsuite/gdc.dg/link.d
@@ -1,4 +1,4 @@
-// { dg-do link { target aarch64*-*-* arm*-*-* i?86-*-* x86_64-*-* } }
+// { dg-do link { target arm*-*-* i?86-*-* x86_64-*-* } }
 
 class A()
 {

--- a/gcc/testsuite/gdc.dg/lto.d
+++ b/gcc/testsuite/gdc.dg/lto.d
@@ -1,6 +1,6 @@
 // { dg-additional-sources "imports/ltoa.d" }
 // { dg-additional-options "-flto" }
-// { dg-do run { target aarch64*-*-* arm*-*-* i?86-*-* x86_64-*-* } }
+// { dg-do run { target arm*-*-* i?86-*-* x86_64-*-* } }
 
 module lto;
 

--- a/gcc/testsuite/gdc.dg/runnable.d
+++ b/gcc/testsuite/gdc.dg/runnable.d
@@ -1,5 +1,5 @@
 // { dg-additional-sources "imports/runnablea.d" }
-// { dg-do run { target aarch64*-*-* arm*-*-* i?86-*-* x86_64-*-* } }
+// { dg-do run { target arm*-*-* i?86-*-* x86_64-*-* } }
 
 module runnable;
 

--- a/gcc/testsuite/gdc.dg/simd.d
+++ b/gcc/testsuite/gdc.dg/simd.d
@@ -1,4 +1,4 @@
-// { dg-do run { target aarch64*-*-* arm*-*-* i?86-*-* x86_64-*-* } }
+// { dg-do run { target arm*-*-* i?86-*-* x86_64-*-* } }
 import core.simd;
 import core.stdc.string;
 import std.stdio;


### PR DESCRIPTION
The buildbot CI doesn't build phobos for aarch64 yet, so this can't be tested properly.