### PR TITLE
fix Bug 272 - ICE with -fsanitize=address

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2017-09-26  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* types.cc (make_array_type): Move checking of void static arrays
+	here.
+
 2017-09-24  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-attribs.c: Add include for attribs.h.

--- a/gcc/d/types.cc
+++ b/gcc/d/types.cc
@@ -121,24 +121,27 @@ get_object_type (void)
 tree
 make_array_type (Type *type, unsigned HOST_WIDE_INT size)
 {
-  tree telem = build_ctype (type);
+  /* In [arrays/void-arrays], void arrays can also be static, the length is
+     specified in bytes.  */
+  if (type->toBasetype ()->ty == Tvoid)
+    type = Type::tuns8;
 
   /* In [arrays/static-arrays], a static array with a dimension of 0 is allowed,
      but no space is allocated for it.  */
   if (size == 0)
     {
-      tree zrange = lang_hooks.types.type_for_size (TYPE_PRECISION (sizetype),
-						    TYPE_UNSIGNED (sizetype));
-      tree zindex = build_range_type (zrange, size_zero_node, NULL_TREE);
-      tree ztype = build_array_type (build_ctype (type), zindex);
+      tree range = lang_hooks.types.type_for_size (TYPE_PRECISION (sizetype),
+						   TYPE_UNSIGNED (sizetype));
+      tree index = build_range_type (range, size_zero_node, NULL_TREE);
 
-      TYPE_SIZE (ztype) = bitsize_zero_node;
-      TYPE_SIZE_UNIT (ztype) = size_zero_node;
-
-      return ztype;
+      tree t = build_array_type (build_ctype (type), index);
+      TYPE_SIZE (t) = bitsize_zero_node;
+      TYPE_SIZE_UNIT (t) = size_zero_node;
+      return t;
     }
 
-  return build_array_type (telem, build_index_type (size_int (size - 1)));
+  return build_array_type (build_ctype (type),
+			   build_index_type (size_int (size - 1)));
 }
 
 /* Builds a record type whose name is NAME.  NFIELDS is the number of fields,
@@ -626,12 +629,7 @@ public:
     if (t->dim->isConst () && t->dim->type->isintegral ())
       {
 	uinteger_t size = t->dim->toUInteger ();
-	/* In [arrays/void-arrays], void arrays can also be static,
-	   the length is specified in bytes.  */
-	if (t->next->toBasetype ()->ty == Tvoid)
-	  t->ctype = make_array_type (Type::tuns8, size);
-	else
-	  t->ctype = make_array_type (t->next, size);
+	t->ctype = make_array_type (t->next, size);
       }
     else
       {

--- a/gcc/testsuite/gdc.dg/asan/asan.exp
+++ b/gcc/testsuite/gdc.dg/asan/asan.exp
@@ -1,0 +1,32 @@
+#   Copyright (C) 2017 Free Software Foundation, Inc.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GCC; see the file COPYING3.  If not see
+# <http://www.gnu.org/licenses/>.
+
+# Load support procs.
+load_lib gdc-dg.exp
+load_lib asan-dg.exp
+
+# Initialize `dg'.
+dg-init
+asan_init
+
+# Main loop.
+if [check_effective_target_fsanitize_address] {
+  gdc-dg-runtest [lsort [glob -nocomplain $srcdir/$subdir/*.d]] "" ""
+}
+
+# All done.
+asan_finish
+dg-finish

--- a/gcc/testsuite/gdc.dg/asan/gdc272.d
+++ b/gcc/testsuite/gdc.dg/asan/gdc272.d
@@ -1,0 +1,16 @@
+/* { dg-options "-fsanitize=address" } */
+/* { dg-do compile } */
+
+module asantests;
+
+
+/******************************************/
+
+// Bug 272
+
+extern(C) void my_memcmp(const(void) *s1, const(void) *s2);
+
+void bug(const(char)* p)
+{
+        my_memcmp(p, "__FILE__".ptr);
+}

--- a/gcc/testsuite/gdc.dg/lto/lto.exp
+++ b/gcc/testsuite/gdc.dg/lto/lto.exp
@@ -1,0 +1,56 @@
+#   Copyright (C) 2017 Free Software Foundation, Inc.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GCC; see the file COPYING3.  If not see
+# <http://www.gnu.org/licenses/>.
+
+# Test link-time optimization across multiple files.
+#
+# Programs are broken into multiple files.  Each one is compiled
+# separately with LTO information.  The final executable is generated
+# by collecting all the generated object files using regular LTO or WHOPR.
+
+if $tracelevel then {
+    strace $tracelevel
+}
+
+# Load procedures from common libraries.
+load_lib standard.exp
+load_lib gdc-dg.exp
+
+# Load the language-independent compabibility support procedures.
+load_lib lto.exp
+
+# If LTO has not been enabled, bail.
+if { ![check_effective_target_lto] } {
+    return
+}
+
+lto_init no-mathlib
+
+# Define an identifier for use with this suite to avoid name conflicts
+# with other lto tests running at the same time.
+set sid "d_lto"
+
+# Main loop.
+foreach src [lsort [find $srcdir/$subdir *_0.d]] {
+    # If we're only testing specific files and this isn't one of them, skip it.
+    if ![runtest_file_p $runtests $src] then {
+        continue
+    }
+
+    lto-execute $src $sid
+}
+
+lto_finish
+

--- a/gcc/testsuite/gdc.dg/lto/ltotests_0.d
+++ b/gcc/testsuite/gdc.dg/lto/ltotests_0.d
@@ -1,10 +1,5 @@
-// { dg-additional-sources "imports/ltoa.d" }
-// { dg-additional-options "-flto" }
-// { dg-do run { target arm*-*-* i?86-*-* x86_64-*-* } }
+module ltotests_0;
 
-module lto;
-
-import imports.ltoa;
 import core.stdc.stdio;
 
 
@@ -63,6 +58,8 @@ struct S61b
 /******************************************/
 
 // Bug 88
+
+extern(C) int test88a();
 
 void test88()
 {

--- a/gcc/testsuite/gdc.dg/lto/ltotests_1.d
+++ b/gcc/testsuite/gdc.dg/lto/ltotests_1.d
@@ -1,9 +1,9 @@
-module imports.ltoa;
+module ltotests_1;
 
 /******************************************/
 // Bug 88
 
-int test88a()
+extern(C) int test88a()
 {
     return 0;
 }


### PR DESCRIPTION
https://bugzilla.gdcproject.org/show_bug.cgi?id=272

The visitor for `TypeSArray` is not the only place where `make_array_type` may be called from.  All need to be checked for void arrays.