### PR TITLE
Fix Bug 240: Order of evaluation not always left to right.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,10 @@
+2017-12-09  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-tree.h (CALL_EXPR_ARGS_ORDERED): Define.
+	* d-codegen.cc (d_build_call): Set CALL_EXPR_ARGS_ORDERED for
+	functions with D linkage.
+	* d-lang.cc (d_gimplify_expr): Handle CALL_EXPR_ARGS_ORDERED.
+
 2017-11-14  Eugene Wissner  <belka@caraus.de>
 
 	* decl.cc (finish_thunk): Drop frequency argument from

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -46,6 +46,7 @@ typedef Array<Expression *> Expressions;
 
 /* Usage of TREE_LANG_FLAG_?:
    0: METHOD_CALL_EXPR
+   1: CALL_EXPR_ARGS_ORDERED (in CALL_EXPR).
 
    Usage of TYPE_LANG_FLAG_?:
    0: TYPE_SHARED
@@ -337,6 +338,11 @@ lang_tree_node
    but a literal function / method reference.  */
 #define METHOD_CALL_EXPR(NODE) \
   (TREE_LANG_FLAG_0 (NODE))
+
+/* True if all arguments in a call expression should be evaluated in the
+   order they are given (left to right).  */
+#define CALL_EXPR_ARGS_ORDERED(NODE) \
+  (TREE_LANG_FLAG_1 (CALL_EXPR_CHECK (NODE)))
 
 /* True if the type was declared 'shared'.  */
 #define TYPE_SHARED(NODE) \

--- a/gcc/testsuite/gdc.dg/runnable.d
+++ b/gcc/testsuite/gdc.dg/runnable.d
@@ -1387,6 +1387,23 @@ void test210()
 
 /******************************************/
 
+// Bug 240
+
+void test240a(int a, int b)
+{
+    assert(a == 0);
+    assert(b == 0);
+}
+
+void test240()
+{
+    int a = 0;
+    test240a(a, a++);
+    assert(a == 1);
+}
+
+/******************************************/
+
 // Bug 242
 
 struct S242
@@ -1542,6 +1559,8 @@ void main()
     test198();
     test200();
     test210();
+    test240();
+    test242();
     test248();
     test250();
     test273();


### PR DESCRIPTION
https://bugzilla.gdcproject.org/show_bug.cgi?id=240

Delays lowering of the order until gimplification.