### PR TITLE
Rename command-line switch -fmodule-filepath= to -fmodule-file=

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,10 @@
 2017-12-09  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* lang.opt (fmodule-filepath=): Rename to fmodule-file.
+	* d-lang.cc (d_handle_option): Update case for OPT_fmodule_file_.
+
+2017-12-09  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* d-tree.h (CALL_EXPR_ARGS_ORDERED): Define.
 	* d-codegen.cc (d_build_call): Set CALL_EXPR_ARGS_ORDERED for
 	functions with D linkage.

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -493,10 +493,10 @@ d_handle_option (size_t scode, const char *arg, int value,
       global.params.useInvariants = value;
       break;
 
-    case OPT_fmodule_filepath_:
+    case OPT_fmodule_file_:
       global.params.modFileAliasStrings->push (arg);
       if (!strchr (arg, '='))
-	error ("bad argument for -fmodule-filepath");
+	error ("bad argument for -fmodule-file");
       break;
 
     case OPT_fmoduleinfo:

--- a/gcc/d/gdc.texi
+++ b/gcc/d/gdc.texi
@@ -364,8 +364,8 @@ When linking, specify a library search directory, as with @command{gcc}.
 This option specifies where to find the executables, libraries,
 source files, and data files of the compiler itself, as with @command{gcc}.
 
-@item -fmodule-filepath=@var{module}=@var{spec}
-@cindex @option{-fmodule-filepath}
+@item -fmodule-file=@var{module}=@var{spec}
+@cindex @option{-fmodule-file}
 This option manipulates file paths of imported modules, such that if an
 imported module matches all or the leftmost part of @var{module}, the file
 path in @var{spec} is used as the location to search for D sources.
@@ -373,7 +373,7 @@ This is used when the source file path and names are not the same as the
 package and module hierachy.  Consider the following examples:
 
 @example
-gdc test.d -fmodule-filepath=A.B=foo.d -fmodule-filepath=C=bar
+gdc test.d -fmodule-file=A.B=foo.d -fmodule-file=C=bar
 @end example
 
 This will tell the compiler to search in all import paths for the source

--- a/gcc/d/lang.opt
+++ b/gcc/d/lang.opt
@@ -260,9 +260,9 @@ fmake-mdeps=
 D Joined RejectNegative
 Deprecated in favor of -MMD
 
-fmodule-filepath=
+fmodule-file=
 D Joined RejectNegative
--fmodule-filepath=<package.module>=<filespec>	use <filespec> as source file for <package.module>
+-fmodule-file=<package.module>=<filespec>	use <filespec> as source file for <package.module>
 
 fmoduleinfo
 D

--- a/gcc/testsuite/gdc.test/d_do_test.exp
+++ b/gcc/testsuite/gdc.test/d_do_test.exp
@@ -81,7 +81,7 @@ proc gdc-convert-args { base args } {
             lappend out "-finline-functions"
 
         } elseif [regexp -- {^-mv=([\w+=./-]+)} $arg pattern value] {
-            lappend out "-fmodule-filepath=$value"
+            lappend out "-fmodule-file=$value"
 
         } elseif [string match "-O" $arg] {
             lappend out "-O2"


### PR DESCRIPTION
I think it's better to name it this way.