### PR TITLE
Phobos test runner: Do not truncate pointer to 32bits

### DIFF
--- a/libphobos/testsuite/test_runner.d
+++ b/libphobos/testsuite/test_runner.d
@@ -40,7 +40,7 @@ bool printAll()
         if (m.unitTest)
         {
             string name = m.name;
-            printf("%.*s\n", cast(uint)name.length, cast(uint)name.ptr);
+            printf("%.*s\n", cast(int)name.length, name.ptr);
         }
     }
     return true;


### PR DESCRIPTION
This is wrong for 64 bit targets. According to POSIX, the length is of type int, but the pointer is a normal pointer type.

Interesting this never caused problems on X86_64, I guess the static data segment is in the lower part of the address space? Anyway, with this fixed, druntime passes tests on AArch64 (except for https://issues.dlang.org/show_bug.cgi?id=18089)