### PR TITLE
Various std.math backports for aarch64

### DIFF
--- a/libphobos/src/std/math.d
+++ b/libphobos/src/std/math.d
@@ -5159,22 +5159,18 @@ struct FloatingPointControl
 private:
     version(ARM)
     {
-        enum uint EXCEPTION_MASK = 0x9F00;
         enum uint ROUNDING_MASK = 0xC00000;
     }
     else version(PPC_Any)
     {
-        enum uint EXCEPTION_MASK = 0x00F8;
         enum uint ROUNDING_MASK = 0x0003;
     }
     else version(X86)
     {
-        enum ushort EXCEPTION_MASK = 0x3F;
         enum ushort ROUNDING_MASK = 0xC00;
     }
     else version(X86_64)
     {
-        enum ushort EXCEPTION_MASK = 0x3F;
         enum ushort ROUNDING_MASK = 0xC00;
     }
     else
@@ -5193,8 +5189,8 @@ public:
             auto oldState = getControlState();
             // If exceptions are not supported, we set the bit but read it back as zero
             // https://sourceware.org/ml/libc-ports/2012-06/msg00091.html
-            setControlState(oldState | (divByZeroException & EXCEPTION_MASK));
-            immutable result = (getControlState() & EXCEPTION_MASK) != 0;
+            setControlState(oldState | (divByZeroException & allExceptions));
+            immutable result = (getControlState() & allExceptions) != 0;
             setControlState(oldState);
             return result;
         }
@@ -5208,9 +5204,9 @@ public:
         assert(hasExceptionTraps);
         initialize();
         version(X86_Any)
-            setControlState(getControlState() & ~(exceptions & EXCEPTION_MASK));
+            setControlState(getControlState() & ~(exceptions & allExceptions));
         else
-            setControlState(getControlState() | (exceptions & EXCEPTION_MASK));
+            setControlState(getControlState() | (exceptions & allExceptions));
     }
 
     /// Disable (mask) specific hardware exceptions. Multiple exceptions may be ORed together.
@@ -5219,9 +5215,9 @@ public:
         assert(hasExceptionTraps);
         initialize();
         version(X86_Any)
-            setControlState(getControlState() | (exceptions & EXCEPTION_MASK));
+            setControlState(getControlState() | (exceptions & allExceptions));
         else
-            setControlState(getControlState() & ~(exceptions & EXCEPTION_MASK));
+            setControlState(getControlState() & ~(exceptions & allExceptions));
     }
 
     /// Returns: the exceptions which are currently enabled (unmasked)
@@ -5229,9 +5225,9 @@ public:
     {
         assert(hasExceptionTraps);
         version(X86_Any)
-            return (getControlState() & EXCEPTION_MASK) ^ EXCEPTION_MASK;
+            return (getControlState() & allExceptions) ^ allExceptions;
         else
-            return (getControlState() & EXCEPTION_MASK);
+            return (getControlState() & allExceptions);
     }
 
     ///  Clear all pending exceptions, then restore the original exception state and rounding mode.
@@ -5363,8 +5359,8 @@ private:
 
                 /* In the FPU control register, masks are bits 0 through 5.
                 In MXCSR they're 7 through 12. */
-                enum EXCEPTION_MASK_SSE = EXCEPTION_MASK << 7;
-                immutable newExceptionMasks = (newState & EXCEPTION_MASK) << 7;
+                enum EXCEPTION_MASK_SSE = allExceptions << 7;
+                immutable newExceptionMasks = (newState & allExceptions) << 7;
                 mxcsr &= ~EXCEPTION_MASK_SSE; // delete old masks
                 mxcsr |= newExceptionMasks; // write new exception masks
 
@@ -5396,8 +5392,8 @@ private:
 
                     /* In the FPU control register, masks are bits 0 through 5.
                        In MXCSR they're 7 through 12. */
-                    mxcsr &= ~(EXCEPTION_MASK << 7);            // delete old masks
-                    mxcsr |= (newState & EXCEPTION_MASK) << 7;  // write new exception masks
+                    mxcsr &= ~(allExceptions << 7);            // delete old masks
+                    mxcsr |= (newState & allExceptions) << 7;  // write new exception masks
 
                     asm pure nothrow @nogc
                     {

--- a/libphobos/src/std/math.d
+++ b/libphobos/src/std/math.d
@@ -139,6 +139,7 @@ version (Win64)
 
 static import core.math;
 static import core.stdc.math;
+static import core.stdc.fenv;
 import std.traits; // CommonType, isFloatingPoint, isIntegral, isSigned, isUnsigned, Largest, Unqual
 
 version(LDC)
@@ -4646,9 +4647,13 @@ struct IeeeFlags
 private:
     // The x87 FPU status register is 16 bits.
     // The Pentium SSE2 status register is 32 bits.
+    // The ARM and PowerPC FPSCR is a 32-bit register.
+    // The SPARC FSR is a 32bit register (64 bits for SPARC 7 & 8, but high bits are uninteresting).
     uint flags;
-    version (X86_Any)
+
+    version (CRuntime_Microsoft)
     {
+        // Microsoft uses hardware-incompatible custom constants in fenv.h (core.stdc.fenv).
         // Applies to both x87 status word (16 bits) and SSE2 status word(32 bits).
         enum : int
         {
@@ -4663,45 +4668,19 @@ private:
         // Don't bother about subnormals, they are not supported on most CPUs.
         //  SUBNORMAL_MASK = 0x02;
     }
-    else version (PPC_Any)
-    {
-        // PowerPC FPSCR is a 32-bit register.
-        enum : int
-        {
-            INEXACT_MASK   = 0x02000000,
-            DIVBYZERO_MASK = 0x04000000,
-            UNDERFLOW_MASK = 0x08000000,
-            OVERFLOW_MASK  = 0x10000000,
-            INVALID_MASK   = 0x20000000 // Summary as PowerPC has five types of invalid exceptions.
-        }
-    }
-    else version (ARM)
-    {
-        // ARM FPSCR is a 32bit register
-        enum : int
-        {
-            INEXACT_MASK   = 0x10,
-            UNDERFLOW_MASK = 0x08,
-            OVERFLOW_MASK  = 0x04,
-            DIVBYZERO_MASK = 0x02,
-            INVALID_MASK   = 0x01
-        }
-    }
-    else version(SPARC)
-    {
-        // SPARC FSR is a 32bit register
-             //(64 bits for Sparc 7 & 8, but high 32 bits are uninteresting).
-        enum : int
-        {
-            INEXACT_MASK   = 0x020,
-            UNDERFLOW_MASK = 0x080,
-            OVERFLOW_MASK  = 0x100,
-            DIVBYZERO_MASK = 0x040,
-            INVALID_MASK   = 0x200
-        }
-    }
     else
-        static assert(0, "Not implemented");
+    {
+        enum : int
+        {
+            INEXACT_MASK    = core.stdc.fenv.FE_INEXACT,
+            UNDERFLOW_MASK  = core.stdc.fenv.FE_UNDERFLOW,
+            OVERFLOW_MASK   = core.stdc.fenv.FE_OVERFLOW,
+            DIVBYZERO_MASK  = core.stdc.fenv.FE_DIVBYZERO,
+            INVALID_MASK    = core.stdc.fenv.FE_INVALID,
+            EXCEPTIONS_MASK = core.stdc.fenv.FE_ALL_EXCEPT,
+        }
+    }
+
 private:
     static uint getIeeeFlags()
     {

--- a/libphobos/src/std/math.d
+++ b/libphobos/src/std/math.d
@@ -5044,34 +5044,25 @@ struct FloatingPointControl
             roundToZero /// ditto
         }
     }
-    else version(ARM)
+    else version (CRuntime_Microsoft)
     {
-        enum : RoundingMode
-        {
-            roundToNearest = 0x000000,
-            roundDown      = 0x800000,
-            roundUp        = 0x400000,
-            roundToZero    = 0xC00000
-        }
-    }
-    else version(PPC_Any)
-    {
-        enum : RoundingMode
-        {
-            roundToNearest = 0x00000000,
-            roundDown      = 0x00000003,
-            roundUp        = 0x00000002,
-            roundToZero    = 0x00000001
-        }
-    }
-    else
-    {
+        // Microsoft uses hardware-incompatible custom constants in fenv.h (core.stdc.fenv).
         enum : RoundingMode
         {
             roundToNearest = 0x0000,
             roundDown      = 0x0400,
             roundUp        = 0x0800,
             roundToZero    = 0x0C00
+        }
+    }
+    else
+    {
+        enum : RoundingMode
+        {
+            roundToNearest = core.stdc.fenv.FE_TONEAREST,
+            roundDown      = core.stdc.fenv.FE_DOWNWARD,
+            roundUp        = core.stdc.fenv.FE_UPWARD,
+            roundToZero    = core.stdc.fenv.FE_TOWARDZERO,
         }
     }
 


### PR DESCRIPTION
This backports some changes from phobos which fix various AArch64 compile errors. The main goal for now is getting phobos to compile.