### PR TITLE
Use CLEANUP_POINT_EXPR for auto-destructing temporaries.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,29 @@
 2017-12-19  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-codegen.cc (build_target_expr): Update signature.
+	(force_target_expr): New function.
+	(build_address): Use force_target_expr to store temporary.
+	(d_build_call): Likewise.
+	* d-lang.cc (d_gimplify_expr): Likewise.
+	* d-tree.h (language_function): Update type for vars_in_scope from
+	vec<VarDeclaration*> to vec<tree>.
+	(force_target_expr): Declare.
+	* decl.cc (DeclVisitor::visit(VarDeclaration)): Put vars with scope
+	destructors into a TARGET_EXPR, setting its cleanup.
+	(declare_local_var): Don't push vars with scope destructors into the
+	function binding level.
+	* expr.cc (ExprVisitor::visit(DeclarationExp)): Don't handle scope
+	destructors.
+	(ExprVisitor::visit(CallExp)): Handle calling constructors using
+	temporary objects.
+	(build_dtor_list): Remove function.
+	(build_expr_dtor): Put result into a CLEANUP_POINT_EXPR if any new
+	temporaries needing destruction were added to scope.
+	(build_return_dtor): Likewise.
+	* toir.cc (add_stmt): Set CLEANUP_POINT_EXPR type as void.
+
+2017-12-19  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* d-attribs.c (attr_noreturn_exclusions): New array.
 	(attr_returns_twice_exclusions, attr_const_pure_exclusions): Likewise.
 	(attr_inline_exclusions, attr_noinline_exclusions): Likewise.

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -851,7 +851,7 @@ d_gimplify_expr (tree *expr_p, gimple_seq *pre_p,
       /* Constructors are not lvalues, so make them one.  */
       if (TREE_CODE (op0) == CONSTRUCTOR)
 	{
-	  TREE_OPERAND (*expr_p, 0) = build_target_expr (op0);
+	  TREE_OPERAND (*expr_p, 0) = force_target_expr (op0);
 	  ret = GS_OK;
 	}
       break;

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -233,7 +233,7 @@ struct GTY(()) language_function
   vec<tree, va_gc> *stmt_list;
 
   /* Variables that are in scope that will need destruction later.  */
-  vec<VarDeclaration *> GTY((skip)) vars_in_scope;
+  vec<tree, va_gc> *vars_in_scope;
 
   /* Table of all used or defined labels in the function.  */
   hash_map<Statement *, d_label_entry> *labels;
@@ -502,7 +502,8 @@ extern void extract_from_method_call (tree, tree &, tree &);
 extern tree build_vindex_ref (tree, tree, size_t);
 extern tree d_save_expr (tree);
 extern tree stabilize_expr (tree *);
-extern tree build_target_expr (tree);
+extern tree build_target_expr (tree, tree);
+extern tree force_target_expr (tree);
 extern tree build_address (tree);
 extern tree d_mark_addressable (tree);
 extern tree d_mark_used (tree);

--- a/gcc/d/toir.cc
+++ b/gcc/d/toir.cc
@@ -205,6 +205,11 @@ add_stmt (tree t)
     }
   else
     {
+      /* Force the type to be void so we don't need to create a temporary
+	 variable to hold the inner expression.  */
+      if (TREE_CODE (t) == CLEANUP_POINT_EXPR)
+	TREE_TYPE (t) = void_type_node;
+
       /* Append the expression to the statement list.
 	 Make sure it has a proper location.  */
       if (EXPR_P (t) && !EXPR_HAS_LOCATION (t))

--- a/gcc/testsuite/gdc.test/runnable/test14903.d
+++ b/gcc/testsuite/gdc.test/runnable/test14903.d
@@ -75,7 +75,7 @@ void dtorsTest() {
         assert(0);
     } catch (Exception) {}
     assert(counter == 1);
-    //assert(StructWithDtor.numDtor == 1); // XGDC
+    assert(StructWithDtor.numDtor == 1);
 
     // TODO: test exception chaining with throwing dtors
 }


### PR DESCRIPTION
Another example moving lowering from frontend (glue) to gimple.

Puts declarations marked `needsScopeDtor` into a `TARGET_EXPR`, i.e:
```
TARGET_EXPR <__pfx79,  // decl
             *__ctor (&__pfx79, 0), // init
             __dtor (&__pfx79), // cleanup>;
```
Then `_build_expr_dtor` wraps up the result into a `CLEANUP_POINT_EXPR`, e.g:
```
<<cleanup_point
  TARGET_EXPR <__pfx79, *__ctor (&__pfx79, 0)>;
  some_func (&__pfx79);>>;
```
The gimplification of `cleanup_point_expr` nodes then adds try/finally as needed for us, in the correct order.  i.e:
```
try
{
  __pfx79 = *__ctor (&__pfx79, 0);
  try
  {
    some_func (&__pfx79); // may throw
  }
  finally
  {
    __dtor (&__pfx79);
  }
}
finally
{
  __pfx79 = {CLOBBER};  // constructor maybe threw.
}
```

Fixes broken test in test14903.d.