### PR TITLE
Recognize when a function is marked pragma(inline).

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -26,6 +26,10 @@
 
 2018-01-21  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* decls.cc (get_symbol_decl): Handle pragma(inline) attributes.
+
+2018-01-21  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* decl.cc (DeclVisitor::visit(StructDeclaration)): Mark compiler
 	generated symbols as DECL_ONE_ONLY instead of DECL_COMDAT.
 	(DeclVisitor::visit(ClassDeclaration)): Likewise.

--- a/gcc/d/decl.cc
+++ b/gcc/d/decl.cc
@@ -1131,8 +1131,16 @@ get_symbol_decl (Declaration *decl)
 	  d_keep (newfntype);
 	}
 
-      /* Miscellaneous function flags.  */
-      if (fd->isMember2 () || fd->isFuncLiteralDeclaration ())
+      /* In [pragma/inline], The attribute pragma(inline) affects whether a
+	 function should be inlined or not.  */
+      if (fd->inlining == PINLINEnever)
+	DECL_UNINLINABLE (decl->csym) = 1;
+      else if (fd->inlining == PINLINEalways)
+	{
+	  DECL_DECLARED_INLINE_P (decl->csym) = 1;
+	  DECL_DISREGARD_INLINE_LIMITS (decl->csym) = 1;
+	}
+      else if (fd->isMember2 () || fd->isFuncLiteralDeclaration ())
 	{
 	  /* See grokmethod in cp/decl.c.  Maybe we shouldn't be setting inline
 	     flags without reason or proper handling.  */
@@ -1239,6 +1247,16 @@ get_symbol_decl (Declaration *decl)
 	    TREE_STATIC (decl->csym) = 1;
 	  else
 	    DECL_EXTERNAL (decl->csym) = 1;
+	}
+
+      /* Don't keep functions declared pragma(inline, true) unless
+	 the user wants us to keep all inline functions.  */
+      if (fd && fd->inlining == PINLINEalways && TREE_PUBLIC (decl->csym))
+	{
+	  if (flag_keep_inline_functions)
+	    mark_needed (decl->csym);
+
+	  d_comdat_linkage (decl->csym);
 	}
     }
 


### PR DESCRIPTION
Primer support for `pragma(inline)`.  Probably won't work unless bodies of external functions are generated as well, which would be part of the cross-module inlining support.