### PR TITLE
Fix inference of 'scope' for parameters for inferable functions

### DIFF
--- a/gcc/d/dfrontend/dtemplate.c
+++ b/gcc/d/dfrontend/dtemplate.c
@@ -2313,9 +2313,9 @@ void functionResolve(Match *m, Dsymbol *dstart, Loc loc, Scope *sc,
         Expressions *fargs;
         // result
         Match *m;
-        int property;       // 0: unintialized
-        // 1: seen @property
-        // 2: not @property
+        int property;   // 0: unintialized
+                        // 1: seen @property
+                        // 2: not @property
         size_t ov_index;
         TemplateDeclaration *td_best;
         TemplateInstance *ti_best;
@@ -2324,13 +2324,12 @@ void functionResolve(Match *m, Dsymbol *dstart, Loc loc, Scope *sc,
 
         static int fp(void *param, Dsymbol *s)
         {
-            if (!s->errors)
-            {
-                if (FuncDeclaration *fd = s->isFuncDeclaration())
-                    return ((ParamDeduce *)param)->applyFunction(fd);
-                if (TemplateDeclaration *td = s->isTemplateDeclaration())
-                    return ((ParamDeduce *)param)->applyTemplate(td);
-            }
+            if (s->errors)
+                return 0;
+            if (FuncDeclaration *fd = s->isFuncDeclaration())
+                return ((ParamDeduce *)param)->applyFunction(fd);
+            if (TemplateDeclaration *td = s->isTemplateDeclaration())
+                return ((ParamDeduce *)param)->applyTemplate(td);
             return 0;
         }
 
@@ -2750,7 +2749,8 @@ void functionResolve(Match *m, Dsymbol *dstart, Loc loc, Scope *sc,
          * Now instantiate the template.
          */
         assert(p.td_best->_scope);
-        if (!sc) sc = p.td_best->_scope; // workaround for Type::aliasthisOf
+        if (!sc)
+            sc = p.td_best->_scope; // workaround for Type::aliasthisOf
 
         TemplateInstance *ti = new TemplateInstance(loc, p.td_best, p.ti_best->tiargs);
         ti->semantic(sc, fargs);

--- a/gcc/d/dfrontend/expressionsem.c
+++ b/gcc/d/dfrontend/expressionsem.c
@@ -981,15 +981,15 @@ public:
             return;
         }
 
-	// Bugzilla 11581: With the syntax `new T[edim]` or `thisexp.new T[edim]`,
-	// T should be analyzed first and edim should go into arguments iff it's
-	// not a tuple.
-	Expression *edim = NULL;
-	if (!exp->arguments && exp->newtype->ty == Tsarray)
-	{
-	    edim = ((TypeSArray *)exp->newtype)->dim;
-	    exp->newtype = ((TypeNext *)exp->newtype)->next;
-	}
+        // Bugzilla 11581: With the syntax `new T[edim]` or `thisexp.new T[edim]`,
+        // T should be analyzed first and edim should go into arguments iff it's
+        // not a tuple.
+        Expression *edim = NULL;
+        if (!exp->arguments && exp->newtype->ty == Tsarray)
+        {
+            edim = ((TypeSArray *)exp->newtype)->dim;
+            exp->newtype = ((TypeNext *)exp->newtype)->next;
+        }
 
         ClassDeclaration *cdthis = NULL;
         if (exp->thisexp)

--- a/gcc/d/dfrontend/func.c
+++ b/gcc/d/dfrontend/func.c
@@ -433,6 +433,10 @@ static void initInferAttributes(FuncDeclaration *fd)
 
     if (!fd->isVirtual() || fd->introducing)
         fd->flags |= FUNCFLAGreturnInprocess;
+
+    // Initialize for inferring STCscope
+    if (global.params.vsafe)
+        fd->flags |= FUNCFLAGinferScope;
 }
 
 // Do the semantic analysis on the external interface to the function.
@@ -1576,7 +1580,7 @@ void FuncDeclaration::semantic3(Scope *sc)
                 stc |= STCparameter;
                 if (f->varargs == 2 && i + 1 == nparams)
                     stc |= STCvariadic;
-                if (flags & FUNCFLAGinferScope)
+                if (flags & FUNCFLAGinferScope && !(fparam->storageClass & STCscope))
                     stc |= STCmaybescope;
                 stc |= fparam->storageClass & (STCin | STCout | STCref | STCreturn | STCscope | STClazy | STCfinal | STC_TYPECTOR | STCnodtor);
                 v->storage_class = stc;
@@ -2485,7 +2489,7 @@ VarDeclaration *FuncDeclaration::declareThis(Scope *sc, AggregateDeclaration *ad
                 if (tf->isscope)
                     v->storage_class |= STCscope;
             }
-            if (flags & FUNCFLAGinferScope)
+            if (flags & FUNCFLAGinferScope && !(v->storage_class & STCscope))
                 v->storage_class |= STCmaybescope;
 
             v->semantic(sc);
@@ -2511,7 +2515,7 @@ VarDeclaration *FuncDeclaration::declareThis(Scope *sc, AggregateDeclaration *ad
             if (tf->isscope)
                 v->storage_class |= STCscope;
         }
-        if (flags & FUNCFLAGinferScope)
+        if (flags & FUNCFLAGinferScope && !(v->storage_class & STCscope))
             v->storage_class |= STCmaybescope;
 
         v->semantic(sc);

--- a/gcc/d/dfrontend/mtype.c
+++ b/gcc/d/dfrontend/mtype.c
@@ -6048,8 +6048,7 @@ MATCH TypeFunction::callMatch(Type *tthis, Expressions *args, int flag)
         {
             if (MODimplicitConv(t->mod, mod))
                 match = MATCHconst;
-            else if ((mod & MODwild)
-                && MODimplicitConv(t->mod, (mod & ~MODwild) | MODconst))
+            else if ((mod & MODwild) && MODimplicitConv(t->mod, (mod & ~MODwild) | MODconst))
             {
                 match = MATCHconst;
             }
@@ -6223,12 +6222,12 @@ MATCH TypeFunction::callMatch(Type *tthis, Expressions *args, int flag)
 
                 switch (tb->ty)
                 {
-                    case Tsarray:
-                        tsa = (TypeSArray *)tb;
-                        sz = tsa->dim->toInteger();
-                        if (sz != nargs - u)
-                            goto Nomatch;
-                    case Tarray:
+                case Tsarray:
+                    tsa = (TypeSArray *)tb;
+                    sz = tsa->dim->toInteger();
+                    if (sz != nargs - u)
+                        goto Nomatch;
+                case Tarray:
                     {
                         TypeArray *ta = (TypeArray *)tb;
                         for (; u < nargs; u++)
@@ -6263,13 +6262,13 @@ MATCH TypeFunction::callMatch(Type *tthis, Expressions *args, int flag)
                         }
                         goto Ldone;
                     }
-                    case Tclass:
-                        // Should see if there's a constructor match?
-                        // Or just leave it ambiguous?
-                        goto Ldone;
+                case Tclass:
+                    // Should see if there's a constructor match?
+                    // Or just leave it ambiguous?
+                    goto Ldone;
 
-                    default:
-                        goto Nomatch;
+                default:
+                    goto Nomatch;
                 }
             }
             goto Nomatch;

--- a/libphobos/libdruntime/core/runtime.d
+++ b/libphobos/libdruntime/core/runtime.d
@@ -491,7 +491,7 @@ extern (C) bool runModuleUnitTests()
             // First frame is LibBacktrace ctor. Second is signal handler, but include that for now
             bt.__ctor(1);
 
-            foreach(size_t i, const(char[]) msg; bt)
+            foreach (size_t i, const(char[]) msg; bt)
                 fprintf(stderr, "%s\n", msg.ptr ? msg.ptr : "???");
         }
 

--- a/libphobos/libdruntime/gcc/backtrace.d
+++ b/libphobos/libdruntime/gcc/backtrace.d
@@ -153,7 +153,7 @@ static if (BACKTRACE_SUPPORTED && !BACKTRACE_USES_MALLOC)
     /*
      * The callback type used with the opApply overload which returns a SymbolOrError
      */
-    private alias scope int delegate(ref size_t, ref SymbolOrError) ApplyCallback;
+    private alias int delegate(ref size_t, ref SymbolOrError) ApplyCallback;
 
     /*
      * Passed to syminfoCallback, pcinfoCallback and pcinfoErrorCallback
@@ -228,7 +228,7 @@ static if (BACKTRACE_SUPPORTED && !BACKTRACE_USES_MALLOC)
 
         override int opApply(scope int delegate(ref const(char[])) dg) const
         {
-            return opApply((ref size_t, ref const(char[]) buf)
+            return opApply( (ref size_t, ref const(char[]) buf)
                             {
                                 return dg(buf);
                             });
@@ -236,12 +236,12 @@ static if (BACKTRACE_SUPPORTED && !BACKTRACE_USES_MALLOC)
 
         override int opApply(scope int delegate(ref size_t, ref const(char[])) dg) const
         {
-            return opApply((ref size_t i, ref SymbolOrError sym)
+            return opApply( (ref size_t i, ref SymbolOrError sym)
                             {
-                               char[512] buffer = '\0';
-                               char[] msg;
-                               if (sym.errnum != 0)
-                               {
+                                char[512] buffer = '\0';
+                                char[] msg;
+                                if (sym.errnum != 0)
+                                {
                                     auto retval = snprintf(buffer.ptr, buffer.length,
                                                            "libbacktrace error: '%s' errno: %d", sym.msg, sym.errnum);
                                     if (retval >= buffer.length)
@@ -257,7 +257,7 @@ static if (BACKTRACE_SUPPORTED && !BACKTRACE_USES_MALLOC)
                             });
         }
 
-        int opApply(ApplyCallback dg) const
+        int opApply(scope ApplyCallback dg) const
         {
             //If backtrace_simple produced an error report it and exit
             if (!state || error != 0)
@@ -352,7 +352,7 @@ else
 
         override int opApply(scope int delegate(ref const(char[])) dg) const
         {
-            return opApply((ref size_t, ref const(char[]) buf)
+            return opApply( (ref size_t, ref const(char[]) buf)
                             {
                                 return dg(buf);
                             });
@@ -485,7 +485,7 @@ struct SymbolInfo
  * Format one output line for symbol sym.
  * Returns a slice of fixbuf.
  */
-char[] formatLine(const SymbolInfo sym, ref char[512] fixbuf)
+char[] formatLine(const SymbolInfo sym, return ref char[512] fixbuf)
 {
     import core.demangle, core.stdc.config;
     import core.stdc.stdio : snprintf, printf;


### PR DESCRIPTION
And update gcc.backtrace to be compatible with DIP 1000.

One hunk of the patch was missing from the original port, which only became evident when testing the build of druntime with `-ftransition=dip1000`

https://github.com/D-Programming-GDC/GDC/pull/591/files?w=1