### PR TITLE
Update alias set language hook to return unhandled.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2018-01-23  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-lang.cc (d_get_alias_set): Use alias set of pointer type for
+	dynamic arrays.  Return unhandled for all other cases.
+
 2018-01-08  Eugene Wissner  <belka@caraus.de>
 
 	* d-builtins.cc (d_eval_constant_expression): Handle polynomial

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -1475,22 +1475,11 @@ d_getdecls (void)
 static alias_set_type
 d_get_alias_set (tree t)
 {
-  /* Permit type-punning when accessing a union, provided the access
-     is directly through the union.  */
-  for (tree u = t; handled_component_p (u); u = TREE_OPERAND (u, 0))
-    {
-      if (TREE_CODE (u) == COMPONENT_REF
-	  && TREE_CODE (TREE_TYPE (TREE_OPERAND (u, 0))) == UNION_TYPE)
-	return 0;
-    }
+  /* For dynamic arrays, use the same alias type as .ptr type.  */
+  if (TREE_CODE (t) == RECORD_TYPE && TYPE_DYNAMIC_ARRAY (t))
+    return get_alias_set (TREE_TYPE (TREE_CHAIN (TYPE_FIELDS (t))));
 
-  /* That's all the expressions we handle.  */
-  if (!TYPE_P (t))
-    return get_alias_set (TREE_TYPE (t));
-
-  /* For now in D, assume everything aliases everything else,
-     until we define some solid rules.  */
-  return 0;
+  return -1;
 }
 
 /* Implements the lang_hooks.types_compatible_p routine for language D.


### PR DESCRIPTION
Let default alias rules in the back-end decide, rather than forcing that everything aliases everything else.

As an experiment, also making sure that `int*` and `int[]` are part of the same alias set.