### PR TITLE
Gimplify all call arguments in order using gimplify_arg.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,10 @@
 2018-01-27  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-lang.cc (d_gimplify_expr): Gimplify all CALL_EXPR_ARGS_ORDERED
+	call arguments, not just non-constant.
+
+2018-01-27  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* decl.cc (DeclVisitor::visit(VarDeclaration)): Don't reuse existing
 	temporary for TARGET_EXPR.
 	(declare_local_var): Push all variables to current binding level.


### PR DESCRIPTION
This prevents a cascading of temporaries being created during gimplification, because using get_formal_tmp_var was being called for both EXPR and SSA node, the latter being needless.

The last argument never needs saving to a temporary either, if it can be avoided.