### PR TITLE
Set input_location in build_function_body.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,7 @@
+2018-01-27  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* toir.cc (build_function_body): Set input_location.
+
 2018-01-23  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-codegen.cc (build_frame_type): Don't add chain field for

--- a/gcc/d/toir.cc
+++ b/gcc/d/toir.cc
@@ -1430,5 +1430,8 @@ void
 build_function_body (FuncDeclaration *fd)
 {
   IRVisitor v = IRVisitor (fd);
+  location_t saved_location = input_location;
+  input_location = get_linemap (fd->loc);
   v.build_stmt (fd->fbody);
+  input_location = saved_location;
 }


### PR DESCRIPTION
Not all expression statements have a location, such as generated function calls.  Any location is better than no location in this instance.