### PR TITLE
Use 'naked' attribute instead of marking functions uninlinable

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -20,6 +20,10 @@
 	(build_closure): Don't set chain field for functions without context
 	pointer.
 
+2018-01-21  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* decls.cc (get_symbol_decl): Use attribute to mark naked functions.
+
 2018-01-08  Eugene Wissner  <belka@caraus.de>
 
 	* d-builtins.cc (d_eval_constant_expression): Handle polynomial

--- a/gcc/d/decl.cc
+++ b/gcc/d/decl.cc
@@ -1143,8 +1143,8 @@ get_symbol_decl (Declaration *decl)
       /* Function was declared 'naked'.  */
       if (fd->naked)
 	{
+	  insert_decl_attribute (decl->csym, "naked");
 	  DECL_NO_INSTRUMENT_FUNCTION_ENTRY_EXIT (decl->csym) = 1;
-	  DECL_UNINLINABLE (decl->csym) = 1;
 	}
 
       /* Vector array operations are always compiler generated.  */


### PR DESCRIPTION
Middle-end handles "naked" attribute properly, and back-end may have special handling also.