### PR TITLE
Add -fweak command-line flag to compiler

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -26,6 +26,15 @@
 
 2018-01-21  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-lang.cc (d_init): Disable flag_weak if not supported.
+	* decl.cc (d_comdat_linkage): Use flag_weak to guard setting
+	DECL_ONE_ONLY on decls.
+	(d_linkonce_linkage): New function.
+	* gdc.texi (Runtime Options): Document -fweak.
+	* lang.opt (fweak): Declare.
+
+2018-01-21  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* decls.cc (get_symbol_decl): Use attribute to mark naked functions.
 
 2018-01-08  Eugene Wissner  <belka@caraus.de>

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -38,6 +38,7 @@ along with GCC; see the file COPYING3.  If not see
 #include "target.h"
 #include "stringpool.h"
 #include "stor-layout.h"
+#include "varasm.h"
 #include "output.h"
 #include "print-tree.h"
 #include "gimple-expr.h"
@@ -360,6 +361,9 @@ d_init (void)
 
   if (flag_exceptions)
     using_eh_for_cleanups ();
+
+  if (!supports_one_only ())
+    flag_weak = 0;
 
   /* This is the C main, not the D main.  */
   main_identifier_node = get_identifier ("main");

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -604,6 +604,7 @@ extern tree build_artificial_decl (tree, tree, const char * = NULL);
 extern tree create_field_decl (tree, const char *, int, int);
 extern void build_type_decl (tree, Dsymbol *);
 extern void d_comdat_linkage (tree);
+extern void d_linkonce_linkage (tree);
 
 /* In expr.cc.  */
 extern tree build_expr (Expression *, bool = false);

--- a/gcc/d/decl.cc
+++ b/gcc/d/decl.cc
@@ -2159,7 +2159,7 @@ d_comdat_group (tree decl)
 void
 d_comdat_linkage (tree decl)
 {
-  /* Weak definitions have to be public.  */
+  /* COMDAT definitions have to be public.  */
   if (!TREE_PUBLIC (decl))
     return;
 
@@ -2167,7 +2167,7 @@ d_comdat_linkage (tree decl)
   if (TREE_CODE (decl) == FUNCTION_DECL)
     DECL_DECLARED_INLINE_P (decl) = 1;
 
-  if (supports_one_only ())
+  if (flag_weak)
     make_decl_one_only (decl, d_comdat_group (decl));
   else if (TREE_CODE (decl) == FUNCTION_DECL
 	   || (VAR_P (decl) && DECL_ARTIFICIAL (decl)))
@@ -2181,4 +2181,24 @@ d_comdat_linkage (tree decl)
 
   if (TREE_PUBLIC (decl))
     DECL_COMDAT (decl) = 1;
+}
+
+/* Set DECL up to have the closest approximation of "linkonce" linkage.  */
+
+void
+d_linkonce_linkage (tree decl)
+{
+  /* Weak definitions have to be public.  */
+  if (!TREE_PUBLIC (decl))
+    return;
+
+  /* Necessary to allow DECL_ONE_ONLY or DECL_WEAK functions to be inlined.  */
+  if (TREE_CODE (decl) == FUNCTION_DECL)
+    DECL_DECLARED_INLINE_P (decl) = 1;
+
+  /* No weak support, fallback to COMDAT linkage.  */
+  if (!flag_weak)
+   return d_comdat_linkage (decl);
+
+  make_decl_one_only (decl, d_comdat_group (decl));
 }

--- a/gcc/d/gdc.texi
+++ b/gcc/d/gdc.texi
@@ -329,6 +329,14 @@ is compiled into the program.
 Turns on compilation of @code{version} code identified by @var{ident}.
 @end table
 
+@item -fno-weak
+@cindex @option{-fweak}
+@cindex @option{-fno-weak}
+Turns off emission of instantiated declarations that can be defined in multiple
+objects as weak or one-only symbols.  The default is to emit all public symbols
+as weak, unless there lacks target support.  Disabling this options means that
+common symbols are instead put in COMDAT or become private.
+
 @end table
 
 @node Directory Options

--- a/gcc/d/lang.opt
+++ b/gcc/d/lang.opt
@@ -344,6 +344,10 @@ fversion=
 D Joined RejectNegative
 -fversion=<level|ident>	Compile in version code >= <level> or identified by <ident>.
 
+fweak
+D Var(flag_weak) Init(1)
+Emit common-like symbols as weak symbols.
+
 fXf=
 D Joined RejectNegative Alias(Xf)
 ; Deprecated in favor of -Xf


### PR DESCRIPTION
The idea is to switch back to using `DECL_ONE_ONLY` or `DECL_WEAK` linkage for all symbols as a default.  Then `DECL_COMDAT` becomes optional or used as a compile-time optimisation to prune unreferenced symbols from the output object file.