### PR TITLE
Prefer d_linkonce_linkage over d_comdat_linkage.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -26,6 +26,22 @@
 
 2018-01-21  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* decl.cc (DeclVisitor::visit(StructDeclaration)): Mark compiler
+	generated symbols as DECL_ONE_ONLY instead of DECL_COMDAT.
+	(DeclVisitor::visit(ClassDeclaration)): Likewise.
+	(DeclVisitor::visit(InterfaceDeclaration)): Likewise.
+	(DeclVisitor::visit(EnumDeclaration)): Likewise.
+	(get_symbol_decl): Mark template instantiations as DECL_ONE_ONLY
+	instead of DECL_COMDAT.  Don't call mark_needed.
+	(declare_extern_var): Don't call mark_needed.
+	(d_finish_decl): Remove zero initializer for common symbols.
+	(finish_thunk): Don't call d_comdat_linkage on generic thunk.
+	(d_comdat_linkage): Don't set DECL_DECLARED_INLINE on functions.
+	* typeinfo.cc (TypeInfoDeclVisitor::visit(TypeInfoDeclaration)): Mark
+	built-in typeinfo symbols as DECL_ONE_ONLY instead of DECL_COMDAT.
+
+2018-01-21  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* d-lang.cc (d_init): Disable flag_weak if not supported.
 	* decl.cc (d_comdat_linkage): Use flag_weak to guard setting
 	DECL_ONE_ONLY on decls.

--- a/gcc/d/typeinfo.cc
+++ b/gcc/d/typeinfo.cc
@@ -1187,6 +1187,28 @@ layout_classinfo_interfaces (ClassDeclaration *decl)
   return type;
 }
 
+/* Returns true if the TypeInfo for type should be placed in
+   the runtime library.  */
+
+static bool
+builtin_typeinfo_p (Type *type)
+{
+  if (type->isTypeBasic () || type->ty == Tclass || type->ty == Tnull)
+    return !type->mod;
+
+  if (type->ty == Tarray)
+    {
+      /* Strings are so common, make them builtin.  */
+      Type *next = type->nextOf ();
+      return !type->mod
+	&& ((next->isTypeBasic () != NULL && !next->mod)
+	    || (next->ty == Tchar && next->mod == MODimmutable)
+	    || (next->ty == Tchar && next->mod == MODconst));
+    }
+
+  return false;
+}
+
 /* Implements a visitor interface to create the decl tree for TypeInfo decls.
    TypeInfo_Class objects differ in that they also have information about
    the class type packed immediately after the TypeInfo symbol.
@@ -1213,7 +1235,11 @@ public:
 
     /* Built-in typeinfo will be referenced as one-only.  */
     gcc_assert (!tid->isInstantiated ());
-    d_comdat_linkage (tid->csym);
+
+    if (builtin_typeinfo_p (tid->tinfo))
+      d_linkonce_linkage (tid->csym);
+    else
+      d_comdat_linkage (tid->csym);
   }
 
   void visit (TypeInfoClassDeclaration *tid)
@@ -1345,28 +1371,6 @@ get_cpp_typeinfo_decl (ClassDeclaration *decl)
   layout_cpp_typeinfo (decl);
 
   return decl->cpp_type_info_ptr_sym;
-}
-
-/* Returns true if the TypeInfo for type should be placed in
-   the runtime library.  */
-
-static bool
-builtin_typeinfo_p (Type *type)
-{
-  if (type->isTypeBasic () || type->ty == Tclass || type->ty == Tnull)
-    return !type->mod;
-
-  if (type->ty == Tarray)
-    {
-      /* Strings are so common, make them builtin.  */
-      Type *next = type->nextOf ();
-      return !type->mod
-	&& ((next->isTypeBasic () != NULL && !next->mod)
-	    || (next->ty == Tchar && next->mod == MODimmutable)
-	    || (next->ty == Tchar && next->mod == MODconst));
-    }
-
-  return false;
 }
 
 /* Get the exact TypeInfo for TYPE, if it doesn't exist, create it.  */


### PR DESCRIPTION
And remove all calls to `mark_needed()`.

Using the STM32 demo project as a benchmark, the size of the unlinked object file is 6872 bytes smaller (from 28kb to 20kb) when compiling with `-fno-weak`.