### PR TITLE
Use builtin expect() to mark assert condition as being likely true.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2018-02-10  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* expr.cc (ExprVisitor::AssertExp): Use builtin expect to mark assert
+	condition as being likely true.
+
 2018-02-11  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* lang.opt (fd-vgc, fd-verbose, fd-vtls): Remove options.


### PR DESCRIPTION
~This would make assertion failures in release mode really do have undefined behaviour, as the resultant code will now _assume_ that false never happens.~

~Only does this if the condition has no side effects, and I expect that any benefits would only be subtle, if there are any at all. For instance, `assert(this !is null)`, if `this` is dereferenced later, then the optimizer already assumes that it isn't null.~

Update:  Rather than doing this, have switched to just using `expect()` instead.