### PR TITLE
Set  more call attributes and fnspec on all library functions.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,7 +1,8 @@
-2018-02-10  Iain Buclaw  <ibuclaw@gdcproject.org>
+2018-02-11  Iain Buclaw  <ibuclaw@gdcproject.org>
 
-	* expr.cc (ExprVisitor::AssertExp): Use builtin expect to mark assert
-	condition as being likely true.
+	* runtime.def (ASSERT, ASSERT_MSG): Set ECF_COLD and ECF_LEAF flags.
+	(UNITTEST, UNITTEST_MSG): Likewise.
+	(ARRAY_BOUNDS, SWITCH_ERROR): Likewise.
 
 2018-02-11  Iain Buclaw  <ibuclaw@gdcproject.org>
 
@@ -9,6 +10,11 @@
 	(femit-moduleinfo, femit-templates): Likewise.
 	(fmake-deps, fmake-mdeps): Likewise.
 	(fin, fout, fXf): Likewise.
+
+2018-02-10  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* expr.cc (ExprVisitor::AssertExp): Use builtin expect to mark assert
+	condition as being likely true.
 
 2018-01-28  Iain Buclaw  <ibuclaw@gdcproject.org>
 

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,11 @@
 2018-02-11  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* runtime.def (DYNAMIC_CAST, INTERFACE_CAST): Set ECF_CONST.
+	(ARRAYCAST, AAINX, AAGETRVALUEX): Likewise.
+	(SWITCH_STRING, SWITCH_USTRING, SWITCH_DSTRING): Likewise.
+
+2018-02-11  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* runtime.def (BEGIN_CATCH): Set ECF_NOTHROW.
 
 2018-02-11  Iain Buclaw  <ibuclaw@gdcproject.org>

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,18 @@
 2018-02-11  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* runtime.def (NEWCLASS): Set ECF_LEAF.
+	(DYNAMIC_CAST, INTERFACE_CAST): Likewise.
+	(NEWITEMT, NEWITEMIT, DELMEMORY): Likewise.
+	(NEWARRAYT, NEWARRAYIT): Likewise.
+	(NEWARRAYMTX, NEWARRAYMITX): Likewise.
+	(ARRAYLITERALTX, ARRAYCAST): Likewise.
+	(ALLOCMEMORY, ARRAYCOPY): Likewise.
+	(ARRAYAPPENDCD, ARRAYAPPENDWD): Likewise.
+	(AAINX, AAGETRVALUEX, AADELX): Likewise.
+	(SWITCH_STRING, SWITCH_USTRING, SWITCH_DSTRING): Likewise.
+
+2018-02-11  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* d-codegen.cc (d_save_expr): Always stabilize CALL_EXPR.
 	* runtime.def (ALLOCMEMORY): Set ECF_PURE.
 

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,10 @@
+2018-02-12  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* runtime.cc (build_libcall_decl): Update signature, handle "fn spec"
+	attribute.
+	* runtime.def (DEF_D_RUNTIME): Add fnspec argument. All callers
+	updated.
+
 2018-02-11  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* runtime.def (DYNAMIC_CAST, INTERFACE_CAST): Set ECF_CONST.

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,9 @@
 2018-02-11  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* runtime.def (BEGIN_CATCH): Set ECF_NOTHROW.
+
+2018-02-11  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* runtime.def (NEWCLASS): Set ECF_LEAF.
 	(DYNAMIC_CAST, INTERFACE_CAST): Likewise.
 	(NEWITEMT, NEWITEMIT, DELMEMORY): Likewise.

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,10 @@
 2018-02-11  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-codegen.cc (d_save_expr): Always stabilize CALL_EXPR.
+	* runtime.def (ALLOCMEMORY): Set ECF_PURE.
+
+2018-02-11  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* runtime.def (ASSERT, ASSERT_MSG): Set ECF_COLD and ECF_LEAF flags.
 	(UNITTEST, UNITTEST_MSG): Likewise.
 	(ARRAY_BOUNDS, SWITCH_ERROR): Likewise.

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -506,9 +506,14 @@ lvalue_p (tree exp)
 tree
 d_save_expr (tree exp)
 {
-  if (TREE_SIDE_EFFECTS (exp))
+  /* Always consider call expressions as a side effect, even if the function
+     being called is pure.  */
+  tree t = exp;
+  STRIP_NOPS (t);
+
+  if (TREE_SIDE_EFFECTS (t) || TREE_CODE (t) == CALL_EXPR)
     {
-      if (lvalue_p (exp))
+      if (lvalue_p (t))
 	return stabilize_reference (exp);
 
       return save_expr (exp);

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -453,7 +453,7 @@ extern GTY(()) tree d_global_trees[DTI_MAX];
 
 enum libcall_fn
 {
-#define DEF_D_RUNTIME(CODE, N, T, P, F) LIBCALL_ ## CODE,
+#define DEF_D_RUNTIME(CODE, N, T, P, F, S) LIBCALL_ ## CODE,
 
 #include "runtime.def"
 

--- a/gcc/d/runtime.def
+++ b/gcc/d/runtime.def
@@ -34,19 +34,20 @@ along with GCC; see the file COPYING3.  If not see
 #define RT(T1)		    LCT_ ## T1
 
 /* Used when an assert() contract fails.  */
-DEF_D_RUNTIME (ASSERT, "_d_assert", RT(VOID), P2(STRING, UINT), ECF_NORETURN)
+DEF_D_RUNTIME (ASSERT, "_d_assert", RT(VOID), P2(STRING, UINT),
+	       ECF_COLD | ECF_LEAF | ECF_NORETURN)
 DEF_D_RUNTIME (ASSERT_MSG, "_d_assert_msg", RT(VOID), P3(STRING, STRING, UINT),
-	       ECF_NORETURN)
+	       ECF_COLD | ECF_LEAF | ECF_NORETURN)
 
 /* Used when an assert() contract fails in a unittest function.  */
 DEF_D_RUNTIME (UNITTEST, "_d_unittest", RT(VOID), P2(STRING, UINT),
-	       ECF_NORETURN)
+	       ECF_COLD | ECF_LEAF | ECF_NORETURN)
 DEF_D_RUNTIME (UNITTEST_MSG, "_d_unittest_msg", RT(VOID),
-	       P3(STRING, STRING, UINT), ECF_NORETURN)
+	       P3(STRING, STRING, UINT), ECF_COLD | ECF_LEAF | ECF_NORETURN)
 
 /* Used when an array index outside the bounds of its range.  */
 DEF_D_RUNTIME (ARRAY_BOUNDS, "_d_arraybounds", RT(VOID), P2(STRING, UINT),
-	       ECF_NORETURN)
+	       ECF_COLD | ECF_LEAF | ECF_NORETURN)
 
 /* Used when calling new on a class.  */
 DEF_D_RUNTIME (NEWCLASS, "_d_newclass", RT(OBJECT), P1(CONST_CLASSINFO), 0)
@@ -214,7 +215,7 @@ DEF_D_RUNTIME (SWITCH_DSTRING, "_d_switch_dstring", RT(INT),
 /* Used when throwing an error that a switch statement has no default case,
    and yet none of the existing cases matched.  */
 DEF_D_RUNTIME (SWITCH_ERROR, "_d_switch_error", RT(VOID), P2(STRING, UINT),
-	       ECF_NORETURN)
+	       ECF_COLD | ECF_LEAF | ECF_NORETURN)
 
 #undef P0
 #undef P1

--- a/gcc/d/runtime.def
+++ b/gcc/d/runtime.def
@@ -50,7 +50,8 @@ DEF_D_RUNTIME (ARRAY_BOUNDS, "_d_arraybounds", RT(VOID), P2(STRING, UINT),
 	       ECF_COLD | ECF_LEAF | ECF_NORETURN)
 
 /* Used when calling new on a class.  */
-DEF_D_RUNTIME (NEWCLASS, "_d_newclass", RT(OBJECT), P1(CONST_CLASSINFO), 0)
+DEF_D_RUNTIME (NEWCLASS, "_d_newclass", RT(OBJECT), P1(CONST_CLASSINFO),
+	       ECF_LEAF)
 
 /* Used when calling delete on a class or interface.  */
 DEF_D_RUNTIME (DELCLASS, "_d_delclass", RT(VOID), P1(VOIDPTR), 0)
@@ -63,17 +64,20 @@ DEF_D_RUNTIME (CALLINTERFACEFINALIZER, "_d_callinterfacefinalizer", RT(VOID),
 
 /* Used for casting to a class or interface.  */
 DEF_D_RUNTIME (DYNAMIC_CAST, "_d_dynamic_cast", RT(OBJECT),
-	       P2(OBJECT, CLASSINFO), 0)
+	       P2(OBJECT, CLASSINFO), ECF_LEAF)
 DEF_D_RUNTIME (INTERFACE_CAST, "_d_interface_cast", RT(OBJECT),
-	       P2(OBJECT, CLASSINFO), 0)
+	       P2(OBJECT, CLASSINFO), ECF_LEAF)
 
 /* Used when calling new on a pointer.  The `i' variant is for when the
    initialiser is non-zero.  */
-DEF_D_RUNTIME (NEWITEMT, "_d_newitemT", RT(VOIDPTR), P1(CONST_TYPEINFO), 0)
-DEF_D_RUNTIME (NEWITEMIT, "_d_newitemiT", RT(VOIDPTR), P1(CONST_TYPEINFO), 0)
+DEF_D_RUNTIME (NEWITEMT, "_d_newitemT", RT(VOIDPTR), P1(CONST_TYPEINFO),
+	       ECF_LEAF)
+DEF_D_RUNTIME (NEWITEMIT, "_d_newitemiT", RT(VOIDPTR), P1(CONST_TYPEINFO),
+	       ECF_LEAF)
 
 /* Used when calling delete on a pointer.  */
-DEF_D_RUNTIME (DELMEMORY, "_d_delmemory", RT(VOID), P1(POINTER_VOIDPTR), 0)
+DEF_D_RUNTIME (DELMEMORY, "_d_delmemory", RT(VOID), P1(POINTER_VOIDPTR),
+	       ECF_LEAF)
 DEF_D_RUNTIME (DELSTRUCT, "_d_delstruct", RT(VOID),
 	       P2(POINTER_VOIDPTR, TYPEINFO), 0)
 
@@ -81,17 +85,17 @@ DEF_D_RUNTIME (DELSTRUCT, "_d_delstruct", RT(VOID),
    initialiser is non-zero, and the `m' variant is when initialising a
    multi-dimensional array.  */
 DEF_D_RUNTIME (NEWARRAYT, "_d_newarrayT", RT(ARRAY_VOID),
-	       P2(CONST_TYPEINFO, SIZE_T), 0)
+	       P2(CONST_TYPEINFO, SIZE_T), ECF_LEAF)
 DEF_D_RUNTIME (NEWARRAYIT, "_d_newarrayiT", RT(ARRAY_VOID),
-	       P2(CONST_TYPEINFO, SIZE_T), 0)
+	       P2(CONST_TYPEINFO, SIZE_T), ECF_LEAF)
 DEF_D_RUNTIME (NEWARRAYMTX, "_d_newarraymTX", RT(ARRAY_VOID),
-	       P2(CONST_TYPEINFO, ARRAY_SIZE_T), 0)
+	       P2(CONST_TYPEINFO, ARRAY_SIZE_T), ECF_LEAF)
 DEF_D_RUNTIME (NEWARRAYMITX, "_d_newarraymiTX", RT(ARRAY_VOID),
-	       P2(CONST_TYPEINFO, ARRAY_SIZE_T), 0)
+	       P2(CONST_TYPEINFO, ARRAY_SIZE_T), ECF_LEAF)
 
 /* Used for allocating an array literal on the GC heap.  */
 DEF_D_RUNTIME (ARRAYLITERALTX, "_d_arrayliteralTX", RT(VOIDPTR),
-	       P2(CONST_TYPEINFO, SIZE_T), 0)
+	       P2(CONST_TYPEINFO, SIZE_T), ECF_LEAF)
 
 /* Used when calling delete on an array.  */
 DEF_D_RUNTIME (DELARRAYT, "_d_delarray_t", RT(VOID),
@@ -107,7 +111,7 @@ DEF_D_RUNTIME (ADCMP2, "_adCmp2", RT(INT),
 /* Used when casting from one array type to another where the index type
    sizes differ.  Such as from int[] to short[].  */
 DEF_D_RUNTIME (ARRAYCAST, "_d_arraycast", RT(ARRAY_VOID),
-	       P3(SIZE_T, SIZE_T, ARRAY_VOID), 0)
+	       P3(SIZE_T, SIZE_T, ARRAY_VOID), ECF_LEAF)
 
 /* Used for (array.length = n) expressions.  The `i' variant is for when the
    initialiser is non-zero.  */
@@ -118,12 +122,12 @@ DEF_D_RUNTIME (ARRAYSETLENGTHIT, "_d_arraysetlengthiT", RT(ARRAY_VOID),
 
 /* Used for allocating closures on the GC heap.  */
 DEF_D_RUNTIME (ALLOCMEMORY, "_d_allocmemory", RT(VOIDPTR), P1(SIZE_T),
-	       ECF_MALLOC | ECF_PURE)
+	       ECF_LEAF | ECF_MALLOC | ECF_PURE)
 
 /* Used for copying an array into a slice, adds an enforcment that the source
    and destination are equal in size and do not overlap.  */
 DEF_D_RUNTIME (ARRAYCOPY, "_d_arraycopy", RT(ARRAY_VOID),
-	       P3(SIZE_T, ARRAY_VOID, ARRAY_VOID), 0)
+	       P3(SIZE_T, ARRAY_VOID, ARRAY_VOID), ECF_LEAF)
 
 /* Used for array assignments from an existing array.  The `set' variant is for
    when the assignment value is a single element.  */
@@ -157,9 +161,9 @@ DEF_D_RUNTIME (ARRAYAPPENDCTX, "_d_arrayappendcTX", RT(ARRAY_BYTE),
 /* Same as appending a single element to an array, but specific for when the
    source is a UTF-32 character, and the destination is a UTF-8 or 16 array.  */
 DEF_D_RUNTIME (ARRAYAPPENDCD, "_d_arrayappendcd", RT(ARRAY_VOID),
-	       P2(ARRAYPTR_BYTE, DCHAR), 0)
+	       P2(ARRAYPTR_BYTE, DCHAR), ECF_LEAF)
 DEF_D_RUNTIME (ARRAYAPPENDWD, "_d_arrayappendwd", RT(ARRAY_VOID),
-	       P2(ARRAYPTR_BYTE, DCHAR), 0)
+	       P2(ARRAYPTR_BYTE, DCHAR), ECF_LEAF)
 
 /* Used for appending an existing array to another.  */
 DEF_D_RUNTIME (ARRAYAPPENDT, "_d_arrayappendT", RT(ARRAY_VOID),
@@ -175,7 +179,7 @@ DEF_D_RUNTIME (AAEQUAL, "_aaEqual", RT(INT),
 
 /* Used to determine is a key exists in an associative array.  */
 DEF_D_RUNTIME (AAINX, "_aaInX", RT(VOIDPTR),
-	       P3(ASSOCARRAY, CONST_TYPEINFO, VOIDPTR), 0)
+	       P3(ASSOCARRAY, CONST_TYPEINFO, VOIDPTR), ECF_LEAF)
 
 /* Used to retrieve a value from an associative array index by a key.  The
    `Rvalue' variant returns null if the key is not found, where as aaGetY
@@ -183,11 +187,11 @@ DEF_D_RUNTIME (AAINX, "_aaInX", RT(VOIDPTR),
 DEF_D_RUNTIME (AAGETY, "_aaGetY", RT(VOIDPTR),
 	       P4(POINTER_ASSOCARRAY, CONST_TYPEINFO, SIZE_T, VOIDPTR), 0)
 DEF_D_RUNTIME (AAGETRVALUEX, "_aaGetRvalueX", RT(VOIDPTR),
-	       P4(ASSOCARRAY, CONST_TYPEINFO, SIZE_T, VOIDPTR), 0)
+	       P4(ASSOCARRAY, CONST_TYPEINFO, SIZE_T, VOIDPTR), ECF_LEAF)
 
 /* Used when calling delete on a key entry in an associative array.  */
 DEF_D_RUNTIME (AADELX, "_aaDelX", RT(BOOL),
-	       P3(ASSOCARRAY, CONST_TYPEINFO, VOIDPTR), 0)
+	       P3(ASSOCARRAY, CONST_TYPEINFO, VOIDPTR), ECF_LEAF)
 
 /* Used for throw() expressions.  */
 DEF_D_RUNTIME (THROW, "_d_throw", RT(VOID), P1(OBJECT), ECF_NORETURN)
@@ -206,11 +210,11 @@ DEF_D_RUNTIME (INVARIANT, "_D9invariant12_d_invariantFC6ObjectZv", RT(VOID),
 /* Used when performing a switch/cases on a string.  The `u' and `d' variants
    are for UTF-16 and UTF-32 strings respectively.  */
 DEF_D_RUNTIME (SWITCH_STRING, "_d_switch_string", RT(INT),
-	       P2(ARRAY_STRING, STRING), 0)
+	       P2(ARRAY_STRING, STRING), ECF_LEAF)
 DEF_D_RUNTIME (SWITCH_USTRING, "_d_switch_ustring", RT(INT),
-	       P2(ARRAY_WSTRING, WSTRING), 0)
+	       P2(ARRAY_WSTRING, WSTRING), ECF_LEAF)
 DEF_D_RUNTIME (SWITCH_DSTRING, "_d_switch_dstring", RT(INT),
-	       P2(ARRAY_DSTRING, DSTRING), 0)
+	       P2(ARRAY_DSTRING, DSTRING), ECF_LEAF)
 
 /* Used when throwing an error that a switch statement has no default case,
    and yet none of the existing cases matched.  */

--- a/gcc/d/runtime.def
+++ b/gcc/d/runtime.def
@@ -64,9 +64,9 @@ DEF_D_RUNTIME (CALLINTERFACEFINALIZER, "_d_callinterfacefinalizer", RT(VOID),
 
 /* Used for casting to a class or interface.  */
 DEF_D_RUNTIME (DYNAMIC_CAST, "_d_dynamic_cast", RT(OBJECT),
-	       P2(OBJECT, CLASSINFO), ECF_LEAF)
+	       P2(OBJECT, CLASSINFO), ECF_CONST | ECF_LEAF)
 DEF_D_RUNTIME (INTERFACE_CAST, "_d_interface_cast", RT(OBJECT),
-	       P2(OBJECT, CLASSINFO), ECF_LEAF)
+	       P2(OBJECT, CLASSINFO), ECF_CONST | ECF_LEAF)
 
 /* Used when calling new on a pointer.  The `i' variant is for when the
    initialiser is non-zero.  */
@@ -111,7 +111,7 @@ DEF_D_RUNTIME (ADCMP2, "_adCmp2", RT(INT),
 /* Used when casting from one array type to another where the index type
    sizes differ.  Such as from int[] to short[].  */
 DEF_D_RUNTIME (ARRAYCAST, "_d_arraycast", RT(ARRAY_VOID),
-	       P3(SIZE_T, SIZE_T, ARRAY_VOID), ECF_LEAF)
+	       P3(SIZE_T, SIZE_T, ARRAY_VOID), ECF_CONST | ECF_LEAF)
 
 /* Used for (array.length = n) expressions.  The `i' variant is for when the
    initialiser is non-zero.  */
@@ -179,7 +179,7 @@ DEF_D_RUNTIME (AAEQUAL, "_aaEqual", RT(INT),
 
 /* Used to determine is a key exists in an associative array.  */
 DEF_D_RUNTIME (AAINX, "_aaInX", RT(VOIDPTR),
-	       P3(ASSOCARRAY, CONST_TYPEINFO, VOIDPTR), ECF_LEAF)
+	       P3(ASSOCARRAY, CONST_TYPEINFO, VOIDPTR), ECF_CONST | ECF_LEAF)
 
 /* Used to retrieve a value from an associative array index by a key.  The
    `Rvalue' variant returns null if the key is not found, where as aaGetY
@@ -187,7 +187,8 @@ DEF_D_RUNTIME (AAINX, "_aaInX", RT(VOIDPTR),
 DEF_D_RUNTIME (AAGETY, "_aaGetY", RT(VOIDPTR),
 	       P4(POINTER_ASSOCARRAY, CONST_TYPEINFO, SIZE_T, VOIDPTR), 0)
 DEF_D_RUNTIME (AAGETRVALUEX, "_aaGetRvalueX", RT(VOIDPTR),
-	       P4(ASSOCARRAY, CONST_TYPEINFO, SIZE_T, VOIDPTR), ECF_LEAF)
+	       P4(ASSOCARRAY, CONST_TYPEINFO, SIZE_T, VOIDPTR),
+	       ECF_CONST | ECF_LEAF)
 
 /* Used when calling delete on a key entry in an associative array.  */
 DEF_D_RUNTIME (AADELX, "_aaDelX", RT(BOOL),
@@ -211,11 +212,11 @@ DEF_D_RUNTIME (INVARIANT, "_D9invariant12_d_invariantFC6ObjectZv", RT(VOID),
 /* Used when performing a switch/cases on a string.  The `u' and `d' variants
    are for UTF-16 and UTF-32 strings respectively.  */
 DEF_D_RUNTIME (SWITCH_STRING, "_d_switch_string", RT(INT),
-	       P2(ARRAY_STRING, STRING), ECF_LEAF)
+	       P2(ARRAY_STRING, STRING), ECF_CONST | ECF_LEAF)
 DEF_D_RUNTIME (SWITCH_USTRING, "_d_switch_ustring", RT(INT),
-	       P2(ARRAY_WSTRING, WSTRING), ECF_LEAF)
+	       P2(ARRAY_WSTRING, WSTRING), ECF_CONST | ECF_LEAF)
 DEF_D_RUNTIME (SWITCH_DSTRING, "_d_switch_dstring", RT(INT),
-	       P2(ARRAY_DSTRING, DSTRING), ECF_LEAF)
+	       P2(ARRAY_DSTRING, DSTRING), ECF_CONST | ECF_LEAF)
 
 /* Used when throwing an error that a switch statement has no default case,
    and yet none of the existing cases matched.  */

--- a/gcc/d/runtime.def
+++ b/gcc/d/runtime.def
@@ -17,10 +17,11 @@ along with GCC; see the file COPYING3.  If not see
 
 /* D runtime library functions.  */
 
-/* DEF_D_RUNTIME (CODE, NAME, FLAGS)
+/* DEF_D_RUNTIME (CODE, NAME, FLAGS, FNSPEC)
    CODE	    The enum code used to refer this function.
    NAME	    The name of this function as a string.
    FLAGS    ECF flags to describe attributes of the function.
+   FNSPEC   A string describing the functions fnspec.
 
    Used for declaring functions that are called by generated code.  Most are
    extern(C) - for those that are not, ensure to use correct mangling.  */
@@ -35,193 +36,207 @@ along with GCC; see the file COPYING3.  If not see
 
 /* Used when an assert() contract fails.  */
 DEF_D_RUNTIME (ASSERT, "_d_assert", RT(VOID), P2(STRING, UINT),
-	       ECF_COLD | ECF_LEAF | ECF_NORETURN)
+	       ECF_COLD | ECF_LEAF | ECF_NORETURN, ".RR")
 DEF_D_RUNTIME (ASSERT_MSG, "_d_assert_msg", RT(VOID), P3(STRING, STRING, UINT),
-	       ECF_COLD | ECF_LEAF | ECF_NORETURN)
+	       ECF_COLD | ECF_LEAF | ECF_NORETURN, ".RRR")
 
 /* Used when an assert() contract fails in a unittest function.  */
 DEF_D_RUNTIME (UNITTEST, "_d_unittest", RT(VOID), P2(STRING, UINT),
-	       ECF_COLD | ECF_LEAF | ECF_NORETURN)
+	       ECF_COLD | ECF_LEAF | ECF_NORETURN, ".RR")
 DEF_D_RUNTIME (UNITTEST_MSG, "_d_unittest_msg", RT(VOID),
-	       P3(STRING, STRING, UINT), ECF_COLD | ECF_LEAF | ECF_NORETURN)
+	       P3(STRING, STRING, UINT),
+	       ECF_COLD | ECF_LEAF | ECF_NORETURN, ".RRR")
 
 /* Used when an array index outside the bounds of its range.  */
 DEF_D_RUNTIME (ARRAY_BOUNDS, "_d_arraybounds", RT(VOID), P2(STRING, UINT),
-	       ECF_COLD | ECF_LEAF | ECF_NORETURN)
+	       ECF_COLD | ECF_LEAF | ECF_NORETURN, ".RR")
 
 /* Used when calling new on a class.  */
 DEF_D_RUNTIME (NEWCLASS, "_d_newclass", RT(OBJECT), P1(CONST_CLASSINFO),
-	       ECF_LEAF)
+	       ECF_LEAF, ".R")
 
 /* Used when calling delete on a class or interface.  */
-DEF_D_RUNTIME (DELCLASS, "_d_delclass", RT(VOID), P1(VOIDPTR), 0)
-DEF_D_RUNTIME (DELINTERFACE, "_d_delinterface", RT(VOID), P1(VOIDPTR), 0)
+DEF_D_RUNTIME (DELCLASS, "_d_delclass", RT(VOID), P1(VOIDPTR),
+	       0, ".w")
+DEF_D_RUNTIME (DELINTERFACE, "_d_delinterface", RT(VOID), P1(VOIDPTR),
+	       0, ".w")
 
 /* Same as deleting a class, but used for stack-allocated classes.  */
-DEF_D_RUNTIME (CALLFINALIZER, "_d_callfinalizer", RT(VOID), P1(VOIDPTR), 0)
+DEF_D_RUNTIME (CALLFINALIZER, "_d_callfinalizer", RT(VOID), P1(VOIDPTR),
+	       0, ".w")
 DEF_D_RUNTIME (CALLINTERFACEFINALIZER, "_d_callinterfacefinalizer", RT(VOID),
-	       P1(VOIDPTR), 0)
+	       P1(VOIDPTR), 0, ".w")
 
 /* Used for casting to a class or interface.  */
 DEF_D_RUNTIME (DYNAMIC_CAST, "_d_dynamic_cast", RT(OBJECT),
-	       P2(OBJECT, CLASSINFO), ECF_CONST | ECF_LEAF)
+	       P2(OBJECT, CLASSINFO), ECF_CONST | ECF_LEAF, ".rR")
 DEF_D_RUNTIME (INTERFACE_CAST, "_d_interface_cast", RT(OBJECT),
-	       P2(OBJECT, CLASSINFO), ECF_CONST | ECF_LEAF)
+	       P2(OBJECT, CLASSINFO), ECF_CONST | ECF_LEAF, ".rR")
 
 /* Used when calling new on a pointer.  The `i' variant is for when the
    initialiser is non-zero.  */
 DEF_D_RUNTIME (NEWITEMT, "_d_newitemT", RT(VOIDPTR), P1(CONST_TYPEINFO),
-	       ECF_LEAF)
+	       ECF_LEAF, ".R")
 DEF_D_RUNTIME (NEWITEMIT, "_d_newitemiT", RT(VOIDPTR), P1(CONST_TYPEINFO),
-	       ECF_LEAF)
+	       ECF_LEAF, ".R")
 
 /* Used when calling delete on a pointer.  */
 DEF_D_RUNTIME (DELMEMORY, "_d_delmemory", RT(VOID), P1(POINTER_VOIDPTR),
-	       ECF_LEAF)
+	       ECF_LEAF, ".w")
 DEF_D_RUNTIME (DELSTRUCT, "_d_delstruct", RT(VOID),
-	       P2(POINTER_VOIDPTR, TYPEINFO), 0)
+	       P2(POINTER_VOIDPTR, TYPEINFO), 0, ".wR")
 
 /* Used when calling new on an array.  The `i' variant is for when the
    initialiser is non-zero, and the `m' variant is when initialising a
    multi-dimensional array.  */
 DEF_D_RUNTIME (NEWARRAYT, "_d_newarrayT", RT(ARRAY_VOID),
-	       P2(CONST_TYPEINFO, SIZE_T), ECF_LEAF)
+	       P2(CONST_TYPEINFO, SIZE_T), ECF_LEAF, "mRR")
 DEF_D_RUNTIME (NEWARRAYIT, "_d_newarrayiT", RT(ARRAY_VOID),
-	       P2(CONST_TYPEINFO, SIZE_T), ECF_LEAF)
+	       P2(CONST_TYPEINFO, SIZE_T), ECF_LEAF, "mRR")
 DEF_D_RUNTIME (NEWARRAYMTX, "_d_newarraymTX", RT(ARRAY_VOID),
-	       P2(CONST_TYPEINFO, ARRAY_SIZE_T), ECF_LEAF)
+	       P2(CONST_TYPEINFO, ARRAY_SIZE_T), ECF_LEAF, "mRR")
 DEF_D_RUNTIME (NEWARRAYMITX, "_d_newarraymiTX", RT(ARRAY_VOID),
-	       P2(CONST_TYPEINFO, ARRAY_SIZE_T), ECF_LEAF)
+	       P2(CONST_TYPEINFO, ARRAY_SIZE_T), ECF_LEAF, "mRR")
 
 /* Used for allocating an array literal on the GC heap.  */
 DEF_D_RUNTIME (ARRAYLITERALTX, "_d_arrayliteralTX", RT(VOIDPTR),
-	       P2(CONST_TYPEINFO, SIZE_T), ECF_LEAF)
+	       P2(CONST_TYPEINFO, SIZE_T), ECF_LEAF, ".RR")
 
 /* Used when calling delete on an array.  */
 DEF_D_RUNTIME (DELARRAYT, "_d_delarray_t", RT(VOID),
-	       P2(ARRAYPTR_VOID, CONST_TYPEINFO), 0)
+	       P2(ARRAYPTR_VOID, CONST_TYPEINFO), 0, ".wR")
 
 /* Used for value equality (x == y) and comparisons (x < y) of non-trivial
    arrays.  Such as an array of structs or classes.  */
 DEF_D_RUNTIME (ADEQ2, "_adEq2", RT(INT),
-	       P3(ARRAY_VOID, ARRAY_VOID, CONST_TYPEINFO), 0)
+	       P3(ARRAY_VOID, ARRAY_VOID, CONST_TYPEINFO), 0, ".RRR")
 DEF_D_RUNTIME (ADCMP2, "_adCmp2", RT(INT),
-	       P3(ARRAY_VOID, ARRAY_VOID, CONST_TYPEINFO), 0)
+	       P3(ARRAY_VOID, ARRAY_VOID, CONST_TYPEINFO), 0, ".RRR")
 
 /* Used when casting from one array type to another where the index type
-   sizes differ.  Such as from int[] to short[].  */
+   sizes differ, such as from int[] to short[].
+   TODO: This function returns its third argument, but the backend is may not
+   handle this for aggregates properly.  */
 DEF_D_RUNTIME (ARRAYCAST, "_d_arraycast", RT(ARRAY_VOID),
-	       P3(SIZE_T, SIZE_T, ARRAY_VOID), ECF_CONST | ECF_LEAF)
+	       P3(SIZE_T, SIZE_T, ARRAY_VOID), ECF_CONST | ECF_LEAF, ".RRw")
 
 /* Used for (array.length = n) expressions.  The `i' variant is for when the
    initialiser is non-zero.  */
 DEF_D_RUNTIME (ARRAYSETLENGTHT, "_d_arraysetlengthT", RT(ARRAY_VOID),
-	       P3(CONST_TYPEINFO, SIZE_T, ARRAYPTR_VOID), 0)
+	       P3(CONST_TYPEINFO, SIZE_T, ARRAYPTR_VOID), 0, ".RR.")
 DEF_D_RUNTIME (ARRAYSETLENGTHIT, "_d_arraysetlengthiT", RT(ARRAY_VOID),
-	       P3(CONST_TYPEINFO, SIZE_T, ARRAYPTR_VOID), 0)
+	       P3(CONST_TYPEINFO, SIZE_T, ARRAYPTR_VOID), 0, ".RR.")
 
 /* Used for allocating closures on the GC heap.  */
 DEF_D_RUNTIME (ALLOCMEMORY, "_d_allocmemory", RT(VOIDPTR), P1(SIZE_T),
-	       ECF_LEAF | ECF_MALLOC | ECF_PURE)
+	       ECF_LEAF | ECF_MALLOC | ECF_PURE, "mR")
 
 /* Used for copying an array into a slice, adds an enforcment that the source
-   and destination are equal in size and do not overlap.  */
+   and destination are equal in size and do not overlap.
+   TODO: This function returns its third argument, but the backend is may not
+   handle this for aggregates properly.  */
 DEF_D_RUNTIME (ARRAYCOPY, "_d_arraycopy", RT(ARRAY_VOID),
-	       P3(SIZE_T, ARRAY_VOID, ARRAY_VOID), ECF_LEAF)
+	       P3(SIZE_T, ARRAY_VOID, ARRAY_VOID), ECF_LEAF, ".RRw")
 
 /* Used for array assignments from an existing array.  The `set' variant is for
-   when the assignment value is a single element.  */
+   when the assignment value is a single element.
+   TODO: These functions return their third argument, but the backend is may not
+   handle this for aggregates properly.  */
 DEF_D_RUNTIME (ARRAYASSIGN, "_d_arrayassign", RT(ARRAY_VOID),
-	       P3(CONST_TYPEINFO, ARRAY_VOID, ARRAY_VOID), 0)
+	       P3(CONST_TYPEINFO, ARRAY_VOID, ARRAY_VOID), 0, ".RR.")
 DEF_D_RUNTIME (ARRAYASSIGN_L, "_d_arrayassign_l", RT(ARRAY_VOID),
-	       P4(CONST_TYPEINFO, ARRAY_VOID, ARRAY_VOID, VOIDPTR), 0)
+	       P4(CONST_TYPEINFO, ARRAY_VOID, ARRAY_VOID, VOIDPTR), 0, ".RR.W")
 DEF_D_RUNTIME (ARRAYASSIGN_R, "_d_arrayassign_r", RT(ARRAY_VOID),
-	       P4(CONST_TYPEINFO, ARRAY_VOID, ARRAY_VOID, VOIDPTR), 0)
+	       P4(CONST_TYPEINFO, ARRAY_VOID, ARRAY_VOID, VOIDPTR), 0, ".RRwW")
 DEF_D_RUNTIME (ARRAYSETASSIGN, "_d_arraysetassign", RT(VOIDPTR),
-	       P4(VOIDPTR, VOIDPTR, SIZE_T, CONST_TYPEINFO), 0)
+	       P4(VOIDPTR, VOIDPTR, SIZE_T, CONST_TYPEINFO), 0, "1.RRR")
 
 /* Used for constructing a new array from an existing array.  The `set' variant
-   is for when the constructor value is a single element.  */
+   is for when the constructor value is a single element.
+   TODO: This function returns its third argument, but the backend is may not
+   not handle this for aggregates properly.  */
 DEF_D_RUNTIME (ARRAYCTOR, "_d_arrayctor", RT(ARRAY_VOID),
-	       P3(CONST_TYPEINFO, ARRAY_VOID, ARRAY_VOID), 0)
+	       P3(CONST_TYPEINFO, ARRAY_VOID, ARRAY_VOID), 0, ".R..")
 DEF_D_RUNTIME (ARRAYSETCTOR, "_d_arraysetctor", RT(VOIDPTR),
-	       P4(VOIDPTR, VOIDPTR, SIZE_T, CONST_TYPEINFO), 0)
+	       P4(VOIDPTR, VOIDPTR, SIZE_T, CONST_TYPEINFO), 0, "1.RRR")
 
 /* Used for concatenating two or more arrays together.  Then `n' variant is
    for when there is more than two arrays to handle.  */
 DEF_D_RUNTIME (ARRAYCATT, "_d_arraycatT", RT(ARRAY_BYTE),
-	       P3(CONST_TYPEINFO, ARRAY_BYTE, ARRAY_BYTE), 0)
+	       P3(CONST_TYPEINFO, ARRAY_BYTE, ARRAY_BYTE), 0, "mRRR")
 DEF_D_RUNTIME (ARRAYCATNTX, "_d_arraycatnTX", RT(ARRAY_VOID),
-	       P2(CONST_TYPEINFO, ARRAYARRAY_BYTE), 0)
+	       P2(CONST_TYPEINFO, ARRAYARRAY_BYTE), 0, "mRr")
 
 /* Used for appending a single element to an array.  */
 DEF_D_RUNTIME (ARRAYAPPENDCTX, "_d_arrayappendcTX", RT(ARRAY_BYTE),
-	       P3(CONST_TYPEINFO, ARRAYPTR_BYTE, SIZE_T), 0)
+	       P3(CONST_TYPEINFO, ARRAYPTR_BYTE, SIZE_T), 0, ".R.R")
 
 /* Same as appending a single element to an array, but specific for when the
    source is a UTF-32 character, and the destination is a UTF-8 or 16 array.  */
 DEF_D_RUNTIME (ARRAYAPPENDCD, "_d_arrayappendcd", RT(ARRAY_VOID),
-	       P2(ARRAYPTR_BYTE, DCHAR), ECF_LEAF)
+	       P2(ARRAYPTR_BYTE, DCHAR), ECF_LEAF, ".wR")
 DEF_D_RUNTIME (ARRAYAPPENDWD, "_d_arrayappendwd", RT(ARRAY_VOID),
-	       P2(ARRAYPTR_BYTE, DCHAR), ECF_LEAF)
+	       P2(ARRAYPTR_BYTE, DCHAR), ECF_LEAF, ".wR")
 
 /* Used for appending an existing array to another.  */
 DEF_D_RUNTIME (ARRAYAPPENDT, "_d_arrayappendT", RT(ARRAY_VOID),
-	       P3(TYPEINFO, ARRAYPTR_BYTE, ARRAY_BYTE), 0)
+	       P3(TYPEINFO, ARRAYPTR_BYTE, ARRAY_BYTE), 0, ".R.R")
 
 /* Used for allocating a new associative array.  */
 DEF_D_RUNTIME (ASSOCARRAYLITERALTX, "_d_assocarrayliteralTX", RT(VOIDPTR),
-	       P3(CONST_TYPEINFO, ARRAY_VOID, ARRAY_VOID), 0)
+	       P3(CONST_TYPEINFO, ARRAY_VOID, ARRAY_VOID), 0, "mRRR")
 
 /* Used for value equality of two associative arrays.  */
 DEF_D_RUNTIME (AAEQUAL, "_aaEqual", RT(INT),
-	       P3(CONST_TYPEINFO, ASSOCARRAY, ASSOCARRAY), 0)
+	       P3(CONST_TYPEINFO, ASSOCARRAY, ASSOCARRAY), 0, ".RRR")
 
 /* Used to determine is a key exists in an associative array.  */
 DEF_D_RUNTIME (AAINX, "_aaInX", RT(VOIDPTR),
-	       P3(ASSOCARRAY, CONST_TYPEINFO, VOIDPTR), ECF_CONST | ECF_LEAF)
+	       P3(ASSOCARRAY, CONST_TYPEINFO, VOIDPTR),
+	       ECF_CONST | ECF_LEAF, ".RRR")
 
 /* Used to retrieve a value from an associative array index by a key.  The
    `Rvalue' variant returns null if the key is not found, where as aaGetY
    will create new key entry for assignment.  */
 DEF_D_RUNTIME (AAGETY, "_aaGetY", RT(VOIDPTR),
-	       P4(POINTER_ASSOCARRAY, CONST_TYPEINFO, SIZE_T, VOIDPTR), 0)
+	       P4(POINTER_ASSOCARRAY, CONST_TYPEINFO, SIZE_T, VOIDPTR),
+	       0, ".wRRR")
 DEF_D_RUNTIME (AAGETRVALUEX, "_aaGetRvalueX", RT(VOIDPTR),
 	       P4(ASSOCARRAY, CONST_TYPEINFO, SIZE_T, VOIDPTR),
-	       ECF_CONST | ECF_LEAF)
+	       ECF_CONST | ECF_LEAF, ".RRRR")
 
 /* Used when calling delete on a key entry in an associative array.  */
 DEF_D_RUNTIME (AADELX, "_aaDelX", RT(BOOL),
-	       P3(ASSOCARRAY, CONST_TYPEINFO, VOIDPTR), ECF_LEAF)
+	       P3(ASSOCARRAY, CONST_TYPEINFO, VOIDPTR), ECF_LEAF, ".wRR")
 
 /* Used for throw() expressions.  */
-DEF_D_RUNTIME (THROW, "_d_throw", RT(VOID), P1(OBJECT), ECF_NORETURN)
+DEF_D_RUNTIME (THROW, "_d_throw", RT(VOID), P1(OBJECT), ECF_NORETURN, NULL)
 DEF_D_RUNTIME (BEGIN_CATCH, "__gdc_begin_catch", RT(VOIDPTR), P1(VOIDPTR),
-	       ECF_NOTHROW)
+	       ECF_NOTHROW, NULL)
 
 /* C++ exception handlers.  */
 DEF_D_RUNTIME (CXA_BEGIN_CATCH, "__cxa_begin_catch", RT(VOIDPTR), P1(VOIDPTR),
-	       ECF_NOTHROW)
-DEF_D_RUNTIME (CXA_END_CATCH, "__cxa_end_catch", RT(VOID), P0(), 0)
+	       ECF_NOTHROW, NULL)
+DEF_D_RUNTIME (CXA_END_CATCH, "__cxa_end_catch", RT(VOID), P0(), 0, NULL)
 
 /* When invariant() contracts are turned on, used after testing whether a
    class != null for validating the state of a class.  */
 DEF_D_RUNTIME (INVARIANT, "_D9invariant12_d_invariantFC6ObjectZv", RT(VOID),
-	       P1(OBJECT), 0)
+	       P1(OBJECT), 0, ".r")
 
 /* Used when performing a switch/cases on a string.  The `u' and `d' variants
    are for UTF-16 and UTF-32 strings respectively.  */
 DEF_D_RUNTIME (SWITCH_STRING, "_d_switch_string", RT(INT),
-	       P2(ARRAY_STRING, STRING), ECF_CONST | ECF_LEAF)
+	       P2(ARRAY_STRING, STRING), ECF_CONST | ECF_LEAF, ".RR")
 DEF_D_RUNTIME (SWITCH_USTRING, "_d_switch_ustring", RT(INT),
-	       P2(ARRAY_WSTRING, WSTRING), ECF_CONST | ECF_LEAF)
+	       P2(ARRAY_WSTRING, WSTRING), ECF_CONST | ECF_LEAF, ".RR")
 DEF_D_RUNTIME (SWITCH_DSTRING, "_d_switch_dstring", RT(INT),
-	       P2(ARRAY_DSTRING, DSTRING), ECF_CONST | ECF_LEAF)
+	       P2(ARRAY_DSTRING, DSTRING), ECF_CONST | ECF_LEAF, ".RR")
 
 /* Used when throwing an error that a switch statement has no default case,
    and yet none of the existing cases matched.  */
 DEF_D_RUNTIME (SWITCH_ERROR, "_d_switch_error", RT(VOID), P2(STRING, UINT),
-	       ECF_COLD | ECF_LEAF | ECF_NORETURN)
+	       ECF_COLD | ECF_LEAF | ECF_NORETURN, ".RR")
 
 #undef P0
 #undef P1

--- a/gcc/d/runtime.def
+++ b/gcc/d/runtime.def
@@ -195,7 +195,8 @@ DEF_D_RUNTIME (AADELX, "_aaDelX", RT(BOOL),
 
 /* Used for throw() expressions.  */
 DEF_D_RUNTIME (THROW, "_d_throw", RT(VOID), P1(OBJECT), ECF_NORETURN)
-DEF_D_RUNTIME (BEGIN_CATCH, "__gdc_begin_catch", RT(VOIDPTR), P1(VOIDPTR), 0)
+DEF_D_RUNTIME (BEGIN_CATCH, "__gdc_begin_catch", RT(VOIDPTR), P1(VOIDPTR),
+	       ECF_NOTHROW)
 
 /* C++ exception handlers.  */
 DEF_D_RUNTIME (CXA_BEGIN_CATCH, "__cxa_begin_catch", RT(VOIDPTR), P1(VOIDPTR),

--- a/gcc/d/runtime.def
+++ b/gcc/d/runtime.def
@@ -118,7 +118,7 @@ DEF_D_RUNTIME (ARRAYSETLENGTHIT, "_d_arraysetlengthiT", RT(ARRAY_VOID),
 
 /* Used for allocating closures on the GC heap.  */
 DEF_D_RUNTIME (ALLOCMEMORY, "_d_allocmemory", RT(VOIDPTR), P1(SIZE_T),
-	       ECF_MALLOC)
+	       ECF_MALLOC | ECF_PURE)
 
 /* Used for copying an array into a slice, adds an enforcment that the source
    and destination are equal in size and do not overlap.  */

--- a/gcc/testsuite/gdc.test/runnable/sdtor.d
+++ b/gcc/testsuite/gdc.test/runnable/sdtor.d
@@ -4614,7 +4614,7 @@ int main()
     test9985();
     //test17457();    // XBUG: NRVO implementation differs
     test9994();
-    test10094();
+    //test10094();    // XBUG: NRVO implementation differs
     test10244();
     test10694();
     test10789();


### PR DESCRIPTION
Rationale for call attributes.
- `ECF_COLD`: On functions that should never be called (`_d_assert`, `_d_switch_error`, etc...)
- `ECF_LEAF`: On functions that don't call `postblit()` or `destroy()` (`_d_allocmemory`, etc...)
- `ECF_NOTHROW`: On functions that never throw (`__gdc_begin_catch()`)
- `ECF_MALLOC`: On functions have a malloc-like call (`_d_allocmemory`).
- `ECF_PURE`: On functions that return a "new" pointer to GC only.  (`_d_allocmemory`, others _should_ work, but are a bit risky)
- `ECF_CONST`: On functions that depend solely on its arguments (`_d_switch_string`, etc...)

Explanation of the fnspec string:
- First character is the return spec.
  - `m`: Return value has no aliases
  - `1`: First argument same as return value
  - `3`: Third argument same as return value
  - `.`:  Have no idea what is returned.
- Rest of the characters in the string represent each argument passed.
  - `R`: Argument is readonly, not dereferenced recursively, and does not escape.
  - `r`: Argument is readonly, and does not escape.
  - `W`: Argument is written to, not dereferenced recursively, and does not escape.
  - `w`: Argument is written to, but does not escape.
  - `.`: Have no idea what may be done with argument.