### PR TITLE
Remove check for D_IMPORT_PATH, undocument all environment variables.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -8,6 +8,11 @@
 	* d-builtins.cc (build_frontend_type): Set alignment of structs in
 	frontend.
 
+2018-02-17  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-incpath.cc (add_environment_paths): Remove function.
+	* gdc.texi (Environment Variables): Remove section.
+
 2018-02-10  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* expr.cc (ExprVisitor::AssertExp): Use builtin expect to mark assert

--- a/gcc/d/d-incpath.cc
+++ b/gcc/d/d-incpath.cc
@@ -21,43 +21,7 @@ along with GCC; see the file COPYING3.  If not see
 
 #include "dfrontend/globals.h"
 
-#include "tree.h"
-#include "diagnostic.h"
-#include "options.h"
 #include "cppdefault.h"
-
-#include "d-tree.h"
-
-/* Read ENV_VAR for a PATH_SEPARATOR-separated list of file names; and
-   append all the names to the import search path.  */
-
-static void
-add_environment_paths (const char *env_var)
-{
-  char *q = getenv (env_var);
-  char *path;
-
-  if (!q)
-    return;
-
-  for (char *p = q; *q; p = q + 1)
-    {
-      q = p;
-      while (*q != 0 && *q != PATH_SEPARATOR)
-	q++;
-
-      if (p == q)
-	path = xstrdup (".");
-      else
-	{
-	  path = XNEWVEC (char, q - p + 1);
-	  memcpy (path, p, q - p);
-	  path[q - p] = '\0';
-	}
-
-      global.params.imppath->push (path);
-    }
-}
 
 /* Look for directories that start with the standard prefix.
    "Translate" them, i.e. replace /usr/local/lib/gcc with
@@ -205,9 +169,6 @@ add_import_paths (const char *iprefix, const char *imultilib, bool stdinc)
 	  global.params.imppath->shift (path);
 	}
     }
-
-  /* Language-dependent environment variables may add to the include chain.  */
-  add_environment_paths ("D_IMPORT_PATH");
 
   /* Add import search paths  */
   if (global.params.imppath)

--- a/gcc/d/gdc.texi
+++ b/gcc/d/gdc.texi
@@ -136,7 +136,6 @@ the options specific to @command{gdc}.
 * Warnings::                Options controlling warnings specific to gdc
 * Linking::                 Options influceing the linking step
 * Developer Options::       Options you won't use
-* Environment Variables::   Environment variables that affect @command{gdc}.
 @end menu
 
 @c man begin OPTIONS
@@ -737,36 +736,6 @@ processed through the @code{parse}, @code{semantic}, @code{semantic2}, and
 and all @code{function} bodies that are being compiled.
 
 @end table
-
-@c man end
-
-@node Environment Variables
-@section Environment variables affecting @command{gdc}
-@cindex environment variable
-
-@c man begin ENVIRONMENT
-
-In addition to the many @command{gcc} environment variables that control
-its operation, @command{gdc} has a few environment variables specific to
-itself.
-
-@vtable @env
-
-@item D_IMPORT_PATH
-@findex D_IMPORT_PATH
-The value of @env{D_IMPORT_PATH} is a list of directories separated by a
-special character, much like @env{PATH}, in which to look for imports.
-The special character, @code{PATH_SEPARATOR}, is target-dependent and
-determined at GCC build time.  For Microsoft Windows-based targets it is a
-semicolon, and for almost all other targets it is a colon.
-
-@item DDOCFILE
-@findex DDOCFILE
-If @env{DDOCFILE} is set, it specifies a text file of macro definitions
-to be read and used by the Ddoc generator.  This overrides any macros
-defined in other @file{.ddoc} files.
-
-@end vtable
 
 @c man end
 


### PR DESCRIPTION
The review of this code being:

> How important are the environment variables to the existing user base? We generally try to avoid changing much behavior based on environment variables.  Can these be made command line options?

They're already command-line options, so just removing them.