### PR TITLE
Fix Bug 284: cc1d: internal compiler error: in add_stack_var

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -3,6 +3,11 @@
 	* Make-lang.in (DMD_WARN_CXXFLAGS): Only filter out
 	-Wmissing-format-attribute from WARN_CXXFLAGS.
 
+2018-02-18  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-builtins.cc (build_frontend_type): Set alignment of structs in
+	frontend.
+
 2018-02-10  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* expr.cc (ExprVisitor::AssertExp): Use builtin expect to mark assert

--- a/gcc/d/d-builtins.cc
+++ b/gcc/d/d-builtins.cc
@@ -228,6 +228,7 @@ build_frontend_type (tree type)
 	  sdecl->parent = stubmod;
 	  sdecl->structsize = int_size_in_bytes (type);
 	  sdecl->alignsize = TYPE_ALIGN_UNIT (type);
+	  sdecl->alignment = STRUCTALIGN_DEFAULT;
 	  sdecl->sizeok = SIZEOKdone;
 	  sdecl->type = (TypeStruct::create (sdecl))->addMod (mod);
 	  sdecl->type->ctype = type;

--- a/gcc/testsuite/gdc.dg/compilable.d
+++ b/gcc/testsuite/gdc.dg/compilable.d
@@ -449,3 +449,14 @@ class RedBlackTree280
 }
 
 __gshared s = new RedBlackTree280('h');
+
+/******************************************/
+
+// Bug 284
+
+alias v284 = __vector(int[2]);
+
+v284 test284(v284 a, ...)
+{
+    return a + a;
+}


### PR DESCRIPTION
Middle-end was getting confused that the alignment of `_argptr` was set to zero.