### PR TITLE
Update longdouble interface to match D port

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,19 @@
+2018-02-24  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-frontend.cc (CTFloat::fabs): Assign result to real_t directly.
+	(CTFloat::ldexp): Likewise.
+	* d-longdouble.cc (longdouble::from_int): Remove function.
+	(longdouble::from_uint): Likewise.
+	(longdouble::to_int): Update Signature.
+	(longdouble::to_uint): Likewise.
+	(longdouble::operator): Likewise.
+	(longdouble::add): New function, move operator overload headers.
+	(longdouble::sub, longdouble::mul, longdouble::div): Likewise.
+	(longdouble::mod, longdouble::neg): Likewise.
+	(longdouble::cmp, longdouble::equals): Likewise.
+	* d-target.cc (Target::_init): Construct assignment into real_t
+	directly.
+
 2018-02-19  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* Make-lang.in (DMD_WARN_CXXFLAGS): Only filter out

--- a/gcc/d/d-frontend.cc
+++ b/gcc/d/d-frontend.cc
@@ -317,8 +317,9 @@ Port::valcpy (void *buffer, uint64_t value, size_t sz)
 real_t
 CTFloat::fabs (real_t r)
 {
-  real_value x = real_value_abs (&r.rv ());
-  return ldouble (x);
+  real_t x;
+  real_arithmetic (&x.rv (), ABS_EXPR, &r.rv (), NULL);
+  return x.normalize ();
 }
 
 /* Return the value of R * 2 ^^ EXP.  */
@@ -326,9 +327,9 @@ CTFloat::fabs (real_t r)
 real_t
 CTFloat::ldexp (real_t r, int exp)
 {
-  real_value rv;
-  real_ldexp (&rv, &r.rv (), exp);
-  return ldouble (rv);
+  real_t x;
+  real_ldexp (&x.rv (), &r.rv (), exp);
+  return x.normalize ();
 }
 
 /* Return true if longdouble value X is identical to Y.  */

--- a/gcc/d/d-longdouble.cc
+++ b/gcc/d/d-longdouble.cc
@@ -36,52 +36,17 @@ real_t CTFloat::one;
 real_t CTFloat::minusone;
 real_t CTFloat::half;
 
-
-/* Return conversion of signed integer value D to longdouble.
-   Conversion is done at precision mode of TYPE.  */
+/* Truncate longdouble to the highest precision supported by target.  */
 
 longdouble
-longdouble::from_int (Type *type, int64_t d)
+longdouble::normalize (void)
 {
-  tree t = build_ctype (type);
-  real_from_integer (&this->rv (), TYPE_MODE (t), d, SIGNED);
+  const machine_mode mode = TYPE_MODE (long_double_type_node);
+  real_convert (&this->rv (), mode, &this->rv ());
   return *this;
 }
 
-/* Return conversion of unsigned integer value D to longdouble.
-   Conversion is done at precision mode of TYPE.  */
-
-longdouble
-longdouble::from_uint (Type *type, uint64_t d)
-{
-  tree t = build_ctype (type);
-  real_from_integer (&this->rv (), TYPE_MODE (t), d, UNSIGNED);
-  return *this;
-}
-
-/* Return conversion of longdouble value to int64_t.
-   Conversion is done at precision mode of TYPE.  */
-
-int64_t
-longdouble::to_int (Type *type) const
-{
-  if (REAL_VALUE_ISNAN (this->rv ()))
-    return 0;
-
-  tree t = fold_build1 (FIX_TRUNC_EXPR, build_ctype (type),
-		       build_float_cst (*this, Type::tfloat80));
-  return TREE_INT_CST_LOW (t);
-}
-
-/* Same as longdouble::to_int, but returns a uint64_t.  */
-
-uint64_t
-longdouble::to_uint (Type *type) const
-{
-  return (uint64_t) to_int (type);
-}
-
-/* Conversion routines between longdouble and real_value.  */
+/* Assign a real_value to a longdouble type.  */
 
 void
 longdouble::set (real_value& d)
@@ -89,102 +54,50 @@ longdouble::set (real_value& d)
   real_convert (&this->rv (), TYPE_MODE (long_double_type_node), &d);
 }
 
-longdouble::operator
-real_value& (void)
-{
-  return this->rv ();
-}
-
 /* Conversion routines between longdouble and integer types.  */
-
-void
-longdouble::set (int8_t d)
-{
-  from_int (Type::tfloat32, d);
-}
-
-void
-longdouble::set (int16_t d)
-{
-  from_int (Type::tfloat32, d);
-}
 
 void
 longdouble::set (int32_t d)
 {
-  from_int (Type::tfloat64, d);
+  real_from_integer (&this->rv (), TYPE_MODE (double_type_node), d, SIGNED);
 }
 
 void
 longdouble::set (int64_t d)
 {
-  from_int (Type::tfloat80, d);
+  real_from_integer (&this->rv (), TYPE_MODE (long_double_type_node), d,
+		     SIGNED);
 }
 
-longdouble::operator int8_t (void)
+int64_t
+longdouble::to_int (void) const
 {
-  return to_int (Type::tint8);
-}
-
-longdouble::operator int16_t (void)
-{
-  return to_int (Type::tint16);
-}
-
-longdouble::operator int32_t (void)
-{
-  return to_int (Type::tint32);
-}
-
-longdouble::operator int64_t (void)
-{
-  return to_int (Type::tint64);
+  bool overflow;
+  wide_int wi = real_to_integer (&this->rv (), &overflow, 64);
+  return wi.to_shwi ();
 }
 
 /* Unsigned variants of the same conversion routines.  */
 
 void
-longdouble::set (uint8_t d)
-{
-  from_uint (Type::tfloat32, d);
-}
-
-void
-longdouble::set (uint16_t d)
-{
-  from_uint (Type::tfloat32, d);
-}
-
-void
 longdouble::set (uint32_t d)
 {
-  from_uint (Type::tfloat64, d);
+  real_from_integer (&this->rv (), TYPE_MODE (double_type_node), d, UNSIGNED);
 }
 
 void
 longdouble::set (uint64_t d)
 {
-  from_uint (Type::tfloat80, d);
+  real_from_integer (&this->rv (), TYPE_MODE (long_double_type_node), d,
+		     UNSIGNED);
 }
 
-longdouble::operator uint8_t (void)
+uint64_t
+longdouble::to_uint (void) const
 {
-  return to_uint (Type::tuns8);
-}
-
-longdouble::operator uint16_t (void)
-{
-  return to_uint (Type::tuns16);
-}
-
-longdouble::operator uint32_t (void)
-{
-  return to_uint (Type::tuns32);
-}
-
-longdouble::operator uint64_t (void)
-{
-  return to_uint (Type::tuns64);
+  bool overflow;
+  wide_int wi = real_to_integer (&this->rv (), &overflow, 64);
+  return wi.to_uhwi ();
 }
 
 /* For conversion between boolean, only need to check if is zero.  */
@@ -195,8 +108,8 @@ longdouble::set (bool d)
   this->rv () = (d == false) ? dconst0 : dconst1;
 }
 
-longdouble::operator
-bool (void)
+bool
+longdouble::to_bool (void) const
 {
   return this->rv ().cl != rvc_zero;
 }
@@ -204,47 +117,47 @@ bool (void)
 /* Overload numeric operators for longdouble types.  */
 
 longdouble
-longdouble::operator + (const longdouble& r)
+longdouble::add (const longdouble& r) const
 {
-  real_value x;
-  real_arithmetic (&x, PLUS_EXPR, &this->rv (), &r.rv ());
-  return ldouble (x);
+  longdouble x;
+  real_arithmetic (&x.rv (), PLUS_EXPR, &this->rv (), &r.rv ());
+  return x.normalize ();
 }
 
 longdouble
-longdouble::operator - (const longdouble& r)
+longdouble::sub (const longdouble& r) const
 {
-  real_value x;
-  real_arithmetic (&x, MINUS_EXPR, &this->rv (), &r.rv ());
-  return ldouble (x);
+  longdouble x;
+  real_arithmetic (&x.rv (), MINUS_EXPR, &this->rv (), &r.rv ());
+  return x.normalize ();
 }
 
 longdouble
-longdouble::operator * (const longdouble& r)
+longdouble::mul (const longdouble& r) const
 {
-  real_value x;
-  real_arithmetic (&x, MULT_EXPR, &this->rv (), &r.rv ());
-  return ldouble (x);
+  longdouble x;
+  real_arithmetic (&x.rv (), MULT_EXPR, &this->rv (), &r.rv ());
+  return x.normalize ();
 }
 
 longdouble
-longdouble::operator / (const longdouble& r)
+longdouble::div (const longdouble& r) const
 {
-  real_value x;
-  real_arithmetic (&x, RDIV_EXPR, &this->rv (), &r.rv ());
-  return ldouble (x);
+  longdouble x;
+  real_arithmetic (&x.rv (), RDIV_EXPR, &this->rv (), &r.rv ());
+  return x.normalize ();
 }
 
 longdouble
-longdouble::operator % (const longdouble& r)
+longdouble::mod (const longdouble& r) const
 {
-  real_value q, x;
+  longdouble x;
+  real_value q;
 
   if (r.rv ().cl == rvc_zero || REAL_VALUE_ISINF (this->rv ()))
     {
-      real_value rvt;
-      real_nan (&rvt, "", 1, TYPE_MODE (long_double_type_node));
-      return ldouble (rvt);
+      real_nan (&x.rv (), "", 1, TYPE_MODE (long_double_type_node));
+      return x;
     }
 
   if (this->rv ().cl == rvc_zero)
@@ -257,52 +170,35 @@ longdouble::operator % (const longdouble& r)
   real_arithmetic (&q, RDIV_EXPR, &this->rv (), &r.rv ());
   real_arithmetic (&q, FIX_TRUNC_EXPR, &q, NULL);
   real_arithmetic (&q, MULT_EXPR, &q, &r.rv ());
-  real_arithmetic (&x, MINUS_EXPR, &this->rv (), &q);
+  real_arithmetic (&x.rv (), MINUS_EXPR, &this->rv (), &q);
 
-  return ldouble (x);
+  return x.normalize ();
 }
 
 longdouble
-longdouble::operator -(void)
+longdouble::neg (void) const
 {
-  real_value x = real_value_negate (&this->rv ());
-  return ldouble (x);
+  longdouble x;
+  real_arithmetic (&x.rv (), NEGATE_EXPR, &this->rv (), NULL);
+  return x.normalize ();
 }
 
 /* Overload equality operators for longdouble types.  */
 
-bool
-longdouble::operator < (const longdouble& r)
+int
+longdouble::cmp (const longdouble& r) const
 {
-  return real_compare (LT_EXPR, &this->rv (), &r.rv ());
+  if (real_compare (LT_EXPR, &this->rv (), &r.rv ()))
+    return -1;
+
+  if (real_compare (GT_EXPR, &this->rv (), &r.rv ()))
+    return 1;
+
+  return 0;
 }
 
-bool
-longdouble::operator > (const longdouble& r)
-{
-  return real_compare (GT_EXPR, &this->rv (), &r.rv ());
-}
-
-bool
-longdouble::operator <= (const longdouble& r)
-{
-  return real_compare (LE_EXPR, &this->rv (), &r.rv ());
-}
-
-bool
-longdouble::operator >= (const longdouble& r)
-{
-  return real_compare (GE_EXPR, &this->rv (), &r.rv ());
-}
-
-bool
-longdouble::operator == (const longdouble& r)
+int
+longdouble::equals (const longdouble& r) const
 {
   return real_compare (EQ_EXPR, &this->rv (), &r.rv ());
-}
-
-bool
-longdouble::operator != (const longdouble& r)
-{
-  return real_compare (NE_EXPR, &this->rv (), &r.rv ());
 }

--- a/gcc/d/d-target.cc
+++ b/gcc/d/d-target.cc
@@ -171,10 +171,11 @@ Target::_init (void)
   define_float_constants <Target::RealProperties> (long_double_type_node);
 
   /* Commonly used floating point constants.  */
-  CTFloat::zero = dconst0;
-  CTFloat::one = dconst1;
-  CTFloat::minusone = dconstm1;
-  CTFloat::half = dconsthalf;
+  const machine_mode mode = TYPE_MODE (long_double_type_node);
+  real_convert (&CTFloat::zero.rv (), mode, &dconst0);
+  real_convert (&CTFloat::one.rv (), mode, &dconst1);
+  real_convert (&CTFloat::minusone.rv (), mode, &dconstm1);
+  real_convert (&CTFloat::half.rv (), mode, &dconsthalf);
 }
 
 /* Return GCC memory alignment size for type TYPE.  */

--- a/gcc/d/longdouble.h
+++ b/gcc/d/longdouble.h
@@ -31,58 +31,90 @@ public:
   real_value& rv (void)
   { return *(real_value *) this; }
 
+  /* Normalize the value to be the precision supported by target.  */
+  longdouble normalize();
+
   /* No constructor to be able to use this class in a union.  */
   template<typename T> longdouble& operator = (T x)
   { set (x); return *this; }
 
-  /* Lvalue operators.
-     We need to list all basic types to avoid ambiguities.  */
-  void set (real_value& rv);
-  void set (int8_t d);
-  void set (int16_t d);
+  /* Lvalue operators.  */
+  void set (real_value& d);
   void set (int32_t d);
   void set (int64_t d);
-  void set (uint8_t d);
-  void set (uint16_t d);
   void set (uint32_t d);
   void set (uint64_t d);
   void set (bool d);
 
   /* Rvalue operators.  */
-  operator real_value&();
-  operator int8_t (void);
-  operator int16_t (void);
-  operator int32_t (void);
-  operator int64_t (void);
-  operator uint8_t (void);
-  operator uint16_t (void);
-  operator uint32_t (void);
-  operator uint64_t (void);
-  operator bool (void);
+  bool to_bool () const;
+  int64_t to_int () const;
+  uint64_t to_uint () const;
+
+  operator int32_t (void)
+  { return (int32_t) this->to_int (); }
+
+  operator int64_t (void)
+  { return this->to_int (); }
+
+  operator uint32_t (void)
+  { return (uint32_t) this->to_uint (); }
+
+  operator uint64_t (void)
+  { return this->to_uint (); }
+
+  operator bool (void)
+  { return this->to_bool (); }
 
   /* Arithmetic operators.  */
-  longdouble operator + (const longdouble& r);
-  longdouble operator - (const longdouble& r);
-  longdouble operator * (const longdouble& r);
-  longdouble operator / (const longdouble& r);
-  longdouble operator % (const longdouble& r);
+  longdouble add(const longdouble& r) const;
+  longdouble sub(const longdouble& r) const;
+  longdouble mul(const longdouble& r) const;
+  longdouble div(const longdouble& r) const;
+  longdouble mod(const longdouble& r) const;
+  longdouble neg() const;
 
-  longdouble operator -();
+  longdouble operator + (const longdouble& r)
+  { return this->add (r); }
+
+  longdouble operator - (const longdouble& r)
+  { return this->sub (r); }
+
+  longdouble operator * (const longdouble& r)
+  { return this->mul (r); }
+
+  longdouble operator / (const longdouble& r)
+  { return this->div (r); }
+
+  longdouble operator % (const longdouble& r)
+  { return this->mod (r); }
+
+  longdouble operator -()
+  { return this->neg (); }
 
   /* Comparison operators.  */
-  bool operator < (const longdouble& r);
-  bool operator <= (const longdouble& r);
-  bool operator > (const longdouble& r);
-  bool operator >= (const longdouble& r);
-  bool operator == (const longdouble& r);
-  bool operator != (const longdouble& r);
+  int cmp(const longdouble& t) const;
+  int equals(const longdouble& t) const;
+
+  bool operator < (const longdouble& r)
+  { return this->cmp (r) < 0; }
+
+  bool operator <= (const longdouble& r)
+  { return this->cmp (r) <= 0; }
+
+  bool operator > (const longdouble& r)
+  { return this->cmp (r) > 0; }
+
+  bool operator >= (const longdouble& r)
+  { return this->cmp (r) >= 0; }
+
+  bool operator == (const longdouble& r)
+  { return this->equals (r); }
+
+  bool operator != (const longdouble& r)
+  { return !this->equals (r); }
 
 private:
-  longdouble from_int (Type *type, int64_t d);
-  longdouble from_uint (Type *type, uint64_t d);
-  int64_t to_int (Type *type) const;
-  uint64_t to_uint (Type *type) const;
-
   /* Including gcc/real.h presents too many problems, so just
      statically allocate enough space for REAL_VALUE_TYPE.  */
   long realvalue[(2 + (16 + sizeof (long)) / sizeof (long))];


### PR DESCRIPTION
New functions that provide backend implementation for real_t operations taken from #550, unneeded overloads were removed and C++ operator overloads moved to headers, so the common interface is the same for both C++ and D branches.