### PR TITLE
Logic error when backpatching fix for issue 15149

### DIFF
--- a/gcc/d/dfrontend/dstruct.c
+++ b/gcc/d/dfrontend/dstruct.c
@@ -168,7 +168,7 @@ void semanticTypeInfo(Scope *sc, Type *t)
     {
         if (!sc->func)
             return;
-        if (!sc->intypeof)
+        if (sc->intypeof)
             return;
         if (sc->flags & (SCOPEctfe | SCOPEcompile))
             return;


### PR DESCRIPTION
Looks like this meant that semanticTypeInfo was never really used, delaying a lot of the semantic analysis to the codegen stage for us.

We force run semantic3 before generating code, so logic bug was hidden.  However upstream dmd asserts that all symbols have completed semantic3.