### PR TITLE
Undocument and deprecate -fdeps switches.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2018-03-04  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* lang.opt (fdeps, fdeps=): Deprecate options.
+	* gdc.texi (Code Generation): Remove deprecated fdeps options.
+
 2018-02-25  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* Make-lang.in (D_FRONTEND_OBJS): Remove inline.o and inlinecost.o.

--- a/gcc/d/gdc.texi
+++ b/gcc/d/gdc.texi
@@ -485,17 +485,6 @@ and applies a @file{.json} suffix.
 Same as @option{-X}, but writes all JSON contents to the specified
 @var{file}.
 
-@item -fdeps
-@cindex @option{-fdeps}
-Dump module dependencies of all source files being compiled in a machine
-readable format.  Suitable for any build tool that needs to track source
-file dependencies for incremental builds.
-
-@item -fdeps=@var{file}
-@cindex @option{-fdeps=}
-Same as @option{-fdeps}, but writes dependencies to the specified
-@var{file}.
-
 @item -fdoc
 @cindex @option{-fdoc}
 Generates @code{Ddoc} documentation and writes to a file.  The compiler

--- a/gcc/d/lang.opt
+++ b/gcc/d/lang.opt
@@ -175,11 +175,11 @@ D Joined RejectNegative
 
 fdeps
 D
-Print information about module dependencies.
+This switch is deprecated; do not use.
 
 fdeps=
 D Joined RejectNegative
--fdeps=<file>	Write module dependencies to <file>.
+This switch is deprecated; do not use.
 
 fdoc
 D


### PR DESCRIPTION
From my POV, this is a buggy, memory bloating feature riddled in technical debt and who's only purpose was to support a now long dead build system for D1.

e.g: https://github.com/dlang/dmd/pull/6748

We have `-M` for make-style dependencies, and it is more lightweight.