### PR TITLE
Deprecate -fintfc in favour of -H

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,5 +1,13 @@
 2018-03-04  Iain Buclaw  <ibuclaw@gdcproject.org>
 
+	* d-lang.cc (d_handle_option): Rename OPT_fintfc cases to OPT_H.
+	* gdc.texi (Code Generation): Rename -fintfc options to -H.
+	* lang-specs.h: Add H, Hd, and Hf options.
+	* lang.opt (H, Hd, Hf): New options.
+	(fintfc, fintfc-dir=, fintfc-file=): Deprecate and alias new options.
+
+2018-03-04  Iain Buclaw  <ibuclaw@gdcproject.org>
+
 	* lang.opt (fdeps, fdeps=): Deprecate options.
 	* gdc.texi (Code Generation): Remove deprecated fdeps options.
 

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -480,20 +480,6 @@ d_handle_option (size_t scode, const char *arg, int value,
       global.params.ignoreUnsupportedPragmas = value;
       break;
 
-    case OPT_fintfc:
-      global.params.doHdrGeneration = value;
-      break;
-
-    case OPT_fintfc_dir_:
-      global.params.doHdrGeneration = true;
-      global.params.hdrdir = arg;
-      break;
-
-    case OPT_fintfc_file_:
-      global.params.doHdrGeneration = true;
-      global.params.hdrname = arg;
-      break;
-
     case OPT_finvariants:
       global.params.useInvariants = value;
       break;
@@ -593,6 +579,20 @@ d_handle_option (size_t scode, const char *arg, int value,
 	}
 
       error ("bad argument for -fversion '%s'", arg);
+      break;
+
+    case OPT_H:
+      global.params.doHdrGeneration = true;
+      break;
+
+    case OPT_Hd:
+      global.params.doHdrGeneration = true;
+      global.params.hdrdir = arg;
+      break;
+
+    case OPT_Hf:
+      global.params.doHdrGeneration = true;
+      global.params.hdrname = arg;
       break;
 
     case OPT_imultilib:

--- a/gcc/d/gdc.texi
+++ b/gcc/d/gdc.texi
@@ -166,7 +166,7 @@ when using @code{-S} or @code{-c}.
 @cindex D interface files.
 A D interface file contains only what an import of the module needs,
 rather than the whole implementation of that module.  They can be created
-by @command{gdc} from a D source file by using the @code{-fintfc} option.
+by @command{gdc} from a D source file by using the @code{-H} option.
 When the compiler resolves an import declaration, it searches for matching
 @file{.di} files first, then for @file{.d}.
 
@@ -422,6 +422,25 @@ In addition to the many @command{gcc} options controlling code generation,
 
 @table @gcctabopt
 
+@item -H
+@cindex @option{-H}
+Generates D interface files for all modules being compiled.  The compiler
+determines the output @var{file} based on the name of the input file,
+removes any directory components and suffix, and applies the @file{.di}
+suffix.
+
+@item -Hd @var{dir}
+@cindex @option{-Hd}
+Same as @option{-H}, but writes interface files to @var{dir} directory.
+This option can be used with @option{-Hf @var{file}} to independently set the
+output file and directory path.
+
+@item -Hf @var{file}
+@cindex @option{-Hf}
+Same as @option{-H} but writes interface files to @var{file}.  This option can
+be used with @option{-Hd @var{dir}} to independently set the output file and
+directory path.
+
 @item -M
 @cindex @option{-M}
 Output the module dependencies of all source files being compiled in a
@@ -509,25 +528,6 @@ Specify @var{file} as a @var{Ddoc} macro file to be read.  Multiple
 @option{-fdoc-inc} options can be used, and files are read and processed
 in the same order.
 
-@item -fintfc
-@cindex @option{-fintfc}
-Generates D interface files for all modules being compiled.  The compiler
-determines the output @var{file} based on the name of the input file,
-removes any directory components and suffix, and applies the @file{.di}
-suffix.
-
-@item -fintfc-dir=@var{dir}
-@cindex @option{-fintfc-dir}
-Same as @option{-fintfc}, but writes interface files to @var{dir}
-directory.  This option can be used with @option{-fintfc-file=@var{file}}
-to independently set the output file and directory path.
-
-@item -fintfc-file=@var{filename}
-@cindex @option{-fintfc-file}
-Same as @option{-fintfc} but writes interface files to @var{file}.  This
-option can be used with @option{-fintfc-dir=@var{dir}} to independently
-set the output file and directory path.
-
 @end table
 
 @node Warnings
@@ -608,7 +608,7 @@ number of error messages produced.
 @cindex @option{-fno-syntax-only}
 Check the code for syntax errors, but do not actually compile it.  This
 only suppresses the generation of the object code, and can be used in
-conjunction with @option{-fdoc} or @option{-fintfc} options.
+conjunction with @option{-fdoc} or @option{-H} options.
 
 @item -ftransition=@var{id}
 @cindex @option{-ftransition}

--- a/gcc/d/lang-specs.h
+++ b/gcc/d/lang-specs.h
@@ -23,7 +23,7 @@ along with GCC; see the file COPYING3.  If not see
 {".di", "@d", 0, 1, 0 },
 {"@d",
   "%{!E:cc1d %i %(cc1_options) %I %{nostdinc*} %{i*} %{I*} %{J*} \
-    %{MD:-MD %b.deps} %{MMD:-MMD %b.deps} \
+    %{H} %{Hd*} %{Hf*} %{MD:-MD %b.deps} %{MMD:-MMD %b.deps} \
     %{M} %{MM} %{MF*} %{MG} %{MP} %{MQ*} %{MT*} \
     %{X:-Xf %b.json} %{Xf*} \
     %{v} %{!fsyntax-only:%(invoke_as)}}", 0, 1, 0 },

--- a/gcc/d/lang.opt
+++ b/gcc/d/lang.opt
@@ -42,6 +42,18 @@ D NoDriverArg Separate Alias(MD)
 D NoDriverArg Separate Alias(MMD)
 ; Documented in C
 
+H
+D
+; Different from documented use in C.
+
+Hd
+D Joined Separate
+-Hd <dir>	Write D interface files to directory <dir>.
+
+Hf
+D Joined Separate
+-Hf <file>	Write D interface to <file>.
+
 I
 D Joined Separate
 ; Documented in C
@@ -206,15 +218,16 @@ D
 Ignore unsupported pragmas.
 
 fintfc
-Generate D interface files.
+D Alias(H)
+; Deprecated in favour of -H
 
 fintfc-dir=
-D Joined RejectNegative
--fintfc-dir=<dir>	Write D interface files to directory <dir>.
+D Joined RejectNegative Alias(Hd)
+; Deprecated in favour of -Hd
 
 fintfc-file=
-D Joined RejectNegative
--fintfc-file=<file>	Write D interface to <file>.
+D Joined RejectNegative Alias(Hf)
+; Deprecated in favour of -Hf
 
 finvariants
 D Var(flag_invariants)


### PR DESCRIPTION
The only remaining option in the list at:

https://bugzilla.gdcproject.org/show_bug.cgi?id=119

Is `-fdoc`, to which can't use `-D` as the use in gcc differs from our use.