### PR TITLE
Rebase GCC patches on top of trunk

### DIFF
--- a/gcc/d/patches/patch-gcc-8.patch
+++ b/gcc/d/patches/patch-gcc-8.patch
@@ -4,7 +4,7 @@ relevant documentation about the GDC front end.
 
 --- a/gcc/config/powerpcspe/powerpcspe.c
 +++ b/gcc/config/powerpcspe/powerpcspe.c
-@@ -32030,11 +32030,12 @@ rs6000_output_function_epilogue (FILE *file)
+@@ -32033,11 +32033,12 @@ rs6000_output_function_epilogue (FILE *f
  	 use language_string.
  	 C is 0.  Fortran is 1.  Pascal is 2.  Ada is 3.  C++ is 9.
  	 Java is 13.  Objective-C is 14.  Objective-C++ isn't assigned
@@ -21,7 +21,7 @@ relevant documentation about the GDC front end.
        else if (! strcmp (language_string, "GNU F77")
 --- a/gcc/config/rs6000/rs6000.c
 +++ b/gcc/config/rs6000/rs6000.c
-@@ -29189,11 +29189,12 @@ rs6000_output_function_epilogue (FILE *file)
+@@ -29267,11 +29267,12 @@ rs6000_output_function_epilogue (FILE *f
  	 use language_string.
  	 C is 0.  Fortran is 1.  Pascal is 2.  Ada is 3.  C++ is 9.
  	 Java is 13.  Objective-C is 14.  Objective-C++ isn't assigned
@@ -57,7 +57,7 @@ relevant documentation about the GDC front end.
  current official meaning is ``GNU Compiler Collection'', which refers
 --- a/gcc/doc/install.texi
 +++ b/gcc/doc/install.texi
-@@ -916,7 +916,7 @@ only for the listed packages.  For other packages, only static libraries
+@@ -921,7 +921,7 @@ only for the listed packages.  For other
  will be built.  Package names currently recognized in the GCC tree are
  @samp{libgcc} (also known as @samp{gcc}), @samp{libstdc++} (not
  @samp{libstdc++-v3}), @samp{libffi}, @samp{zlib}, @samp{boehm-gc},
@@ -66,7 +66,7 @@ relevant documentation about the GDC front end.
  Note @samp{libiberty} does not support shared libraries at all.
  
  Use @option{--disable-shared} to build only static libraries.  Note that
-@@ -1601,12 +1601,12 @@ their runtime libraries should be built.  For a list of valid values for
+@@ -1606,12 +1606,12 @@ their runtime libraries should be built.
  grep ^language= */config-lang.in
  @end smallexample
  Currently, you can use any of the following:
@@ -82,7 +82,7 @@ relevant documentation about the GDC front end.
  default language, but is built by default because @option{--enable-lto} is
  enabled by default.  The other languages are default languages.  If
  @code{all} is specified, then all available languages are built.  An
-@@ -2699,7 +2699,7 @@ on a simulator as described at @uref{http://gcc.gnu.org/simtest-howto.html}.
+@@ -2746,7 +2746,7 @@ on a simulator as described at @uref{htt
  
  In order to run sets of tests selectively, there are targets
  @samp{make check-gcc} and language specific @samp{make check-c},
@@ -93,7 +93,7 @@ relevant documentation about the GDC front end.
  in the @file{gcc} subdirectory of the object directory.  You can also
 --- a/gcc/doc/invoke.texi
 +++ b/gcc/doc/invoke.texi
-@@ -1354,6 +1354,15 @@ Go source code.
+@@ -1406,6 +1406,15 @@ Go source code.
  @item @var{file}.brig
  BRIG files (binary representation of HSAIL).
  
@@ -109,7 +109,7 @@ relevant documentation about the GDC front end.
  @item @var{file}.ads
  Ada source code file that contains a library unit declaration (a
  declaration of a package, subprogram, or generic, or a generic
-@@ -1400,6 +1409,7 @@ objective-c  objective-c-header  objective-c-cpp-output
+@@ -1452,6 +1461,7 @@ objective-c  objective-c-header  objecti
  objective-c++ objective-c++-header objective-c++-cpp-output
  assembler  assembler-with-cpp
  ada
@@ -119,7 +119,7 @@ relevant documentation about the GDC front end.
  brig
 --- a/gcc/doc/sourcebuild.texi
 +++ b/gcc/doc/sourcebuild.texi
-@@ -106,6 +106,10 @@ The Objective-C and Objective-C++ runtime library.
+@@ -106,6 +106,10 @@ The Objective-C and Objective-C++ runtim
  @item libquadmath
  The runtime support library for quad-precision math operations.
  
@@ -132,7 +132,7 @@ relevant documentation about the GDC front end.
  
 --- a/gcc/doc/standards.texi
 +++ b/gcc/doc/standards.texi
-@@ -313,6 +313,12 @@ capability is typically utilized to implement the HSA runtime API's HSAIL
+@@ -313,6 +313,12 @@ capability is typically utilized to impl
  finalization extension for a gcc supported processor. HSA standards are
  freely available at @uref{http://www.hsafoundation.com/standards/}.
  
@@ -147,7 +147,7 @@ relevant documentation about the GDC front end.
  @xref{Top, GNAT Reference Manual, About This Guide, gnat_rm,
 --- a/gcc/dwarf2out.c
 +++ b/gcc/dwarf2out.c
-@@ -5176,6 +5176,16 @@ is_ada (void)
+@@ -5431,6 +5431,16 @@ is_ada (void)
    return lang == DW_LANG_Ada95 || lang == DW_LANG_Ada83;
  }
  
@@ -164,7 +164,7 @@ relevant documentation about the GDC front end.
  /* Remove the specified attribute if present.  Return TRUE if removal
     was successful.  */
  
-@@ -23551,6 +23561,8 @@ gen_compile_unit_die (const char *filename)
+@@ -24300,6 +24310,8 @@ gen_compile_unit_die (const char *filena
  	language = DW_LANG_ObjC;
        else if (strcmp (language_string, "GNU Objective-C++") == 0)
  	language = DW_LANG_ObjC_plus_plus;
@@ -173,7 +173,7 @@ relevant documentation about the GDC front end.
        else if (dwarf_version >= 5 || !dwarf_strict)
  	{
  	  if (strcmp (language_string, "GNU Go") == 0)
-@@ -25154,7 +25166,7 @@ declare_in_namespace (tree thing, dw_die_ref context_die)
+@@ -25903,7 +25915,7 @@ declare_in_namespace (tree thing, dw_die
  
    if (ns_context != context_die)
      {
@@ -182,7 +182,7 @@ relevant documentation about the GDC front end.
  	return ns_context;
        if (DECL_P (thing))
  	gen_decl_die (thing, NULL, NULL, ns_context);
-@@ -25177,7 +25189,7 @@ gen_namespace_die (tree decl, dw_die_ref context_die)
+@@ -25926,7 +25938,7 @@ gen_namespace_die (tree decl, dw_die_ref
      {
        /* Output a real namespace or module.  */
        context_die = setup_namespace_context (decl, comp_unit_die ());
@@ -191,7 +191,7 @@ relevant documentation about the GDC front end.
  			       ? DW_TAG_module : DW_TAG_namespace,
  			       context_die, decl);
        /* For Fortran modules defined in different CU don't add src coords.  */
-@@ -25249,7 +25261,7 @@ gen_decl_die (tree decl, tree origin, struct vlr_context *ctx,
+@@ -25998,7 +26010,7 @@ gen_decl_die (tree decl, tree origin, st
        break;
  
      case CONST_DECL:
@@ -200,7 +200,7 @@ relevant documentation about the GDC front end.
  	{
  	  /* The individual enumerators of an enum type get output when we output
  	     the Dwarf representation of the relevant enum type itself.  */
-@@ -25823,7 +25835,7 @@ dwarf2out_decl (tree decl)
+@@ -26595,7 +26607,7 @@ dwarf2out_decl (tree decl)
      case CONST_DECL:
        if (debug_info_level <= DINFO_LEVEL_TERSE)
  	return;
@@ -211,7 +211,7 @@ relevant documentation about the GDC front end.
  	context_die = lookup_decl_die (DECL_CONTEXT (decl));
 --- a/gcc/gcc.c
 +++ b/gcc/gcc.c
-@@ -1308,6 +1308,7 @@ static const struct compiler default_compilers[] =
+@@ -1301,6 +1301,7 @@ static const struct compiler default_com
    {".f08", "#Fortran", 0, 0, 0}, {".F08", "#Fortran", 0, 0, 0},
    {".r", "#Ratfor", 0, 0, 0},
    {".go", "#Go", 0, 1, 0},

--- a/gcc/d/patches/patch-targetdm-8.patch
+++ b/gcc/d/patches/patch-targetdm-8.patch
@@ -53,7 +53,7 @@ The following OS versions are implemented:
  
 --- a/gcc/Makefile.in
 +++ b/gcc/Makefile.in
-@@ -546,6 +546,8 @@ tm_include_list=@tm_include_list@
+@@ -552,6 +552,8 @@ tm_include_list=@tm_include_list@
  tm_defines=@tm_defines@
  tm_p_file_list=@tm_p_file_list@
  tm_p_include_list=@tm_p_include_list@
@@ -62,7 +62,7 @@ The following OS versions are implemented:
  build_xm_file_list=@build_xm_file_list@
  build_xm_include_list=@build_xm_include_list@
  build_xm_defines=@build_xm_defines@
-@@ -840,6 +842,7 @@ BCONFIG_H = bconfig.h $(build_xm_file_list)
+@@ -846,6 +848,7 @@ BCONFIG_H = bconfig.h $(build_xm_file_li
  CONFIG_H  = config.h  $(host_xm_file_list)
  TCONFIG_H = tconfig.h $(xm_file_list)
  TM_P_H    = tm_p.h    $(tm_p_file_list)
@@ -70,7 +70,7 @@ The following OS versions are implemented:
  GTM_H     = tm.h      $(tm_file_list) insn-constants.h
  TM_H      = $(GTM_H) insn-flags.h $(OPTIONS_H)
  
-@@ -897,9 +900,11 @@ EXCEPT_H = except.h $(HASHTAB_H)
+@@ -903,9 +906,11 @@ EXCEPT_H = except.h $(HASHTAB_H)
  TARGET_DEF = target.def target-hooks-macros.h target-insns.def
  C_TARGET_DEF = c-family/c-target.def target-hooks-macros.h
  COMMON_TARGET_DEF = common/common-target.def target-hooks-macros.h
@@ -82,7 +82,7 @@ The following OS versions are implemented:
  MACHMODE_H = machmode.h mode-classes.def
  HOOKS_H = hooks.h
  HOSTHOOKS_DEF_H = hosthooks-def.h $(HOOKS_H)
-@@ -1175,6 +1180,9 @@ C_TARGET_OBJS=@c_target_objs@
+@@ -1181,6 +1186,9 @@ C_TARGET_OBJS=@c_target_objs@
  # Target specific, C++ specific object file
  CXX_TARGET_OBJS=@cxx_target_objs@
  
@@ -92,7 +92,7 @@ The following OS versions are implemented:
  # Target specific, Fortran specific object file
  FORTRAN_TARGET_OBJS=@fortran_target_objs@
  
-@@ -1763,6 +1771,7 @@ bconfig.h: cs-bconfig.h ; @true
+@@ -1779,6 +1787,7 @@ bconfig.h: cs-bconfig.h ; @true
  tconfig.h: cs-tconfig.h ; @true
  tm.h: cs-tm.h ; @true
  tm_p.h: cs-tm_p.h ; @true
@@ -100,7 +100,7 @@ The following OS versions are implemented:
  
  cs-config.h: Makefile
  	TARGET_CPU_DEFAULT="" \
-@@ -1789,6 +1798,11 @@ cs-tm_p.h: Makefile
+@@ -1805,6 +1814,11 @@ cs-tm_p.h: Makefile
  	HEADERS="$(tm_p_include_list)" DEFINES="" \
  	$(SHELL) $(srcdir)/mkconfig.sh tm_p.h
  
@@ -112,7 +112,7 @@ The following OS versions are implemented:
  # Don't automatically run autoconf, since configure.ac might be accidentally
  # newer than configure.  Also, this writes into the source directory which
  # might be on a read-only file system.  If configured for maintainer mode
-@@ -2152,6 +2166,12 @@ default-c.o: config/default-c.c
+@@ -2171,6 +2185,12 @@ default-c.o: config/default-c.c
  CFLAGS-prefix.o += -DPREFIX=\"$(prefix)\" -DBASEVER=$(BASEVER_s)
  prefix.o: $(BASEVER)
  
@@ -125,7 +125,7 @@ The following OS versions are implemented:
  # Language-independent files.
  
  DRIVER_DEFINES = \
-@@ -2447,6 +2467,15 @@ s-common-target-hooks-def-h: build/genhooks$(build_exeext)
+@@ -2466,6 +2486,15 @@ s-common-target-hooks-def-h: build/genho
  					     common/common-target-hooks-def.h
  	$(STAMP) s-common-target-hooks-def-h
  
@@ -141,7 +141,7 @@ The following OS versions are implemented:
  # check if someone mistakenly only changed tm.texi.
  # We use a different pathname here to avoid a circular dependency.
  s-tm-texi: $(srcdir)/doc/../doc/tm.texi
-@@ -2470,6 +2499,7 @@ s-tm-texi: build/genhooks$(build_exeext) $(srcdir)/doc/tm.texi.in
+@@ -2489,6 +2518,7 @@ s-tm-texi: build/genhooks$(build_exeext)
  	  && ( test $(srcdir)/doc/tm.texi -nt $(srcdir)/target.def \
  	    || test $(srcdir)/doc/tm.texi -nt $(srcdir)/c-family/c-target.def \
  	    || test $(srcdir)/doc/tm.texi -nt $(srcdir)/common/common-target.def \
@@ -149,7 +149,7 @@ The following OS versions are implemented:
  	  ); then \
  	  echo >&2 ; \
  	  echo You should edit $(srcdir)/doc/tm.texi.in rather than $(srcdir)/doc/tm.texi . >&2 ; \
-@@ -2608,14 +2638,15 @@ s-gtype: build/gengtype$(build_exeext) $(filter-out [%], $(GTFILES)) \
+@@ -2627,14 +2657,15 @@ s-gtype: build/gengtype$(build_exeext) $
                      -r gtype.state
  	$(STAMP) s-gtype
  
@@ -167,7 +167,7 @@ The following OS versions are implemented:
         cfn-operators.pd
  
  #
-@@ -2758,7 +2789,7 @@ build/genrecog.o : genrecog.c $(RTL_BASE_H) $(BCONFIG_H) $(SYSTEM_H)	\
+@@ -2777,7 +2808,7 @@ build/genrecog.o : genrecog.c $(RTL_BASE
    $(CORETYPES_H) $(GTM_H) errors.h $(READ_MD_H) $(GENSUPPORT_H)		\
    $(HASH_TABLE_H) inchash.h
  build/genhooks.o : genhooks.c $(TARGET_DEF) $(C_TARGET_DEF)		\
@@ -251,7 +251,7 @@ The following OS versions are implemented:
  	extra_objs="x86-tune-sched.o x86-tune-sched-bd.o x86-tune-sched-atom.o x86-tune-sched-core.o"
  	extra_options="${extra_options} fused-madd.opt"
  	extra_headers="cpuid.h mmintrin.h mm3dnow.h xmmintrin.h emmintrin.h
-@@ -385,6 +400,7 @@ x86_64-*-*)
+@@ -388,6 +403,7 @@ x86_64-*-*)
  	cpu_type=i386
  	c_target_objs="i386-c.o"
  	cxx_target_objs="i386-c.o"
@@ -259,7 +259,7 @@ The following OS versions are implemented:
  	extra_options="${extra_options} fused-madd.opt"
  	extra_objs="x86-tune-sched.o x86-tune-sched-bd.o x86-tune-sched-atom.o x86-tune-sched-core.o"
  	extra_headers="cpuid.h mmintrin.h mm3dnow.h xmmintrin.h emmintrin.h
-@@ -430,6 +446,7 @@ microblaze*-*-*)
+@@ -436,6 +452,7 @@ microblaze*-*-*)
          ;;
  mips*-*-*)
  	cpu_type=mips
@@ -267,7 +267,7 @@ The following OS versions are implemented:
  	extra_headers="loongson.h msa.h"
  	extra_objs="frame-header-opt.o"
  	extra_options="${extra_options} g.opt fused-madd.opt mips/mips-tables.opt"
-@@ -485,6 +502,7 @@ sparc*-*-*)
+@@ -491,6 +508,7 @@ sparc*-*-*)
  	cpu_type=sparc
  	c_target_objs="sparc-c.o"
  	cxx_target_objs="sparc-c.o"
@@ -275,7 +275,7 @@ The following OS versions are implemented:
  	extra_headers="visintrin.h"
  	;;
  spu*-*-*)
-@@ -492,6 +510,7 @@ spu*-*-*)
+@@ -498,6 +516,7 @@ spu*-*-*)
  	;;
  s390*-*-*)
  	cpu_type=s390
@@ -283,7 +283,7 @@ The following OS versions are implemented:
  	extra_options="${extra_options} fused-madd.opt"
  	extra_headers="s390intrin.h htmintrin.h htmxlintrin.h vecintrin.h"
  	;;
-@@ -521,10 +540,13 @@ tilepro*-*-*)
+@@ -527,10 +546,13 @@ tilepro*-*-*)
  esac
  
  tm_file=${cpu_type}/${cpu_type}.h
@@ -297,7 +297,7 @@ The following OS versions are implemented:
  extra_modes=
  if test -f ${srcdir}/config/${cpu_type}/${cpu_type}-modes.def
  then
-@@ -793,8 +815,10 @@ case ${target} in
+@@ -799,8 +821,10 @@ case ${target} in
    esac
    c_target_objs="${c_target_objs} glibc-c.o"
    cxx_target_objs="${cxx_target_objs} glibc-c.o"
@@ -308,7 +308,7 @@ The following OS versions are implemented:
    ;;
  *-*-netbsd*)
    tm_p_file="${tm_p_file} netbsd-protos.h"
-@@ -3140,6 +3164,10 @@ if [ "$common_out_file" = "" ]; then
+@@ -3160,6 +3184,10 @@ if [ "$common_out_file" = "" ]; then
    fi
  fi
  
@@ -319,7 +319,7 @@ The following OS versions are implemented:
  # Support for --with-cpu and related options (and a few unrelated options,
  # too).
  case ${with_cpu} in
-@@ -4626,6 +4654,7 @@ case ${target} in
+@@ -4664,6 +4692,7 @@ case ${target} in
  		out_file="${cpu_type}/${cpu_type}.c"
  		c_target_objs="${c_target_objs} ${cpu_type}-c.o"
  		cxx_target_objs="${cxx_target_objs} ${cpu_type}-c.o"
@@ -327,7 +327,7 @@ The following OS versions are implemented:
  		tmake_file="${cpu_type}/t-${cpu_type} ${tmake_file}"
  		;;
  
---- a/gcc/config/aarch64/aarch64-d.c
+--- /dev/null
 +++ b/gcc/config/aarch64/aarch64-d.c
 @@ -0,0 +1,31 @@
 +/* Subroutines for the D front end on the AArch64 architecture.
@@ -374,7 +374,7 @@ The following OS versions are implemented:
  /* Uninitialized common symbols in non-PIE executables, even with
 --- a/gcc/config/aarch64/aarch64-protos.h
 +++ b/gcc/config/aarch64/aarch64-protos.h
-@@ -494,6 +494,9 @@ enum aarch64_parse_opt_result aarch64_parse_extension (const char *,
+@@ -547,6 +547,9 @@ enum aarch64_parse_opt_result aarch64_pa
  std::string aarch64_get_extension_string_for_isa_flags (unsigned long,
  							unsigned long);
  
@@ -383,7 +383,7 @@ The following OS versions are implemented:
 +
  rtl_opt_pass *make_pass_fma_steering (gcc::context *ctxt);
  
- #endif /* GCC_AARCH64_PROTOS_H */
+ poly_uint64 aarch64_regmode_natural_size (machine_mode);
 --- a/gcc/config/aarch64/aarch64.h
 +++ b/gcc/config/aarch64/aarch64.h
 @@ -26,6 +26,9 @@
@@ -398,7 +398,7 @@ The following OS versions are implemented:
  #define REGISTER_TARGET_PRAGMAS() aarch64_register_pragmas ()
 --- a/gcc/config/aarch64/t-aarch64
 +++ b/gcc/config/aarch64/t-aarch64
-@@ -56,6 +56,10 @@ aarch64-c.o: $(srcdir)/config/aarch64/aarch64-c.c $(CONFIG_H) $(SYSTEM_H) \
+@@ -56,6 +56,10 @@ aarch64-c.o: $(srcdir)/config/aarch64/aa
  	$(COMPILER) -c $(ALL_COMPILERFLAGS) $(ALL_CPPFLAGS) $(INCLUDES) \
  		$(srcdir)/config/aarch64/aarch64-c.c
  
@@ -409,7 +409,7 @@ The following OS versions are implemented:
  PASSES_EXTRA += $(srcdir)/config/aarch64/aarch64-passes.def
  
  cortex-a57-fma-steering.o: $(srcdir)/config/aarch64/cortex-a57-fma-steering.c \
---- a/gcc/config/alpha/alpha-d.c
+--- /dev/null
 +++ b/gcc/config/alpha/alpha-d.c
 @@ -0,0 +1,41 @@
 +/* Subroutines for the D front end on the Alpha architecture.
@@ -464,7 +464,7 @@ The following OS versions are implemented:
 +extern void alpha_d_target_versions (void);
 --- a/gcc/config/alpha/alpha.h
 +++ b/gcc/config/alpha/alpha.h
-@@ -94,6 +94,9 @@ along with GCC; see the file COPYING3.  If not see
+@@ -94,6 +94,9 @@ along with GCC; see the file COPYING3.
    while (0)
  #endif
  
@@ -476,7 +476,7 @@ The following OS versions are implemented:
  /* Which processor to schedule for. The cpu attribute defines a list that
 --- a/gcc/config/alpha/linux.h
 +++ b/gcc/config/alpha/linux.h
-@@ -33,6 +33,19 @@ along with GCC; see the file COPYING3.  If not see
+@@ -33,6 +33,19 @@ along with GCC; see the file COPYING3.
  	  builtin_define ("_GNU_SOURCE");			\
      } while (0)
  
@@ -507,7 +507,7 @@ The following OS versions are implemented:
 +	$(POSTCOMPILE)
 +
  PASSES_EXTRA += $(srcdir)/config/alpha/alpha-passes.def
---- a/gcc/config/arm/arm-d.c
+--- /dev/null
 +++ b/gcc/config/arm/arm-d.c
 @@ -0,0 +1,53 @@
 +/* Subroutines for the D front end on the ARM architecture.
@@ -565,7 +565,7 @@ The following OS versions are implemented:
 +}
 --- a/gcc/config/arm/arm-protos.h
 +++ b/gcc/config/arm/arm-protos.h
-@@ -352,6 +352,9 @@ extern void arm_lang_object_attributes_init (void);
+@@ -373,6 +373,9 @@ extern void arm_lang_object_attributes_i
  extern void arm_register_target_pragmas (void);
  extern void arm_cpu_cpp_builtins (struct cpp_reader *);
  
@@ -601,7 +601,7 @@ The following OS versions are implemented:
     change the setting of GLIBC_DYNAMIC_LINKER_DEFAULT as well.  */
 --- a/gcc/config/arm/t-arm
 +++ b/gcc/config/arm/t-arm
-@@ -144,4 +144,8 @@ arm-c.o: $(srcdir)/config/arm/arm-c.c $(CONFIG_H) $(SYSTEM_H) \
+@@ -144,4 +144,8 @@ arm-c.o: $(srcdir)/config/arm/arm-c.c $(
  	$(COMPILER) -c $(ALL_COMPILERFLAGS) $(ALL_CPPFLAGS) $(INCLUDES) \
  		$(srcdir)/config/arm/arm-c.c
  
@@ -610,7 +610,7 @@ The following OS versions are implemented:
 +	$(POSTCOMPILE)
 +
  arm-common.o: arm-cpu-cdata.h
---- a/gcc/config/default-d.c
+--- /dev/null
 +++ b/gcc/config/default-d.c
 @@ -0,0 +1,25 @@
 +/* Default D language target hooks initializer.
@@ -638,7 +638,7 @@ The following OS versions are implemented:
 +#include "d/d-target-def.h"
 +
 +struct gcc_targetdm targetdm = TARGETDM_INITIALIZER;
---- a/gcc/config/glibc-d.c
+--- /dev/null
 +++ b/gcc/config/glibc-d.c
 @@ -0,0 +1,64 @@
 +/* Glibc support needed only by D front-end.
@@ -707,7 +707,7 @@ The following OS versions are implemented:
 +struct gcc_targetdm targetdm = TARGETDM_INITIALIZER;
 --- a/gcc/config/gnu.h
 +++ b/gcc/config/gnu.h
-@@ -31,3 +31,9 @@ along with GCC.  If not, see <http://www.gnu.org/licenses/>.
+@@ -31,3 +31,9 @@ along with GCC.  If not, see <http://www
  	builtin_assert ("system=unix");		\
  	builtin_assert ("system=posix");	\
      } while (0)
@@ -717,7 +717,7 @@ The following OS versions are implemented:
 +	builtin_version ("Hurd");		\
 +	builtin_version ("CRuntime_Glibc");	\
 +    } while (0)
---- a/gcc/config/i386/i386-d.c
+--- /dev/null
 +++ b/gcc/config/i386/i386-d.c
 @@ -0,0 +1,44 @@
 +/* Subroutines for the D front end on the x86 architecture.
@@ -766,7 +766,7 @@ The following OS versions are implemented:
 +}
 --- a/gcc/config/i386/i386-protos.h
 +++ b/gcc/config/i386/i386-protos.h
-@@ -239,6 +239,9 @@ extern bool ix86_bnd_prefixed_insn_p (rtx);
+@@ -238,6 +238,9 @@ extern bool ix86_bnd_prefixed_insn_p (rt
  extern void ix86_target_macros (void);
  extern void ix86_register_pragmas (void);
  
@@ -778,7 +778,7 @@ The following OS versions are implemented:
  extern void i386_pe_declare_function_type (FILE *, const char *, int);
 --- a/gcc/config/i386/i386.h
 +++ b/gcc/config/i386/i386.h
-@@ -681,6 +681,9 @@ extern const char *host_detect_local_cpu (int argc, const char **argv);
+@@ -697,6 +697,9 @@ extern const char *host_detect_local_cpu
  /* Target Pragmas.  */
  #define REGISTER_TARGET_PRAGMAS() ix86_register_pragmas ()
  
@@ -790,7 +790,7 @@ The following OS versions are implemented:
  #endif
 --- a/gcc/config/i386/linux-common.h
 +++ b/gcc/config/i386/linux-common.h
-@@ -27,6 +27,12 @@ along with GCC; see the file COPYING3.  If not see
+@@ -27,6 +27,12 @@ along with GCC; see the file COPYING3.
      }                                          \
    while (0)
  
@@ -805,7 +805,7 @@ The following OS versions are implemented:
    LINUX_OR_ANDROID_CC (GNU_USER_TARGET_CC1_SPEC, \
 --- a/gcc/config/i386/t-i386
 +++ b/gcc/config/i386/t-i386
-@@ -40,6 +40,10 @@ x86-tune-sched-core.o: $(srcdir)/config/i386/x86-tune-sched-core.c
+@@ -40,6 +40,10 @@ x86-tune-sched-core.o: $(srcdir)/config/
  	  $(COMPILE) $<
  	  $(POSTCOMPILE)
  
@@ -818,7 +818,7 @@ The following OS versions are implemented:
  i386-builtin-types.inc: s-i386-bt ; @true
 --- a/gcc/config/kfreebsd-gnu.h
 +++ b/gcc/config/kfreebsd-gnu.h
-@@ -29,6 +29,12 @@ along with GCC; see the file COPYING3.  If not see
+@@ -29,6 +29,12 @@ along with GCC; see the file COPYING3.
      }						\
    while (0)
  
@@ -833,7 +833,7 @@ The following OS versions are implemented:
  #define GNU_USER_DYNAMIC_LINKER64      GLIBC_DYNAMIC_LINKER64
 --- a/gcc/config/kopensolaris-gnu.h
 +++ b/gcc/config/kopensolaris-gnu.h
-@@ -30,5 +30,11 @@ along with GCC; see the file COPYING3.  If not see
+@@ -30,5 +30,11 @@ along with GCC; see the file COPYING3.
      }						\
    while (0)
  
@@ -862,7 +862,7 @@ The following OS versions are implemented:
  #else
 --- a/gcc/config/linux.h
 +++ b/gcc/config/linux.h
-@@ -53,6 +53,19 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+@@ -53,6 +53,19 @@ see the files COPYING3 and COPYING.RUNTI
  	builtin_assert ("system=posix");			\
      } while (0)
  
@@ -884,7 +884,7 @@ The following OS versions are implemented:
     -muclibc or -mglibc or -mbionic or -mmusl has been passed to change
 --- a/gcc/config/mips/linux-common.h
 +++ b/gcc/config/mips/linux-common.h
-@@ -27,6 +27,9 @@ along with GCC; see the file COPYING3.  If not see
+@@ -27,6 +27,9 @@ along with GCC; see the file COPYING3.
      ANDROID_TARGET_OS_CPP_BUILTINS();				\
    } while (0)
  
@@ -894,7 +894,7 @@ The following OS versions are implemented:
  #undef  LINK_SPEC
  #define LINK_SPEC							\
    LINUX_OR_ANDROID_LD (GNU_USER_TARGET_LINK_SPEC,			\
---- a/gcc/config/mips/mips-d.c
+--- /dev/null
 +++ b/gcc/config/mips/mips-d.c
 @@ -0,0 +1,56 @@
 +/* Subroutines for the D front end on the MIPS architecture.
@@ -955,7 +955,7 @@ The following OS versions are implemented:
 +}
 --- a/gcc/config/mips/mips-protos.h
 +++ b/gcc/config/mips/mips-protos.h
-@@ -386,4 +386,7 @@ extern mulsidi3_gen_fn mips_mulsidi3_gen_fn (enum rtx_code);
+@@ -385,4 +385,7 @@ extern mulsidi3_gen_fn mips_mulsidi3_gen
  extern void mips_register_frame_header_opt (void);
  extern void mips_expand_vec_cond_expr (machine_mode, machine_mode, rtx *);
  
@@ -977,7 +977,7 @@ The following OS versions are implemented:
  #ifndef TARGET_DEFAULT
 --- a/gcc/config/mips/t-mips
 +++ b/gcc/config/mips/t-mips
-@@ -24,3 +24,7 @@ $(srcdir)/config/mips/mips-tables.opt: $(srcdir)/config/mips/genopt.sh \
+@@ -24,3 +24,7 @@ $(srcdir)/config/mips/mips-tables.opt: $
  frame-header-opt.o: $(srcdir)/config/mips/frame-header-opt.c
  	$(COMPILE) $<
  	$(POSTCOMPILE)
@@ -1029,7 +1029,7 @@ The following OS versions are implemented:
  #undef  CPP_OS_DEFAULT_SPEC
  #define CPP_OS_DEFAULT_SPEC "%(cpp_os_linux) %(include_extra)"
  
---- a/gcc/config/powerpcspe/powerpcspe-d.c
+--- /dev/null
 +++ b/gcc/config/powerpcspe/powerpcspe-d.c
 @@ -0,0 +1,45 @@
 +/* Subroutines for the D front end on the PowerPC architecture.
@@ -1079,7 +1079,7 @@ The following OS versions are implemented:
 +}
 --- a/gcc/config/powerpcspe/powerpcspe-protos.h
 +++ b/gcc/config/powerpcspe/powerpcspe-protos.h
-@@ -233,6 +233,9 @@ extern void rs6000_target_modify_macros (bool, HOST_WIDE_INT, HOST_WIDE_INT);
+@@ -231,6 +231,9 @@ extern void rs6000_target_modify_macros
  extern void (*rs6000_target_modify_macros_ptr) (bool, HOST_WIDE_INT,
  						HOST_WIDE_INT);
  
@@ -1091,7 +1091,7 @@ The following OS versions are implemented:
  #endif
 --- a/gcc/config/powerpcspe/powerpcspe.h
 +++ b/gcc/config/powerpcspe/powerpcspe.h
-@@ -822,6 +822,9 @@ extern unsigned char rs6000_recip_bits[];
+@@ -822,6 +822,9 @@ extern unsigned char rs6000_recip_bits[]
  #define TARGET_CPU_CPP_BUILTINS() \
    rs6000_cpu_cpp_builtins (pfile)
  
@@ -1103,7 +1103,7 @@ The following OS versions are implemented:
  #define RS6000_CPU_CPP_ENDIAN_BUILTINS()	\
 --- a/gcc/config/powerpcspe/t-powerpcspe
 +++ b/gcc/config/powerpcspe/t-powerpcspe
-@@ -26,6 +26,10 @@ powerpcspe-c.o: $(srcdir)/config/powerpcspe/powerpcspe-c.c
+@@ -26,6 +26,10 @@ powerpcspe-c.o: $(srcdir)/config/powerpc
  	$(COMPILE) $<
  	$(POSTCOMPILE)
  
@@ -1138,7 +1138,7 @@ The following OS versions are implemented:
  
 --- a/gcc/config/rs6000/linux64.h
 +++ b/gcc/config/rs6000/linux64.h
-@@ -391,6 +391,19 @@ extern int dot_symbols;
+@@ -398,6 +398,19 @@ extern int dot_symbols;
      }							\
    while (0)
  
@@ -1158,7 +1158,7 @@ The following OS versions are implemented:
  #undef  CPP_OS_DEFAULT_SPEC
  #define CPP_OS_DEFAULT_SPEC "%(cpp_os_linux) %(include_extra)"
  
---- a/gcc/config/rs6000/rs6000-d.c
+--- /dev/null
 +++ b/gcc/config/rs6000/rs6000-d.c
 @@ -0,0 +1,45 @@
 +/* Subroutines for the D front end on the PowerPC architecture.
@@ -1208,7 +1208,7 @@ The following OS versions are implemented:
 +}
 --- a/gcc/config/rs6000/rs6000-protos.h
 +++ b/gcc/config/rs6000/rs6000-protos.h
-@@ -234,6 +234,9 @@ extern void rs6000_target_modify_macros (bool, HOST_WIDE_INT, HOST_WIDE_INT);
+@@ -233,6 +233,9 @@ extern void rs6000_target_modify_macros
  extern void (*rs6000_target_modify_macros_ptr) (bool, HOST_WIDE_INT,
  						HOST_WIDE_INT);
  
@@ -1220,7 +1220,7 @@ The following OS versions are implemented:
  #endif
 --- a/gcc/config/rs6000/rs6000.h
 +++ b/gcc/config/rs6000/rs6000.h
-@@ -793,6 +793,9 @@ extern unsigned char rs6000_recip_bits[];
+@@ -797,6 +797,9 @@ extern unsigned char rs6000_recip_bits[]
  #define TARGET_CPU_CPP_BUILTINS() \
    rs6000_cpu_cpp_builtins (pfile)
  
@@ -1232,7 +1232,7 @@ The following OS versions are implemented:
  #define RS6000_CPU_CPP_ENDIAN_BUILTINS()	\
 --- a/gcc/config/rs6000/t-rs6000
 +++ b/gcc/config/rs6000/t-rs6000
-@@ -34,6 +34,10 @@ rs6000-p8swap.o: $(srcdir)/config/rs6000/rs6000-p8swap.c
+@@ -34,6 +34,10 @@ rs6000-p8swap.o: $(srcdir)/config/rs6000
  	$(COMPILE) $<
  	$(POSTCOMPILE)
  
@@ -1243,7 +1243,7 @@ The following OS versions are implemented:
  $(srcdir)/config/rs6000/rs6000-tables.opt: $(srcdir)/config/rs6000/genopt.sh \
    $(srcdir)/config/rs6000/rs6000-cpus.def
  	$(SHELL) $(srcdir)/config/rs6000/genopt.sh $(srcdir)/config/rs6000 > \
---- a/gcc/config/s390/s390-d.c
+--- /dev/null
 +++ b/gcc/config/s390/s390-d.c
 @@ -0,0 +1,41 @@
 +/* Subroutines for the D front end on the IBM S/390 and zSeries architectures.
@@ -1289,7 +1289,7 @@ The following OS versions are implemented:
 +}
 --- a/gcc/config/s390/s390-protos.h
 +++ b/gcc/config/s390/s390-protos.h
-@@ -153,3 +153,6 @@ extern void s390_register_target_pragmas (void);
+@@ -165,3 +165,6 @@ extern void s390_register_target_pragmas
  
  /* Routines for s390-c.c */
  extern bool s390_const_operand_ok (tree, int, int, tree);
@@ -1310,7 +1310,7 @@ The following OS versions are implemented:
                              | MASK_OPT_HTM | MASK_OPT_VX)
 --- a/gcc/config/s390/t-s390
 +++ b/gcc/config/s390/t-s390
-@@ -25,3 +25,7 @@ s390-c.o: $(srcdir)/config/s390/s390-c.c \
+@@ -25,3 +25,7 @@ s390-c.o: $(srcdir)/config/s390/s390-c.c
    $(TARGET_H) $(TARGET_DEF_H) $(CPPLIB_H) $(C_PRAGMA_H)
  	$(COMPILER) -c $(ALL_COMPILERFLAGS) $(ALL_CPPFLAGS) $(INCLUDES) \
  		$(srcdir)/config/s390/s390-c.c
@@ -1318,7 +1318,7 @@ The following OS versions are implemented:
 +s390-d.o: $(srcdir)/config/s390/s390-d.c
 +	$(COMPILE) $<
 +	$(POSTCOMPILE)
---- a/gcc/config/sparc/sparc-d.c
+--- /dev/null
 +++ b/gcc/config/sparc/sparc-d.c
 @@ -0,0 +1,48 @@
 +/* Subroutines for the D front end on the SPARC architecture.
@@ -1371,7 +1371,7 @@ The following OS versions are implemented:
 +}
 --- a/gcc/config/sparc/sparc-protos.h
 +++ b/gcc/config/sparc/sparc-protos.h
-@@ -111,4 +111,7 @@ unsigned int sparc_regmode_natural_size (machine_mode);
+@@ -111,4 +111,7 @@ unsigned int sparc_regmode_natural_size
  
  extern rtl_opt_pass *make_pass_work_around_errata (gcc::context *);
  
@@ -1381,7 +1381,7 @@ The following OS versions are implemented:
  #endif /* __SPARC_PROTOS_H__ */
 --- a/gcc/config/sparc/sparc.h
 +++ b/gcc/config/sparc/sparc.h
-@@ -27,6 +27,9 @@ along with GCC; see the file COPYING3.  If not see
+@@ -27,6 +27,9 @@ along with GCC; see the file COPYING3.
  
  #define TARGET_CPU_CPP_BUILTINS() sparc_target_macros ()
  
@@ -1393,7 +1393,7 @@ The following OS versions are implemented:
  
 --- a/gcc/config/sparc/t-sparc
 +++ b/gcc/config/sparc/t-sparc
-@@ -23,3 +23,7 @@ PASSES_EXTRA += $(srcdir)/config/sparc/sparc-passes.def
+@@ -23,3 +23,7 @@ PASSES_EXTRA += $(srcdir)/config/sparc/s
  sparc-c.o: $(srcdir)/config/sparc/sparc-c.c
  	$(COMPILE) $<
  	$(POSTCOMPILE)
@@ -1510,7 +1510,7 @@ The following OS versions are implemented:
  xm_file_list=
  xm_include_list=
  for f in $xm_file; do
-@@ -6242,6 +6258,8 @@ AC_SUBST(tm_include_list)
+@@ -6335,6 +6351,8 @@ AC_SUBST(tm_include_list)
  AC_SUBST(tm_defines)
  AC_SUBST(tm_p_file_list)
  AC_SUBST(tm_p_include_list)
@@ -1519,7 +1519,7 @@ The following OS versions are implemented:
  AC_SUBST(xm_file_list)
  AC_SUBST(xm_include_list)
  AC_SUBST(xm_defines)
-@@ -6249,6 +6267,7 @@ AC_SUBST(use_gcc_stdint)
+@@ -6342,6 +6360,7 @@ AC_SUBST(use_gcc_stdint)
  AC_SUBST(c_target_objs)
  AC_SUBST(cxx_target_objs)
  AC_SUBST(fortran_target_objs)
@@ -1529,7 +1529,7 @@ The following OS versions are implemented:
  AC_SUBST_FILE(language_hooks)
 --- a/gcc/doc/tm.texi
 +++ b/gcc/doc/tm.texi
-@@ -52,6 +52,7 @@ through the macros defined in the @file{.h} file.
+@@ -52,6 +52,7 @@ through the macros defined in the @file{
  * MIPS Coprocessors::   MIPS coprocessor support and how to customize it.
  * PCH Target::          Validity checking for precompiled headers.
  * C++ ABI::             Controlling C++ ABI changes.
@@ -1537,7 +1537,7 @@ The following OS versions are implemented:
  * Named Address Spaces:: Adding support for named address spaces
  * Misc::                Everything else.
  @end menu
-@@ -106,6 +107,14 @@ documented as ``Common Target Hook''.  This is declared in
+@@ -106,6 +107,14 @@ documented as ``Common Target Hook''.  T
  @code{target_has_targetm_common=yes} in @file{config.gcc}; otherwise a
  default definition is used.
  
@@ -1552,7 +1552,7 @@ The following OS versions are implemented:
  @node Driver
  @section Controlling the Compilation Driver, @file{gcc}
  @cindex driver
-@@ -10488,6 +10497,22 @@ unloaded. The default is to return false.
+@@ -10617,6 +10626,22 @@ unloaded. The default is to return false
  Return target-specific mangling context of @var{decl} or @code{NULL_TREE}.
  @end deftypefn
  
@@ -1577,7 +1577,7 @@ The following OS versions are implemented:
  @cindex named address spaces
 --- a/gcc/doc/tm.texi.in
 +++ b/gcc/doc/tm.texi.in
-@@ -52,6 +52,7 @@ through the macros defined in the @file{.h} file.
+@@ -52,6 +52,7 @@ through the macros defined in the @file{
  * MIPS Coprocessors::   MIPS coprocessor support and how to customize it.
  * PCH Target::          Validity checking for precompiled headers.
  * C++ ABI::             Controlling C++ ABI changes.
@@ -1585,7 +1585,7 @@ The following OS versions are implemented:
  * Named Address Spaces:: Adding support for named address spaces
  * Misc::                Everything else.
  @end menu
-@@ -106,6 +107,14 @@ documented as ``Common Target Hook''.  This is declared in
+@@ -106,6 +107,14 @@ documented as ``Common Target Hook''.  T
  @code{target_has_targetm_common=yes} in @file{config.gcc}; otherwise a
  default definition is used.
  
@@ -1600,7 +1600,7 @@ The following OS versions are implemented:
  @node Driver
  @section Controlling the Compilation Driver, @file{gcc}
  @cindex driver
-@@ -7234,6 +7243,16 @@ floating-point support; they are not included in this mechanism.
+@@ -7275,6 +7284,16 @@ floating-point support; they are not inc
  
  @hook TARGET_CXX_DECL_MANGLING_CONTEXT
  

--- a/gcc/d/patches/patch-targetdm-untested-8.patch
+++ b/gcc/d/patches/patch-targetdm-untested-8.patch
@@ -55,15 +55,15 @@ These official OS versions are not implemented:
  frv*)	cpu_type=frv
  	extra_options="${extra_options} g.opt"
  	;;
-@@ -419,6 +422,7 @@ x86_64-*-*)
- 		       clzerointrin.h pkuintrin.h sgxintrin.h"
+@@ -429,6 +432,7 @@ x86_64-*-*)
+ 		       avx512vpopcntdqvlintrin.h avx512bitalgintrin.h"
  	;;
  ia64-*-*)
 +	d_target_objs="ia64-d.o"
  	extra_headers=ia64intrin.h
  	extra_options="${extra_options} g.opt fused-madd.opt"
  	;;
-@@ -458,6 +462,7 @@ nios2-*-*)
+@@ -468,6 +472,7 @@ nios2-*-*)
  	;;
  nvptx-*-*)
  	cpu_type=nvptx
@@ -71,7 +71,7 @@ These official OS versions are not implemented:
  	;;
  powerpc*-*-*spe*)
  	cpu_type=powerpcspe
-@@ -486,6 +491,7 @@ powerpc*-*-*)
+@@ -499,6 +504,7 @@ powerpc*-*-*)
  riscv*)
  	cpu_type=riscv
  	extra_objs="riscv-builtins.o riscv-c.o"
@@ -79,7 +79,7 @@ These official OS versions are not implemented:
  	;;
  rs6000*-*-*)
  	extra_options="${extra_options} g.opt fused-madd.opt rs6000/rs6000-tables.opt"
-@@ -672,8 +678,10 @@ case ${target} in
+@@ -685,8 +691,10 @@ case ${target} in
    extra_options="${extra_options} darwin.opt"
    c_target_objs="${c_target_objs} darwin-c.o"
    cxx_target_objs="${cxx_target_objs} darwin-c.o"
@@ -87,10 +87,10 @@ These official OS versions are not implemented:
    fortran_target_objs="darwin-f.o"
    target_has_targetcm=yes
 +  target_has_targetdm=yes
-   extra_objs="darwin.o"
+   extra_objs="${extra_objs} darwin.o"
    extra_gcc_objs="darwin-driver.o"
    default_use_cxa_atexit=yes
-@@ -698,6 +706,9 @@ case ${target} in
+@@ -711,6 +719,9 @@ case ${target} in
        exit 1
        ;;
    esac
@@ -100,7 +100,7 @@ These official OS versions are not implemented:
    extra_options="$extra_options rpath.opt dragonfly.opt"
    default_use_cxa_atexit=yes
    use_gcc_stdint=wrap
-@@ -741,6 +752,9 @@ case ${target} in
+@@ -754,6 +765,9 @@ case ${target} in
        ;;
    esac
    fbsd_tm_file="${fbsd_tm_file} freebsd-spec.h freebsd.h freebsd-stdint.h"
@@ -110,17 +110,16 @@ These official OS versions are not implemented:
    extra_options="$extra_options rpath.opt freebsd.opt"
    case ${target} in
      *-*-freebsd[345].*)
-@@ -816,6 +830,9 @@ case ${target} in
+@@ -830,6 +844,8 @@ case ${target} in
+   tm_p_file="${tm_p_file} netbsd-protos.h"
+   tmake_file="t-netbsd t-slibgcc"
+   extra_objs="${extra_objs} netbsd.o"
++  d_target_objs="${d_target_objs} netbsd-d.o"
++  target_has_targetdm=yes
    gas=yes
    gnu_ld=yes
    use_gcc_stdint=wrap
-+  d_target_objs="${d_target_objs} netbsd-d.o"
-+  target_has_targetdm=yes
-+  tmake_file="${tmake_file} t-netbsd"
- 
-   # NetBSD 2.0 and later get POSIX threads enabled by default.
-   # Allow them to be explicitly enabled on any other version.
-@@ -844,6 +861,8 @@ case ${target} in
+@@ -841,6 +857,8 @@ case ${target} in
    ;;
  *-*-openbsd*)
    tmake_file="t-openbsd"
@@ -129,16 +128,16 @@ These official OS versions are not implemented:
    case ${enable_threads} in
      yes)
        thread_file='posix'
-@@ -909,6 +928,8 @@ case ${target} in
+@@ -906,6 +924,8 @@ case ${target} in
    tmake_file="${tmake_file} t-sol2 t-slibgcc"
    c_target_objs="${c_target_objs} sol2-c.o"
    cxx_target_objs="${cxx_target_objs} sol2-c.o sol2-cxx.o"
 +  d_target_objs="${d_target_objs} sol2-d.o"
 +  target_has_targetdm="yes"
-   extra_objs="sol2.o sol2-stubs.o"
+   extra_objs="${extra_objs} sol2.o sol2-stubs.o"
    extra_options="${extra_options} sol2.opt"
    case ${enable_threads}:${have_pthread_h}:${have_thread_h} in
-@@ -1747,7 +1768,9 @@ i[34567]86-*-mingw* | x86_64-*-mingw*)
+@@ -1768,7 +1788,9 @@ i[34567]86-*-mingw* | x86_64-*-mingw*)
  	xm_file=i386/xm-mingw32.h
  	c_target_objs="${c_target_objs} winnt-c.o"
  	cxx_target_objs="${cxx_target_objs} winnt-c.o"
@@ -148,7 +147,7 @@ These official OS versions are not implemented:
  	case ${target} in
  		x86_64-*-* | *-w64-*)
  			need_64bit_isa=yes
-@@ -4534,6 +4562,8 @@ case ${target} in
+@@ -4606,6 +4628,8 @@ case ${target} in
  		then
  			target_cpu_default2="MASK_GAS"
  		fi
@@ -157,7 +156,7 @@ These official OS versions are not implemented:
  		;;
  
  	fido*-*-* | m68k*-*-*)
-@@ -4656,6 +4656,7 @@ case ${target} in
+@@ -4699,6 +4723,7 @@ case ${target} in
  	sh[123456ble]*-*-* | sh-*-*)
  		c_target_objs="${c_target_objs} sh-c.o"
  		cxx_target_objs="${cxx_target_objs} sh-c.o"
@@ -165,7 +164,7 @@ These official OS versions are not implemented:
  		;;
  
  	sparc*-*-*)
---- a/gcc/config/darwin-d.c
+--- /dev/null
 +++ b/gcc/config/darwin-d.c
 @@ -0,0 +1,55 @@
 +/* Darwin support needed only by D front-end.
@@ -223,7 +222,7 @@ These official OS versions are not implemented:
 +#define TARGET_D_CRITSEC_SIZE darwin_d_critsec_size
 +
 +struct gcc_targetdm targetdm = TARGETDM_INITIALIZER;
---- a/gcc/config/dragonfly-d.c
+--- /dev/null
 +++ b/gcc/config/dragonfly-d.c
 @@ -0,0 +1,49 @@
 +/* DragonFly support needed only by D front-end.
@@ -275,7 +274,7 @@ These official OS versions are not implemented:
 +#define TARGET_D_CRITSEC_SIZE dragonfly_d_critsec_size
 +
 +struct gcc_targetdm targetdm = TARGETDM_INITIALIZER;
---- a/gcc/config/epiphany/epiphany-d.c
+--- /dev/null
 +++ b/gcc/config/epiphany/epiphany-d.c
 @@ -0,0 +1,31 @@
 +/* Subroutines for the D front end on the EPIPHANY architecture.
@@ -311,7 +310,7 @@ These official OS versions are not implemented:
 +}
 --- a/gcc/config/epiphany/epiphany-protos.h
 +++ b/gcc/config/epiphany/epiphany-protos.h
-@@ -61,3 +61,5 @@ extern bool epiphany_regno_rename_ok (unsigned src, unsigned dst);
+@@ -60,3 +60,5 @@ extern bool epiphany_regno_rename_ok (un
     it uses peephole2 predicates without having all the necessary headers.  */
  extern int get_attr_sched_use_fpu (rtx_insn *);
  
@@ -319,7 +318,7 @@ These official OS versions are not implemented:
 +extern void epiphany_d_target_versions (void);
 --- a/gcc/config/epiphany/epiphany.h
 +++ b/gcc/config/epiphany/epiphany.h
-@@ -41,6 +41,9 @@ along with GCC; see the file COPYING3.  If not see
+@@ -41,6 +41,9 @@ along with GCC; see the file COPYING3.
  	builtin_assert ("machine=epiphany");	\
      } while (0)
  
@@ -339,7 +338,7 @@ These official OS versions are not implemented:
 +epiphany-d.o: $(srcdir)/config/epiphany/epiphany-d.c
 +	$(COMPILE) $<
 +	$(POSTCOMPILE)
---- a/gcc/config/freebsd-d.c
+--- /dev/null
 +++ b/gcc/config/freebsd-d.c
 @@ -0,0 +1,49 @@
 +/* FreeBSD support needed only by D front-end.
@@ -393,7 +392,7 @@ These official OS versions are not implemented:
 +struct gcc_targetdm targetdm = TARGETDM_INITIALIZER;
 --- a/gcc/config/i386/cygwin.h
 +++ b/gcc/config/i386/cygwin.h
-@@ -29,6 +29,12 @@ along with GCC; see the file COPYING3.  If not see
+@@ -29,6 +29,12 @@ along with GCC; see the file COPYING3.
      }								\
    while (0)
  
@@ -408,7 +407,7 @@ These official OS versions are not implemented:
    %{!ansi:-Dunix} \
 --- a/gcc/config/i386/mingw32.h
 +++ b/gcc/config/i386/mingw32.h
-@@ -53,6 +53,16 @@ along with GCC; see the file COPYING3.  If not see
+@@ -53,6 +53,16 @@ along with GCC; see the file COPYING3.
      }								\
    while (0)
  
@@ -427,7 +426,7 @@ These official OS versions are not implemented:
  #define SPEC_PTHREAD2 "!no-pthread"
 --- a/gcc/config/i386/t-cygming
 +++ b/gcc/config/i386/t-cygming
-@@ -32,6 +32,9 @@ winnt-cxx.o: $(srcdir)/config/i386/winnt-cxx.c $(CONFIG_H) $(SYSTEM_H) coretypes
+@@ -32,6 +32,9 @@ winnt-cxx.o: $(srcdir)/config/i386/winnt
  	$(COMPILER) -c $(ALL_COMPILERFLAGS) $(ALL_CPPFLAGS) $(INCLUDES) \
  	$(srcdir)/config/i386/winnt-cxx.c
  
@@ -437,7 +436,7 @@ These official OS versions are not implemented:
  
  winnt-stubs.o: $(srcdir)/config/i386/winnt-stubs.c $(CONFIG_H) $(SYSTEM_H) coretypes.h \
    $(TM_H) $(RTL_H) $(REGS_H) hard-reg-set.h output.h $(TREE_H) flags.h \
---- a/gcc/config/i386/winnt-d.c
+--- /dev/null
 +++ b/gcc/config/i386/winnt-d.c
 @@ -0,0 +1,60 @@
 +/* Windows support needed only by D front-end.
@@ -500,7 +499,7 @@ These official OS versions are not implemented:
 +#define TARGET_D_CRITSEC_SIZE winnt_d_critsec_size
 +
 +struct gcc_targetdm targetdm = TARGETDM_INITIALIZER;
---- a/gcc/config/ia64/ia64-d.c
+--- /dev/null
 +++ b/gcc/config/ia64/ia64-d.c
 @@ -0,0 +1,31 @@
 +/* Subroutines for the D front end on the IA64 architecture.
@@ -536,7 +535,7 @@ These official OS versions are not implemented:
 +}
 --- a/gcc/config/ia64/ia64-protos.h
 +++ b/gcc/config/ia64/ia64-protos.h
-@@ -98,6 +98,9 @@ extern void ia64_hpux_handle_builtin_pragma (struct cpp_reader *);
+@@ -92,6 +92,9 @@ extern void ia64_hpux_handle_builtin_pra
  extern void ia64_output_function_profiler (FILE *, int);
  extern void ia64_profile_hook (int);
  
@@ -560,7 +559,7 @@ These official OS versions are not implemented:
  #endif
 --- a/gcc/config/ia64/t-ia64
 +++ b/gcc/config/ia64/t-ia64
-@@ -21,6 +21,10 @@ ia64-c.o: $(srcdir)/config/ia64/ia64-c.c $(CONFIG_H) $(SYSTEM_H) \
+@@ -21,6 +21,10 @@ ia64-c.o: $(srcdir)/config/ia64/ia64-c.c
  	$(COMPILER) -c $(ALL_COMPILERFLAGS) $(ALL_CPPFLAGS) $(INCLUDES) \
  		$(srcdir)/config/ia64/ia64-c.c
  
@@ -571,7 +570,7 @@ These official OS versions are not implemented:
  # genattrtab generates very long string literals.
  insn-attrtab.o-warn = -Wno-error
  
---- a/gcc/config/netbsd-d.c
+--- /dev/null
 +++ b/gcc/config/netbsd-d.c
 @@ -0,0 +1,49 @@
 +/* NetBSD support needed only by D front-end.
@@ -623,7 +622,7 @@ These official OS versions are not implemented:
 +#define TARGET_D_CRITSEC_SIZE netbsd_d_critsec_size
 +
 +struct gcc_targetdm targetdm = TARGETDM_INITIALIZER;
---- a/gcc/config/nvptx/nvptx-d.c
+--- /dev/null
 +++ b/gcc/config/nvptx/nvptx-d.c
 @@ -0,0 +1,34 @@
 +/* Subroutines for the D front end on the NVPTX architecture.
@@ -662,9 +661,9 @@ These official OS versions are not implemented:
 +}
 --- a/gcc/config/nvptx/nvptx-protos.h
 +++ b/gcc/config/nvptx/nvptx-protos.h
-@@ -42,6 +42,9 @@ extern void nvptx_output_skip (FILE *, unsigned HOST_WIDE_INT);
- extern void nvptx_output_ascii (FILE *, const char *, unsigned HOST_WIDE_INT);
+@@ -43,6 +43,9 @@ extern void nvptx_output_ascii (FILE *,
  extern void nvptx_register_pragmas (void);
+ extern unsigned int nvptx_data_alignment (const_tree, unsigned int);
  
 +/* Routines implemented in nvptx-d.c  */
 +extern void nvptx_d_target_versions (void);
@@ -686,7 +685,7 @@ These official OS versions are not implemented:
  #define GOMP_SELF_SPECS ""
 --- a/gcc/config/nvptx/t-nvptx
 +++ b/gcc/config/nvptx/t-nvptx
-@@ -10,3 +10,7 @@ mkoffload$(exeext): mkoffload.o collect-utils.o libcommon-target.a $(LIBIBERTY)
+@@ -10,3 +10,7 @@ mkoffload$(exeext): mkoffload.o collect-
  	  mkoffload.o collect-utils.o libcommon-target.a $(LIBIBERTY) $(LIBS)
  
  MULTILIB_OPTIONS = mgomp
@@ -694,7 +693,7 @@ These official OS versions are not implemented:
 +nvptx-d.o: $(srcdir)/config/nvptx/nvptx-d.c
 +	$(COMPILE) $<
 +	$(POSTCOMPILE)
---- a/gcc/config/openbsd-d.c
+--- /dev/null
 +++ b/gcc/config/openbsd-d.c
 @@ -0,0 +1,49 @@
 +/* OpenBSD support needed only by D front-end.
@@ -746,7 +745,7 @@ These official OS versions are not implemented:
 +#define TARGET_D_CRITSEC_SIZE openbsd_d_critsec_size
 +
 +struct gcc_targetdm targetdm = TARGETDM_INITIALIZER;
---- a/gcc/config/pa/pa-d.c
+--- /dev/null
 +++ b/gcc/config/pa/pa-d.c
 @@ -0,0 +1,39 @@
 +/* Subroutines for the D front end on the HPPA architecture.
@@ -790,7 +789,7 @@ These official OS versions are not implemented:
 +}
 --- a/gcc/config/pa/pa-linux.h
 +++ b/gcc/config/pa/pa-linux.h
-@@ -27,6 +27,8 @@ along with GCC; see the file COPYING3.  If not see
+@@ -27,6 +27,8 @@ along with GCC; see the file COPYING3.
      }						\
    while (0)
  
@@ -801,8 +800,8 @@ These official OS versions are not implemented:
  
 --- a/gcc/config/pa/pa-protos.h
 +++ b/gcc/config/pa/pa-protos.h
-@@ -109,3 +109,6 @@ extern void pa_hpux_asm_output_external (FILE *, tree, const char *);
- extern HOST_WIDE_INT pa_initial_elimination_offset (int, int);
+@@ -110,3 +110,6 @@ extern HOST_WIDE_INT pa_initial_eliminat
+ extern HOST_WIDE_INT pa_function_arg_size (machine_mode, const_tree);
  
  extern const int pa_magic_milli[];
 +
@@ -820,13 +819,13 @@ These official OS versions are not implemented:
  #define CC1_SPEC "%{pg:} %{p:}"
  
  #define LINK_SPEC "%{mlinker-opt:-O} %{!shared:-u main} %{shared:-b}"
---- a/gcc/config/pa/t-pa
+--- /dev/null
 +++ b/gcc/config/pa/t-pa
 @@ -0,0 +1,3 @@
 +pa-d.o: $(srcdir)/config/pa/pa-d.c
 +	$(COMPILE) $<
 +	$(POSTCOMPILE)
---- a/gcc/config/riscv/riscv-d.c
+--- /dev/null
 +++ b/gcc/config/riscv/riscv-d.c
 @@ -0,0 +1,39 @@
 +/* Subroutines for the D front end on the RISC-V architecture.
@@ -870,7 +869,7 @@ These official OS versions are not implemented:
 +}
 --- a/gcc/config/riscv/riscv-protos.h
 +++ b/gcc/config/riscv/riscv-protos.h
-@@ -74,6 +74,9 @@ extern unsigned int riscv_hard_regno_nregs (int, enum machine_mode);
+@@ -74,6 +74,9 @@ extern bool riscv_expand_block_move (rtx
  /* Routines implemented in riscv-c.c.  */
  void riscv_cpu_cpp_builtins (cpp_reader *);
  
@@ -879,10 +878,10 @@ These official OS versions are not implemented:
 +
  /* Routines implemented in riscv-builtins.c.  */
  extern void riscv_atomic_assign_expand_fenv (tree *, tree *, tree *);
- extern rtx riscv_expand_builtin (tree, rtx, rtx, enum machine_mode, int);
+ extern rtx riscv_expand_builtin (tree, rtx, rtx, machine_mode, int);
 --- a/gcc/config/riscv/riscv.h
 +++ b/gcc/config/riscv/riscv.h
-@@ -27,6 +27,9 @@ along with GCC; see the file COPYING3.  If not see
+@@ -27,6 +27,9 @@ along with GCC; see the file COPYING3.
  /* Target CPU builtins.  */
  #define TARGET_CPU_CPP_BUILTINS() riscv_cpu_cpp_builtins (pfile)
  
@@ -894,7 +893,7 @@ These official OS versions are not implemented:
  #ifndef TARGET_DEFAULT
 --- a/gcc/config/riscv/t-riscv
 +++ b/gcc/config/riscv/t-riscv
-@@ -9,3 +9,7 @@ riscv-c.o: $(srcdir)/config/riscv/riscv-c.c $(CONFIG_H) $(SYSTEM_H) \
+@@ -9,3 +9,7 @@ riscv-c.o: $(srcdir)/config/riscv/riscv-
      coretypes.h $(TM_H) $(TREE_H) output.h $(C_COMMON_H) $(TARGET_H)
  	$(COMPILER) -c $(ALL_COMPILERFLAGS) $(ALL_CPPFLAGS) $(INCLUDES) \
  		$(srcdir)/config/riscv/riscv-c.c
@@ -902,7 +901,7 @@ These official OS versions are not implemented:
 +riscv-d.o: $(srcdir)/config/riscv/riscv-d.c
 +	$(COMPILE) $<
 +	$(POSTCOMPILE)
---- a/gcc/config/sh/sh-d.c
+--- /dev/null
 +++ b/gcc/config/sh/sh-d.c
 @@ -0,0 +1,36 @@
 +/* Subroutines for the D front end on the SuperH architecture.
@@ -943,7 +942,7 @@ These official OS versions are not implemented:
 +}
 --- a/gcc/config/sh/sh-protos.h
 +++ b/gcc/config/sh/sh-protos.h
-@@ -363,4 +363,7 @@ extern machine_mode sh_hard_regno_caller_save_mode (unsigned int, unsigned int,
+@@ -363,4 +363,7 @@ extern machine_mode sh_hard_regno_caller
  						    machine_mode);
  extern bool sh_can_use_simple_return_p (void);
  extern rtx sh_load_function_descriptor (rtx);
@@ -953,7 +952,7 @@ These official OS versions are not implemented:
  #endif /* ! GCC_SH_PROTOS_H */
 --- a/gcc/config/sh/sh.h
 +++ b/gcc/config/sh/sh.h
-@@ -31,6 +31,9 @@ extern int code_for_indirect_jump_scratch;
+@@ -31,6 +31,9 @@ extern int code_for_indirect_jump_scratc
  
  #define TARGET_CPU_CPP_BUILTINS() sh_cpu_cpp_builtins (pfile)
  
@@ -976,7 +975,7 @@ These official OS versions are not implemented:
  sh_treg_combine.o: $(srcdir)/config/sh/sh_treg_combine.cc \
    $(CONFIG_H) $(SYSTEM_H) $(TREE_H) $(TM_H) $(TM_P_H) coretypes.h
  	$(COMPILER) -c $(ALL_COMPILERFLAGS) $(ALL_CPPFLAGS) $(INCLUDES) $<
---- a/gcc/config/sol2-d.c
+--- /dev/null
 +++ b/gcc/config/sol2-d.c
 @@ -0,0 +1,49 @@
 +/* Solaris support needed only by D front-end.
@@ -1040,13 +1039,13 @@ These official OS versions are not implemented:
  
  darwin-f.o: $(srcdir)/config/darwin-f.c
  	$(COMPILE) $<
---- a/gcc/config/t-dragonfly
+--- /dev/null
 +++ b/gcc/config/t-dragonfly
 @@ -0,0 +1,3 @@
 +dragonfly-d.o: config/dragonfly-d.c
 +	$(COMPILE) $<
 +	$(POSTCOMPILE)
---- a/gcc/config/t-freebsd
+--- /dev/null
 +++ b/gcc/config/t-freebsd
 @@ -0,0 +1,3 @@
 +freebsd-d.o: config/freebsd-d.c
@@ -1054,10 +1053,13 @@ These official OS versions are not implemented:
 +	$(POSTCOMPILE)
 --- a/gcc/config/t-netbsd
 +++ b/gcc/config/t-netbsd
-@@ -0,0 +1,3 @@
+@@ -1,3 +1,6 @@
 +netbsd-d.o: config/netbsd-d.c
 +	$(COMPILE) $<
 +	$(POSTCOMPILE)
+ # Copyright (C) 2017-2018 Free Software Foundation, Inc.
+ #
+ # This file is part of GCC.
 --- a/gcc/config/t-openbsd
 +++ b/gcc/config/t-openbsd
 @@ -1,2 +1,6 @@

--- a/gcc/d/patches/patch-toplev-8.patch
+++ b/gcc/d/patches/patch-toplev-8.patch
@@ -3,7 +3,7 @@ This implements building of libphobos library in GCC.
 
 --- a/Makefile.def
 +++ b/Makefile.def
-@@ -158,6 +158,7 @@ target_modules = { module= libgfortran; };
+@@ -156,6 +156,7 @@ target_modules = { module= libgfortran;
  target_modules = { module= libobjc; };
  target_modules = { module= libgo; };
  target_modules = { module= libhsail-rt; };
@@ -11,7 +11,16 @@ This implements building of libphobos library in GCC.
  target_modules = { module= libtermcap; no_check=true;
                     missing=mostlyclean;
                     missing=clean;
-@@ -283,6 +284,8 @@ flags_to_pass = { flag= FLAGS_FOR_TARGET ; };
+@@ -268,6 +269,8 @@ flags_to_pass = { flag= STAGE1_CHECKING
+ flags_to_pass = { flag= STAGE1_LANGUAGES ; };
+ flags_to_pass = { flag= GNATBIND ; };
+ flags_to_pass = { flag= GNATMAKE ; };
++flags_to_pass = { flag= GDC ; };
++flags_to_pass = { flag= GDCFLAGS ; };
+ 
+ // Target tools
+ flags_to_pass = { flag= AR_FOR_TARGET ; };
+@@ -281,6 +284,8 @@ flags_to_pass = { flag= FLAGS_FOR_TARGET
  flags_to_pass = { flag= GFORTRAN_FOR_TARGET ; };
  flags_to_pass = { flag= GOC_FOR_TARGET ; };
  flags_to_pass = { flag= GOCFLAGS_FOR_TARGET ; };
@@ -20,7 +29,7 @@ This implements building of libphobos library in GCC.
  flags_to_pass = { flag= LD_FOR_TARGET ; };
  flags_to_pass = { flag= LIPO_FOR_TARGET ; };
  flags_to_pass = { flag= LDFLAGS_FOR_TARGET ; };
-@@ -550,6 +553,11 @@ dependencies = { module=configure-target-libgo; on=all-target-libstdc++-v3; };
+@@ -547,6 +552,11 @@ dependencies = { module=configure-target
  dependencies = { module=all-target-libgo; on=all-target-libbacktrace; };
  dependencies = { module=all-target-libgo; on=all-target-libffi; };
  dependencies = { module=all-target-libgo; on=all-target-libatomic; };
@@ -32,7 +41,7 @@ This implements building of libphobos library in GCC.
  dependencies = { module=configure-target-libstdc++-v3; on=configure-target-libgomp; };
  dependencies = { module=configure-target-liboffloadmic; on=configure-target-libgomp; };
  dependencies = { module=configure-target-libsanitizer; on=all-target-libstdc++-v3; };
-@@ -563,6 +571,7 @@ dependencies = { module=all-target-liboffloadmic; on=all-target-libgomp; };
+@@ -560,6 +570,7 @@ dependencies = { module=all-target-libof
  dependencies = { module=install-target-libgo; on=install-target-libatomic; };
  dependencies = { module=install-target-libgfortran; on=install-target-libquadmath; };
  dependencies = { module=install-target-libgfortran; on=install-target-libgcc; };
@@ -40,7 +49,7 @@ This implements building of libphobos library in GCC.
  dependencies = { module=install-target-libsanitizer; on=install-target-libstdc++-v3; };
  dependencies = { module=install-target-libsanitizer; on=install-target-libgcc; };
  dependencies = { module=install-target-libvtv; on=install-target-libstdc++-v3; };
-@@ -605,6 +614,8 @@ languages = { language=go;	gcc-check-target=check-go;
+@@ -600,6 +611,8 @@ languages = { language=go;	gcc-check-tar
  				lib-check-target=check-gotools; };
  languages = { language=brig;	gcc-check-target=check-brig;
  				lib-check-target=check-target-libhsail-rt; };
@@ -68,7 +77,17 @@ This implements building of libphobos library in GCC.
  	AR="$(AR)"; export AR; \
  	AS="$(AS)"; export AS; \
  	CC_FOR_BUILD="$(CC_FOR_BUILD)"; export CC_FOR_BUILD; \
-@@ -278,6 +281,7 @@ BASE_TARGET_EXPORTS = \
+@@ -256,6 +259,9 @@ POSTSTAGE1_HOST_EXPORTS = \
+ 	CC_FOR_BUILD="$$CC"; export CC_FOR_BUILD; \
+ 	$(POSTSTAGE1_CXX_EXPORT) \
+ 	$(LTO_EXPORTS) \
++	GDC="$$r/$(HOST_SUBDIR)/prev-gcc/gdc$(exeext) -B$$r/$(HOST_SUBDIR)/prev-gcc/ \
++	  -B$(build_tooldir)/bin/ $(GDC_FLAGS_FOR_TARGET)"; export GDC; \
++	GDC_FOR_BUILD="$$GDC"; export GDC_FOR_BUILD; \
+ 	GNATBIND="$$r/$(HOST_SUBDIR)/prev-gcc/gnatbind"; export GNATBIND; \
+ 	LDFLAGS="$(POSTSTAGE1_LDFLAGS) $(BOOT_LDFLAGS)"; export LDFLAGS; \
+ 	HOST_LIBS="$(POSTSTAGE1_LIBS)"; export HOST_LIBS;
+@@ -278,6 +284,7 @@ BASE_TARGET_EXPORTS = \
  	CXXFLAGS="$(CXXFLAGS_FOR_TARGET)"; export CXXFLAGS; \
  	GFORTRAN="$(GFORTRAN_FOR_TARGET) $(XGCC_FLAGS_FOR_TARGET) $$TFLAGS"; export GFORTRAN; \
  	GOC="$(GOC_FOR_TARGET) $(XGCC_FLAGS_FOR_TARGET) $$TFLAGS"; export GOC; \
@@ -76,7 +95,7 @@ This implements building of libphobos library in GCC.
  	DLLTOOL="$(DLLTOOL_FOR_TARGET)"; export DLLTOOL; \
  	LD="$(COMPILER_LD_FOR_TARGET)"; export LD; \
  	LDFLAGS="$(LDFLAGS_FOR_TARGET)"; export LDFLAGS; \
-@@ -342,6 +346,7 @@ CXX_FOR_BUILD = @CXX_FOR_BUILD@
+@@ -342,6 +349,7 @@ CXX_FOR_BUILD = @CXX_FOR_BUILD@
  DLLTOOL_FOR_BUILD = @DLLTOOL_FOR_BUILD@
  GFORTRAN_FOR_BUILD = @GFORTRAN_FOR_BUILD@
  GOC_FOR_BUILD = @GOC_FOR_BUILD@
@@ -84,7 +103,15 @@ This implements building of libphobos library in GCC.
  LDFLAGS_FOR_BUILD = @LDFLAGS_FOR_BUILD@
  LD_FOR_BUILD = @LD_FOR_BUILD@
  NM_FOR_BUILD = @NM_FOR_BUILD@
-@@ -408,6 +413,7 @@ LIBCFLAGS = $(CFLAGS)
+@@ -399,6 +407,7 @@ STRIP = @STRIP@
+ WINDRES = @WINDRES@
+ WINDMC = @WINDMC@
+ 
++GDC = @GDC@
+ GNATBIND = @GNATBIND@
+ GNATMAKE = @GNATMAKE@
+ 
+@@ -408,6 +417,7 @@ LIBCFLAGS = $(CFLAGS)
  CXXFLAGS = @CXXFLAGS@
  LIBCXXFLAGS = $(CXXFLAGS) -fno-implicit-templates
  GOCFLAGS = $(CFLAGS)
@@ -92,7 +119,7 @@ This implements building of libphobos library in GCC.
  
  CREATE_GCOV = create_gcov
  
-@@ -564,6 +570,7 @@ CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @CXX_FOR_TARGET@
+@@ -564,6 +574,7 @@ CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @CXX_
  RAW_CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @RAW_CXX_FOR_TARGET@
  GFORTRAN_FOR_TARGET=$(STAGE_CC_WRAPPER) @GFORTRAN_FOR_TARGET@
  GOC_FOR_TARGET=$(STAGE_CC_WRAPPER) @GOC_FOR_TARGET@
@@ -100,7 +127,7 @@ This implements building of libphobos library in GCC.
  DLLTOOL_FOR_TARGET=@DLLTOOL_FOR_TARGET@
  LD_FOR_TARGET=@LD_FOR_TARGET@
  
-@@ -588,6 +595,7 @@ LIBCFLAGS_FOR_TARGET = $(CFLAGS_FOR_TARGET)
+@@ -588,6 +599,7 @@ LIBCFLAGS_FOR_TARGET = $(CFLAGS_FOR_TARG
  LIBCXXFLAGS_FOR_TARGET = $(CXXFLAGS_FOR_TARGET) -fno-implicit-templates
  LDFLAGS_FOR_TARGET = @LDFLAGS_FOR_TARGET@
  GOCFLAGS_FOR_TARGET = -O2 -g
@@ -108,7 +135,16 @@ This implements building of libphobos library in GCC.
  
  FLAGS_FOR_TARGET = @FLAGS_FOR_TARGET@
  SYSROOT_CFLAGS_FOR_TARGET = @SYSROOT_CFLAGS_FOR_TARGET@
-@@ -787,6 +795,8 @@ BASE_FLAGS_TO_PASS = \
+@@ -772,6 +784,8 @@ BASE_FLAGS_TO_PASS = \
+ 	"STAGE1_LANGUAGES=$(STAGE1_LANGUAGES)" \
+ 	"GNATBIND=$(GNATBIND)" \
+ 	"GNATMAKE=$(GNATMAKE)" \
++	"GDC=$(GDC)" \
++	"GDCFLAGS=$(GDCFLAGS)" \
+ 	"AR_FOR_TARGET=$(AR_FOR_TARGET)" \
+ 	"AS_FOR_TARGET=$(AS_FOR_TARGET)" \
+ 	"CC_FOR_TARGET=$(CC_FOR_TARGET)" \
+@@ -783,6 +797,8 @@ BASE_FLAGS_TO_PASS = \
  	"GFORTRAN_FOR_TARGET=$(GFORTRAN_FOR_TARGET)" \
  	"GOC_FOR_TARGET=$(GOC_FOR_TARGET)" \
  	"GOCFLAGS_FOR_TARGET=$(GOCFLAGS_FOR_TARGET)" \
@@ -117,7 +153,7 @@ This implements building of libphobos library in GCC.
  	"LD_FOR_TARGET=$(LD_FOR_TARGET)" \
  	"LIPO_FOR_TARGET=$(LIPO_FOR_TARGET)" \
  	"LDFLAGS_FOR_TARGET=$(LDFLAGS_FOR_TARGET)" \
-@@ -849,6 +859,7 @@ EXTRA_HOST_FLAGS = \
+@@ -845,6 +861,7 @@ EXTRA_HOST_FLAGS = \
  	'DLLTOOL=$(DLLTOOL)' \
  	'GFORTRAN=$(GFORTRAN)' \
  	'GOC=$(GOC)' \
@@ -125,7 +161,15 @@ This implements building of libphobos library in GCC.
  	'LD=$(LD)' \
  	'LIPO=$(LIPO)' \
  	'NM=$(NM)' \
-@@ -905,6 +916,8 @@ EXTRA_TARGET_FLAGS = \
+@@ -869,6 +886,7 @@ STAGE1_FLAGS_TO_PASS = \
+ POSTSTAGE1_FLAGS_TO_PASS = \
+ 	CC="$${CC}" CC_FOR_BUILD="$${CC_FOR_BUILD}" \
+ 	CXX="$${CXX}" CXX_FOR_BUILD="$${CXX_FOR_BUILD}" \
++	GDC="$${GDC}" GDC_FOR_BUILD="$${GDC_FOR_BUILD}" \
+ 	GNATBIND="$${GNATBIND}" \
+ 	LDFLAGS="$${LDFLAGS}" \
+ 	HOST_LIBS="$${HOST_LIBS}" \
+@@ -901,6 +919,8 @@ EXTRA_TARGET_FLAGS = \
  	'GFORTRAN=$$(GFORTRAN_FOR_TARGET) $$(XGCC_FLAGS_FOR_TARGET) $$(TFLAGS)' \
  	'GOC=$$(GOC_FOR_TARGET) $$(XGCC_FLAGS_FOR_TARGET) $$(TFLAGS)' \
  	'GOCFLAGS=$$(GOCFLAGS_FOR_TARGET)' \
@@ -134,7 +178,7 @@ This implements building of libphobos library in GCC.
  	'LD=$(COMPILER_LD_FOR_TARGET)' \
  	'LDFLAGS=$$(LDFLAGS_FOR_TARGET)' \
  	'LIBCFLAGS=$$(LIBCFLAGS_FOR_TARGET)' \
-@@ -1008,6 +1021,7 @@ configure-target:  \
+@@ -1003,6 +1023,7 @@ configure-target:  \
      maybe-configure-target-libobjc \
      maybe-configure-target-libgo \
      maybe-configure-target-libhsail-rt \
@@ -142,7 +186,7 @@ This implements building of libphobos library in GCC.
      maybe-configure-target-libtermcap \
      maybe-configure-target-winsup \
      maybe-configure-target-libgloss \
-@@ -1174,6 +1188,7 @@ all-target: maybe-all-target-libgfortran
+@@ -1168,6 +1189,7 @@ all-target: maybe-all-target-libgfortran
  all-target: maybe-all-target-libobjc
  all-target: maybe-all-target-libgo
  all-target: maybe-all-target-libhsail-rt
@@ -150,7 +194,7 @@ This implements building of libphobos library in GCC.
  all-target: maybe-all-target-libtermcap
  all-target: maybe-all-target-winsup
  all-target: maybe-all-target-libgloss
-@@ -1267,6 +1282,7 @@ info-target: maybe-info-target-libgfortran
+@@ -1260,6 +1282,7 @@ info-target: maybe-info-target-libgfortr
  info-target: maybe-info-target-libobjc
  info-target: maybe-info-target-libgo
  info-target: maybe-info-target-libhsail-rt
@@ -158,7 +202,7 @@ This implements building of libphobos library in GCC.
  info-target: maybe-info-target-libtermcap
  info-target: maybe-info-target-winsup
  info-target: maybe-info-target-libgloss
-@@ -1353,6 +1369,7 @@ dvi-target: maybe-dvi-target-libgfortran
+@@ -1345,6 +1368,7 @@ dvi-target: maybe-dvi-target-libgfortran
  dvi-target: maybe-dvi-target-libobjc
  dvi-target: maybe-dvi-target-libgo
  dvi-target: maybe-dvi-target-libhsail-rt
@@ -166,7 +210,7 @@ This implements building of libphobos library in GCC.
  dvi-target: maybe-dvi-target-libtermcap
  dvi-target: maybe-dvi-target-winsup
  dvi-target: maybe-dvi-target-libgloss
-@@ -1439,6 +1456,7 @@ pdf-target: maybe-pdf-target-libgfortran
+@@ -1430,6 +1454,7 @@ pdf-target: maybe-pdf-target-libgfortran
  pdf-target: maybe-pdf-target-libobjc
  pdf-target: maybe-pdf-target-libgo
  pdf-target: maybe-pdf-target-libhsail-rt
@@ -174,7 +218,7 @@ This implements building of libphobos library in GCC.
  pdf-target: maybe-pdf-target-libtermcap
  pdf-target: maybe-pdf-target-winsup
  pdf-target: maybe-pdf-target-libgloss
-@@ -1525,6 +1543,7 @@ html-target: maybe-html-target-libgfortran
+@@ -1515,6 +1540,7 @@ html-target: maybe-html-target-libgfortr
  html-target: maybe-html-target-libobjc
  html-target: maybe-html-target-libgo
  html-target: maybe-html-target-libhsail-rt
@@ -182,7 +226,7 @@ This implements building of libphobos library in GCC.
  html-target: maybe-html-target-libtermcap
  html-target: maybe-html-target-winsup
  html-target: maybe-html-target-libgloss
-@@ -1611,6 +1630,7 @@ TAGS-target: maybe-TAGS-target-libgfortran
+@@ -1600,6 +1626,7 @@ TAGS-target: maybe-TAGS-target-libgfortr
  TAGS-target: maybe-TAGS-target-libobjc
  TAGS-target: maybe-TAGS-target-libgo
  TAGS-target: maybe-TAGS-target-libhsail-rt
@@ -190,7 +234,7 @@ This implements building of libphobos library in GCC.
  TAGS-target: maybe-TAGS-target-libtermcap
  TAGS-target: maybe-TAGS-target-winsup
  TAGS-target: maybe-TAGS-target-libgloss
-@@ -1697,6 +1717,7 @@ install-info-target: maybe-install-info-target-libgfortran
+@@ -1685,6 +1712,7 @@ install-info-target: maybe-install-info-
  install-info-target: maybe-install-info-target-libobjc
  install-info-target: maybe-install-info-target-libgo
  install-info-target: maybe-install-info-target-libhsail-rt
@@ -198,7 +242,7 @@ This implements building of libphobos library in GCC.
  install-info-target: maybe-install-info-target-libtermcap
  install-info-target: maybe-install-info-target-winsup
  install-info-target: maybe-install-info-target-libgloss
-@@ -1783,6 +1804,7 @@ install-pdf-target: maybe-install-pdf-target-libgfortran
+@@ -1770,6 +1798,7 @@ install-pdf-target: maybe-install-pdf-ta
  install-pdf-target: maybe-install-pdf-target-libobjc
  install-pdf-target: maybe-install-pdf-target-libgo
  install-pdf-target: maybe-install-pdf-target-libhsail-rt
@@ -206,7 +250,7 @@ This implements building of libphobos library in GCC.
  install-pdf-target: maybe-install-pdf-target-libtermcap
  install-pdf-target: maybe-install-pdf-target-winsup
  install-pdf-target: maybe-install-pdf-target-libgloss
-@@ -1869,6 +1891,7 @@ install-html-target: maybe-install-html-target-libgfortran
+@@ -1855,6 +1884,7 @@ install-html-target: maybe-install-html-
  install-html-target: maybe-install-html-target-libobjc
  install-html-target: maybe-install-html-target-libgo
  install-html-target: maybe-install-html-target-libhsail-rt
@@ -214,7 +258,7 @@ This implements building of libphobos library in GCC.
  install-html-target: maybe-install-html-target-libtermcap
  install-html-target: maybe-install-html-target-winsup
  install-html-target: maybe-install-html-target-libgloss
-@@ -1955,6 +1978,7 @@ installcheck-target: maybe-installcheck-target-libgfortran
+@@ -1940,6 +1970,7 @@ installcheck-target: maybe-installcheck-
  installcheck-target: maybe-installcheck-target-libobjc
  installcheck-target: maybe-installcheck-target-libgo
  installcheck-target: maybe-installcheck-target-libhsail-rt
@@ -222,7 +266,7 @@ This implements building of libphobos library in GCC.
  installcheck-target: maybe-installcheck-target-libtermcap
  installcheck-target: maybe-installcheck-target-winsup
  installcheck-target: maybe-installcheck-target-libgloss
-@@ -2041,6 +2065,7 @@ mostlyclean-target: maybe-mostlyclean-target-libgfortran
+@@ -2025,6 +2056,7 @@ mostlyclean-target: maybe-mostlyclean-ta
  mostlyclean-target: maybe-mostlyclean-target-libobjc
  mostlyclean-target: maybe-mostlyclean-target-libgo
  mostlyclean-target: maybe-mostlyclean-target-libhsail-rt
@@ -230,7 +274,7 @@ This implements building of libphobos library in GCC.
  mostlyclean-target: maybe-mostlyclean-target-libtermcap
  mostlyclean-target: maybe-mostlyclean-target-winsup
  mostlyclean-target: maybe-mostlyclean-target-libgloss
-@@ -2127,6 +2152,7 @@ clean-target: maybe-clean-target-libgfortran
+@@ -2110,6 +2142,7 @@ clean-target: maybe-clean-target-libgfor
  clean-target: maybe-clean-target-libobjc
  clean-target: maybe-clean-target-libgo
  clean-target: maybe-clean-target-libhsail-rt
@@ -238,7 +282,7 @@ This implements building of libphobos library in GCC.
  clean-target: maybe-clean-target-libtermcap
  clean-target: maybe-clean-target-winsup
  clean-target: maybe-clean-target-libgloss
-@@ -2213,6 +2239,7 @@ distclean-target: maybe-distclean-target-libgfortran
+@@ -2195,6 +2228,7 @@ distclean-target: maybe-distclean-target
  distclean-target: maybe-distclean-target-libobjc
  distclean-target: maybe-distclean-target-libgo
  distclean-target: maybe-distclean-target-libhsail-rt
@@ -246,7 +290,7 @@ This implements building of libphobos library in GCC.
  distclean-target: maybe-distclean-target-libtermcap
  distclean-target: maybe-distclean-target-winsup
  distclean-target: maybe-distclean-target-libgloss
-@@ -2299,6 +2326,7 @@ maintainer-clean-target: maybe-maintainer-clean-target-libgfortran
+@@ -2280,6 +2314,7 @@ maintainer-clean-target: maybe-maintaine
  maintainer-clean-target: maybe-maintainer-clean-target-libobjc
  maintainer-clean-target: maybe-maintainer-clean-target-libgo
  maintainer-clean-target: maybe-maintainer-clean-target-libhsail-rt
@@ -254,7 +298,7 @@ This implements building of libphobos library in GCC.
  maintainer-clean-target: maybe-maintainer-clean-target-libtermcap
  maintainer-clean-target: maybe-maintainer-clean-target-winsup
  maintainer-clean-target: maybe-maintainer-clean-target-libgloss
-@@ -2441,6 +2469,7 @@ check-target:  \
+@@ -2421,6 +2456,7 @@ check-target:  \
      maybe-check-target-libobjc \
      maybe-check-target-libgo \
      maybe-check-target-libhsail-rt \
@@ -262,7 +306,7 @@ This implements building of libphobos library in GCC.
      maybe-check-target-libtermcap \
      maybe-check-target-winsup \
      maybe-check-target-libgloss \
-@@ -2623,6 +2652,7 @@ install-target:  \
+@@ -2602,6 +2638,7 @@ install-target:  \
      maybe-install-target-libobjc \
      maybe-install-target-libgo \
      maybe-install-target-libhsail-rt \
@@ -270,7 +314,7 @@ This implements building of libphobos library in GCC.
      maybe-install-target-libtermcap \
      maybe-install-target-winsup \
      maybe-install-target-libgloss \
-@@ -2729,6 +2759,7 @@ install-strip-target:  \
+@@ -2707,6 +2744,7 @@ install-strip-target:  \
      maybe-install-strip-target-libobjc \
      maybe-install-strip-target-libgo \
      maybe-install-strip-target-libhsail-rt \
@@ -278,7 +322,7 @@ This implements building of libphobos library in GCC.
      maybe-install-strip-target-libtermcap \
      maybe-install-strip-target-winsup \
      maybe-install-strip-target-libgloss \
-@@ -48681,6 +48712,464 @@ maintainer-clean-target-libhsail-rt:
+@@ -48201,6 +48239,464 @@ maintainer-clean-target-libhsail-rt:
  
  
  
@@ -743,7 +787,7 @@ This implements building of libphobos library in GCC.
  .PHONY: configure-target-libtermcap maybe-configure-target-libtermcap
  maybe-configure-target-libtermcap:
  @if gcc-bootstrap
-@@ -54062,6 +54551,14 @@ check-gcc-brig:
+@@ -53582,6 +54078,14 @@ check-gcc-brig:
  	(cd gcc && $(MAKE) $(GCC_FLAGS_TO_PASS) check-brig);
  check-brig: check-gcc-brig check-target-libhsail-rt
  
@@ -758,7 +802,7 @@ This implements building of libphobos library in GCC.
  
  # The gcc part of install-no-fixedincludes, which relies on an intimate
  # knowledge of how a number of gcc internal targets (inter)operate.  Delegate.
-@@ -57264,6 +57761,7 @@ configure-target-libgfortran: stage_last
+@@ -56783,6 +57287,7 @@ configure-target-libgfortran: stage_last
  configure-target-libobjc: stage_last
  configure-target-libgo: stage_last
  configure-target-libhsail-rt: stage_last
@@ -766,7 +810,7 @@ This implements building of libphobos library in GCC.
  configure-target-libtermcap: stage_last
  configure-target-winsup: stage_last
  configure-target-libgloss: stage_last
-@@ -57300,6 +57798,7 @@ configure-target-libgfortran: maybe-all-gcc
+@@ -56818,6 +57323,7 @@ configure-target-libgfortran: maybe-all-
  configure-target-libobjc: maybe-all-gcc
  configure-target-libgo: maybe-all-gcc
  configure-target-libhsail-rt: maybe-all-gcc
@@ -774,7 +818,7 @@ This implements building of libphobos library in GCC.
  configure-target-libtermcap: maybe-all-gcc
  configure-target-winsup: maybe-all-gcc
  configure-target-libgloss: maybe-all-gcc
-@@ -58416,6 +58915,11 @@ configure-target-libgo: maybe-all-target-libstdc++-v3
+@@ -57934,6 +58440,11 @@ configure-target-libgo: maybe-all-target
  all-target-libgo: maybe-all-target-libbacktrace
  all-target-libgo: maybe-all-target-libffi
  all-target-libgo: maybe-all-target-libatomic
@@ -786,7 +830,7 @@ This implements building of libphobos library in GCC.
  configure-target-libstdc++-v3: maybe-configure-target-libgomp
  
  configure-stage1-target-libstdc++-v3: maybe-configure-stage1-target-libgomp
-@@ -58465,6 +58969,7 @@ all-target-liboffloadmic: maybe-all-target-libgomp
+@@ -57983,6 +58494,7 @@ all-target-liboffloadmic: maybe-all-targ
  install-target-libgo: maybe-install-target-libatomic
  install-target-libgfortran: maybe-install-target-libquadmath
  install-target-libgfortran: maybe-install-target-libgcc
@@ -794,7 +838,7 @@ This implements building of libphobos library in GCC.
  install-target-libsanitizer: maybe-install-target-libstdc++-v3
  install-target-libsanitizer: maybe-install-target-libgcc
  install-target-libvtv: maybe-install-target-libstdc++-v3
-@@ -58552,6 +59057,7 @@ configure-target-libgfortran: maybe-all-target-libgcc
+@@ -58067,6 +58579,7 @@ configure-target-libgfortran: maybe-all-
  configure-target-libobjc: maybe-all-target-libgcc
  configure-target-libgo: maybe-all-target-libgcc
  configure-target-libhsail-rt: maybe-all-target-libgcc
@@ -802,7 +846,7 @@ This implements building of libphobos library in GCC.
  configure-target-libtermcap: maybe-all-target-libgcc
  configure-target-winsup: maybe-all-target-libgcc
  configure-target-libgloss: maybe-all-target-libgcc
-@@ -58595,6 +59101,8 @@ configure-target-libgo: maybe-all-target-newlib maybe-all-target-libgloss
+@@ -58107,6 +58620,8 @@ configure-target-libgo: maybe-all-target
  
  configure-target-libhsail-rt: maybe-all-target-newlib maybe-all-target-libgloss
  
@@ -830,7 +874,17 @@ This implements building of libphobos library in GCC.
  	AR="$(AR)"; export AR; \
  	AS="$(AS)"; export AS; \
  	CC_FOR_BUILD="$(CC_FOR_BUILD)"; export CC_FOR_BUILD; \
-@@ -281,6 +284,7 @@ BASE_TARGET_EXPORTS = \
+@@ -259,6 +262,9 @@ POSTSTAGE1_HOST_EXPORTS = \
+ 	CC_FOR_BUILD="$$CC"; export CC_FOR_BUILD; \
+ 	$(POSTSTAGE1_CXX_EXPORT) \
+ 	$(LTO_EXPORTS) \
++	GDC="$$r/$(HOST_SUBDIR)/prev-gcc/gdc$(exeext) -B$$r/$(HOST_SUBDIR)/prev-gcc/ \
++	  -B$(build_tooldir)/bin/ $(GDC_FLAGS_FOR_TARGET)"; export GDC; \
++	GDC_FOR_BUILD="$$GDC"; export GDC_FOR_BUILD; \
+ 	GNATBIND="$$r/$(HOST_SUBDIR)/prev-gcc/gnatbind"; export GNATBIND; \
+ 	LDFLAGS="$(POSTSTAGE1_LDFLAGS) $(BOOT_LDFLAGS)"; export LDFLAGS; \
+ 	HOST_LIBS="$(POSTSTAGE1_LIBS)"; export HOST_LIBS;
+@@ -281,6 +287,7 @@ BASE_TARGET_EXPORTS = \
  	CXXFLAGS="$(CXXFLAGS_FOR_TARGET)"; export CXXFLAGS; \
  	GFORTRAN="$(GFORTRAN_FOR_TARGET) $(XGCC_FLAGS_FOR_TARGET) $$TFLAGS"; export GFORTRAN; \
  	GOC="$(GOC_FOR_TARGET) $(XGCC_FLAGS_FOR_TARGET) $$TFLAGS"; export GOC; \
@@ -838,7 +892,7 @@ This implements building of libphobos library in GCC.
  	DLLTOOL="$(DLLTOOL_FOR_TARGET)"; export DLLTOOL; \
  	LD="$(COMPILER_LD_FOR_TARGET)"; export LD; \
  	LDFLAGS="$(LDFLAGS_FOR_TARGET)"; export LDFLAGS; \
-@@ -345,6 +349,7 @@ CXX_FOR_BUILD = @CXX_FOR_BUILD@
+@@ -345,6 +352,7 @@ CXX_FOR_BUILD = @CXX_FOR_BUILD@
  DLLTOOL_FOR_BUILD = @DLLTOOL_FOR_BUILD@
  GFORTRAN_FOR_BUILD = @GFORTRAN_FOR_BUILD@
  GOC_FOR_BUILD = @GOC_FOR_BUILD@
@@ -846,7 +900,15 @@ This implements building of libphobos library in GCC.
  LDFLAGS_FOR_BUILD = @LDFLAGS_FOR_BUILD@
  LD_FOR_BUILD = @LD_FOR_BUILD@
  NM_FOR_BUILD = @NM_FOR_BUILD@
-@@ -411,6 +416,7 @@ LIBCFLAGS = $(CFLAGS)
+@@ -402,6 +410,7 @@ STRIP = @STRIP@
+ WINDRES = @WINDRES@
+ WINDMC = @WINDMC@
+ 
++GDC = @GDC@
+ GNATBIND = @GNATBIND@
+ GNATMAKE = @GNATMAKE@
+ 
+@@ -411,6 +420,7 @@ LIBCFLAGS = $(CFLAGS)
  CXXFLAGS = @CXXFLAGS@
  LIBCXXFLAGS = $(CXXFLAGS) -fno-implicit-templates
  GOCFLAGS = $(CFLAGS)
@@ -854,7 +916,7 @@ This implements building of libphobos library in GCC.
  
  CREATE_GCOV = create_gcov
  
-@@ -487,6 +493,7 @@ CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @CXX_FOR_TARGET@
+@@ -487,6 +497,7 @@ CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @CXX_
  RAW_CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @RAW_CXX_FOR_TARGET@
  GFORTRAN_FOR_TARGET=$(STAGE_CC_WRAPPER) @GFORTRAN_FOR_TARGET@
  GOC_FOR_TARGET=$(STAGE_CC_WRAPPER) @GOC_FOR_TARGET@
@@ -862,7 +924,7 @@ This implements building of libphobos library in GCC.
  DLLTOOL_FOR_TARGET=@DLLTOOL_FOR_TARGET@
  LD_FOR_TARGET=@LD_FOR_TARGET@
  
-@@ -511,6 +518,7 @@ LIBCFLAGS_FOR_TARGET = $(CFLAGS_FOR_TARGET)
+@@ -511,6 +522,7 @@ LIBCFLAGS_FOR_TARGET = $(CFLAGS_FOR_TARG
  LIBCXXFLAGS_FOR_TARGET = $(CXXFLAGS_FOR_TARGET) -fno-implicit-templates
  LDFLAGS_FOR_TARGET = @LDFLAGS_FOR_TARGET@
  GOCFLAGS_FOR_TARGET = -O2 -g
@@ -870,7 +932,7 @@ This implements building of libphobos library in GCC.
  
  FLAGS_FOR_TARGET = @FLAGS_FOR_TARGET@
  SYSROOT_CFLAGS_FOR_TARGET = @SYSROOT_CFLAGS_FOR_TARGET@
-@@ -612,6 +620,7 @@ EXTRA_HOST_FLAGS = \
+@@ -612,6 +624,7 @@ EXTRA_HOST_FLAGS = \
  	'DLLTOOL=$(DLLTOOL)' \
  	'GFORTRAN=$(GFORTRAN)' \
  	'GOC=$(GOC)' \
@@ -878,7 +940,15 @@ This implements building of libphobos library in GCC.
  	'LD=$(LD)' \
  	'LIPO=$(LIPO)' \
  	'NM=$(NM)' \
-@@ -668,6 +677,8 @@ EXTRA_TARGET_FLAGS = \
+@@ -636,6 +649,7 @@ STAGE1_FLAGS_TO_PASS = \
+ POSTSTAGE1_FLAGS_TO_PASS = \
+ 	CC="$${CC}" CC_FOR_BUILD="$${CC_FOR_BUILD}" \
+ 	CXX="$${CXX}" CXX_FOR_BUILD="$${CXX_FOR_BUILD}" \
++	GDC="$${GDC}" GDC_FOR_BUILD="$${GDC_FOR_BUILD}" \
+ 	GNATBIND="$${GNATBIND}" \
+ 	LDFLAGS="$${LDFLAGS}" \
+ 	HOST_LIBS="$${HOST_LIBS}" \
+@@ -668,6 +682,8 @@ EXTRA_TARGET_FLAGS = \
  	'GFORTRAN=$$(GFORTRAN_FOR_TARGET) $$(XGCC_FLAGS_FOR_TARGET) $$(TFLAGS)' \
  	'GOC=$$(GOC_FOR_TARGET) $$(XGCC_FLAGS_FOR_TARGET) $$(TFLAGS)' \
  	'GOCFLAGS=$$(GOCFLAGS_FOR_TARGET)' \
@@ -897,7 +967,7 @@ This implements building of libphobos library in GCC.
  				CXXFLAGS="$(CXXFLAGS) $${flags}" \
  				LIBCFLAGS="$(LIBCFLAGS) $${flags}" \
  				LIBCXXFLAGS="$(LIBCXXFLAGS) $${flags}" \
-@@ -745,7 +746,7 @@ if [ -n "${multidirs}" ] && [ -z "${ml_norecursion}" ]; then
+@@ -745,7 +746,7 @@ if [ -n "${multidirs}" ] && [ -z "${ml_n
          break
        fi
      done
@@ -906,7 +976,7 @@ This implements building of libphobos library in GCC.
  
      if [ "${with_target_subdir}" = "." ]; then
  	CC_=$CC' '
-@@ -753,6 +754,7 @@ if [ -n "${multidirs}" ] && [ -z "${ml_norecursion}" ]; then
+@@ -753,6 +754,7 @@ if [ -n "${multidirs}" ] && [ -z "${ml_n
  	F77_=$F77' '
  	GFORTRAN_=$GFORTRAN' '
  	GOC_=$GOC' '
@@ -914,7 +984,7 @@ This implements building of libphobos library in GCC.
      else
  	# Create a regular expression that matches any string as long
  	# as ML_POPDIR.
-@@ -817,6 +819,18 @@ if [ -n "${multidirs}" ] && [ -z "${ml_norecursion}" ]; then
+@@ -817,6 +819,18 @@ if [ -n "${multidirs}" ] && [ -z "${ml_n
  	  esac
  	done
  
@@ -977,7 +1047,7 @@ This implements building of libphobos library in GCC.
    AR_FOR_TARGET
                AR for the target
    AS_FOR_TARGET
-@@ -2766,7 +2771,8 @@ target_libraries="target-libgcc \
+@@ -2765,7 +2770,8 @@ target_libraries="target-libgcc \
  		target-libffi \
  		target-libobjc \
  		target-libada \
@@ -987,7 +1057,7 @@ This implements building of libphobos library in GCC.
  
  # these tools are built using the target libraries, and are intended to
  # run only in the target environment
-@@ -3960,6 +3966,7 @@ if test "${build}" != "${host}" ; then
+@@ -3936,6 +3942,7 @@ if test "${build}" != "${host}" ; then
    CXX_FOR_BUILD=${CXX_FOR_BUILD-g++}
    GFORTRAN_FOR_BUILD=${GFORTRAN_FOR_BUILD-gfortran}
    GOC_FOR_BUILD=${GOC_FOR_BUILD-gccgo}
@@ -995,7 +1065,7 @@ This implements building of libphobos library in GCC.
    DLLTOOL_FOR_BUILD=${DLLTOOL_FOR_BUILD-dlltool}
    LD_FOR_BUILD=${LD_FOR_BUILD-ld}
    NM_FOR_BUILD=${NM_FOR_BUILD-nm}
-@@ -3973,6 +3980,7 @@ else
+@@ -3949,6 +3956,7 @@ else
    CXX_FOR_BUILD="\$(CXX)"
    GFORTRAN_FOR_BUILD="\$(GFORTRAN)"
    GOC_FOR_BUILD="\$(GOC)"
@@ -1003,7 +1073,7 @@ This implements building of libphobos library in GCC.
    DLLTOOL_FOR_BUILD="\$(DLLTOOL)"
    LD_FOR_BUILD="\$(LD)"
    NM_FOR_BUILD="\$(NM)"
-@@ -7690,6 +7698,7 @@ done
+@@ -7666,6 +7674,7 @@ done
  
  
  
@@ -1011,7 +1081,7 @@ This implements building of libphobos library in GCC.
  # Generate default definitions for YACC, M4, LEX and other programs that run
  # on the build machine.  These are used if the Makefile can't locate these
  # programs in objdir.
-@@ -10744,6 +10753,167 @@ fi
+@@ -10720,6 +10729,167 @@ fi
  
  
  
@@ -1179,10 +1249,16 @@ This implements building of libphobos library in GCC.
  cat > conftest.c << \EOF
  #ifdef __GNUC__
    gcc_yay;
-@@ -14140,6 +14310,51 @@ $as_echo "pre-installed" >&6; }
-   fi
- fi
- 
+@@ -14110,6 +14280,51 @@ $as_echo "pre-installed in $ac_dir" >&6;
+     { $as_echo "$as_me:${as_lineno-$LINENO}: result: host tool" >&5
+ $as_echo "host tool" >&6; }
+   else
++    # We need a cross tool
++    { $as_echo "$as_me:${as_lineno-$LINENO}: result: pre-installed" >&5
++$as_echo "pre-installed" >&6; }
++  fi
++fi
++
 +{ $as_echo "$as_me:${as_lineno-$LINENO}: checking where to find the target gdc" >&5
 +$as_echo_n "checking where to find the target gdc... " >&6; }
 +if test "x${build}" != "x${host}" ; then
@@ -1222,18 +1298,12 @@ This implements building of libphobos library in GCC.
 +    { $as_echo "$as_me:${as_lineno-$LINENO}: result: host tool" >&5
 +$as_echo "host tool" >&6; }
 +  else
-+    # We need a cross tool
-+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: pre-installed" >&5
-+$as_echo "pre-installed" >&6; }
-+  fi
-+fi
-+
- { $as_echo "$as_me:${as_lineno-$LINENO}: checking where to find the target ld" >&5
- $as_echo_n "checking where to find the target ld... " >&6; }
- if test "x${build}" != "x${host}" ; then
+     # We need a cross tool
+     { $as_echo "$as_me:${as_lineno-$LINENO}: result: pre-installed" >&5
+ $as_echo "pre-installed" >&6; }
 --- a/configure.ac
 +++ b/configure.ac
-@@ -165,7 +165,8 @@ target_libraries="target-libgcc \
+@@ -164,7 +164,8 @@ target_libraries="target-libgcc \
  		target-libffi \
  		target-libobjc \
  		target-libada \
@@ -1243,7 +1313,7 @@ This implements building of libphobos library in GCC.
  
  # these tools are built using the target libraries, and are intended to
  # run only in the target environment
-@@ -1269,6 +1270,7 @@ if test "${build}" != "${host}" ; then
+@@ -1248,6 +1249,7 @@ if test "${build}" != "${host}" ; then
    CXX_FOR_BUILD=${CXX_FOR_BUILD-g++}
    GFORTRAN_FOR_BUILD=${GFORTRAN_FOR_BUILD-gfortran}
    GOC_FOR_BUILD=${GOC_FOR_BUILD-gccgo}
@@ -1251,7 +1321,7 @@ This implements building of libphobos library in GCC.
    DLLTOOL_FOR_BUILD=${DLLTOOL_FOR_BUILD-dlltool}
    LD_FOR_BUILD=${LD_FOR_BUILD-ld}
    NM_FOR_BUILD=${NM_FOR_BUILD-nm}
-@@ -1282,6 +1284,7 @@ else
+@@ -1261,6 +1263,7 @@ else
    CXX_FOR_BUILD="\$(CXX)"
    GFORTRAN_FOR_BUILD="\$(GFORTRAN)"
    GOC_FOR_BUILD="\$(GOC)"
@@ -1259,7 +1329,7 @@ This implements building of libphobos library in GCC.
    DLLTOOL_FOR_BUILD="\$(DLLTOOL)"
    LD_FOR_BUILD="\$(LD)"
    NM_FOR_BUILD="\$(NM)"
-@@ -3269,6 +3272,7 @@ AC_SUBST(CXX_FOR_BUILD)
+@@ -3248,6 +3251,7 @@ AC_SUBST(CXX_FOR_BUILD)
  AC_SUBST(DLLTOOL_FOR_BUILD)
  AC_SUBST(GFORTRAN_FOR_BUILD)
  AC_SUBST(GOC_FOR_BUILD)
@@ -1267,7 +1337,7 @@ This implements building of libphobos library in GCC.
  AC_SUBST(LDFLAGS_FOR_BUILD)
  AC_SUBST(LD_FOR_BUILD)
  AC_SUBST(NM_FOR_BUILD)
-@@ -3378,6 +3382,7 @@ NCN_STRICT_CHECK_TARGET_TOOLS(CXX_FOR_TARGET, c++ g++ cxx gxx)
+@@ -3357,6 +3361,7 @@ NCN_STRICT_CHECK_TARGET_TOOLS(CXX_FOR_TA
  NCN_STRICT_CHECK_TARGET_TOOLS(GCC_FOR_TARGET, gcc, ${CC_FOR_TARGET})
  NCN_STRICT_CHECK_TARGET_TOOLS(GFORTRAN_FOR_TARGET, gfortran)
  NCN_STRICT_CHECK_TARGET_TOOLS(GOC_FOR_TARGET, gccgo)
@@ -1275,7 +1345,7 @@ This implements building of libphobos library in GCC.
  
  ACX_CHECK_INSTALLED_TARGET_TOOL(AR_FOR_TARGET, ar)
  ACX_CHECK_INSTALLED_TARGET_TOOL(AS_FOR_TARGET, as)
-@@ -3411,6 +3416,8 @@ GCC_TARGET_TOOL(gfortran, GFORTRAN_FOR_TARGET, GFORTRAN,
+@@ -3390,6 +3395,8 @@ GCC_TARGET_TOOL(gfortran, GFORTRAN_FOR_T
  		[gcc/gfortran -B$$r/$(HOST_SUBDIR)/gcc/], fortran)
  GCC_TARGET_TOOL(gccgo, GOC_FOR_TARGET, GOC,
  		[gcc/gccgo -B$$r/$(HOST_SUBDIR)/gcc/], go)


### PR DESCRIPTION
Present here are also toplevel changes from the ddmd PR, just the addition of more `GDC` and `GDCFLAGS` variables.