### PR TITLE
Add quilt option to setup-gcc.sh script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # gdc specific    #
 ###################
 dev/
+gcc/d/patches/series
 
 # libphobos specific #
 ######################

--- a/setup-gcc.sh
+++ b/setup-gcc.sh
@@ -2,6 +2,7 @@
 d_gdcsrc=$(realpath $(dirname $0))
 d_gccsrc=
 d_update_gcc=0
+d_quilt_patch=0
 top=$(pwd)
 
 # -1. Make sure we know where the top-level GCC source directory is
@@ -18,6 +19,7 @@ fi
 # Read command line arguments
 for arg in "$@"; do
     case "$arg" in
+        --quilt) d_quilt_patch=1 ;;
         --update) d_update_gcc=1 ;;
         *)
             if test -z "$d_gccsrc" && test -d "$arg" && test -d "$arg/gcc"; then
@@ -51,13 +53,28 @@ fi
 echo "found gcc version $gcc_ver"
 gcc_patch_key=${gcc_ver}.patch
 
-# 1. Determine if this version of GCC is supported
+# Determine if this version of GCC is supported
 if test ! -f "$d_gdcsrc/gcc/d/patches/patch-gcc-$gcc_patch_key"; then
     echo "This version of GCC ($gcc_ver) is not supported."
     exit 1
 fi
 
-# 1. Remove d sources from d_gccsrc if already exist
+# 1. Clean the GCC tree if any changes were already made to it.
+
+# Remove any applied patches, if managed by quilt.
+if test $d_quilt_patch -eq 1 && test -d "$d_gccsrc/.pc"; then
+  cd $d_gccsrc && \
+    quilt pop -a && \
+    rm -r ".pc"
+  cd $top
+
+  if test -d "$d_gccsrc/.pc"; then
+    echo "error: cannot update gcc source, please remove applied quilt patches by hand."
+    exit 1
+  fi
+fi
+
+# Remove D sources from d_gccsrc if already exist
 test -h "$d_gccsrc/gcc/d" && rm "$d_gccsrc/gcc/d"
 test -d "$d_gccsrc/libphobos" && rm -r "$d_gccsrc/libphobos"
 if test -e "$d_gccsrc/gcc/d" -o -e "$d_gccsrc/libphobos"; then
@@ -65,8 +82,8 @@ if test -e "$d_gccsrc/gcc/d" -o -e "$d_gccsrc/libphobos"; then
     exit 1
 fi
 
+# Remove testsuite sources
 d_test=$d_gccsrc/gcc/testsuite
-# remove testsuite sources
 test -d "$d_test/gdc.dg" && rm -r "$d_test/gdc.dg"
 test -d "$d_test/gdc.test" && rm -r "$d_test/gdc.test"
 test -e "$d_test/lib/gdc.exp" && rm "$d_test/lib/gdc.exp"
@@ -75,7 +92,6 @@ if test -e "$d_test/gdc.test" -o -e "$d_test/lib/gdc.exp" -o -e "$d_test/lib/gdc
     echo "error: cannot update gcc source, please remove D testsuite sources by hand."
     exit 1
 fi
-
 
 # 2. Copy sources
 ln -s "$d_gdcsrc/gcc/d" "$d_gccsrc/gcc/d"   && \
@@ -93,24 +109,39 @@ if test $d_update_gcc -eq 1; then
 fi
 
 
-# 3. Patch the top-level directory
+# 3. Patch the GCC tree, both toplevel and subdirectories.
 #
 # If the patch for the top-level Makefile.in doesn't take, you can regenerate
 # it with:
 #   autogen -T Makefile.tpl Makefile.def
 #
 # You will need the autogen package to do this. (http://autogen.sf.net/)
-cd $d_gccsrc && \
-  patch -p1 -i gcc/d/patches/patch-toplev-${gcc_patch_key} && \
-  cd $top || exit 1
+#
+# If managing the patch series with quilt, then will also initialize metadata.
+# Existing patches can be refreshed using:
+#   quilt refresh -p ab --no-index --sort
+if test $d_quilt_patch -eq 1; then
+  cd $d_gccsrc && \
+    mkdir -p .pc && \
+    echo "gcc/d/patches" > .pc/.quilt_patches && \
+    echo "series" > .pc/.quilt_series || exit 1
 
+  cat > gcc/d/patches/series << EOF
+patch-toplev-${gcc_patch_key}
+patch-gcc-${gcc_patch_key}
+patch-targetdm-${gcc_patch_key}
+EOF
 
-# 4. Patch the gcc subdirectory
-cd $d_gccsrc && \
-  patch -p1 -i gcc/d/patches/patch-gcc-${gcc_patch_key} && \
-  patch -p1 -i gcc/d/patches/patch-targetdm-${gcc_patch_key} && \
-  cd $top || exit 1
-
+  quilt upgrade && \
+    quilt push -a && \
+    cd $top || exit 1
+else
+  cd $d_gccsrc && \
+    patch -p1 -i gcc/d/patches/patch-toplev-${gcc_patch_key} && \
+    patch -p1 -i gcc/d/patches/patch-gcc-${gcc_patch_key} && \
+    patch -p1 -i gcc/d/patches/patch-targetdm-${gcc_patch_key} && \
+    cd $top || exit 1
+fi
 
 echo "GDC setup complete."
 exit 0


### PR DESCRIPTION
Patch maintenance is a chore, especially when it comes to altering or rebasing one.

Quilt is a simple tool I've used in the past to make such management of patches easier.

For example, rebasing all patches can be done in the following way (inside the gcc tree):
```
quilt pop -a
while quilt push; do quilt refresh; done
```

Or making a change to gcc.
```
quilt add source/file.c  # if file is not present in the patch.
${editor} source/file.c
quilt refresh
```

Viewing the diff of the current patch
```
quilt diff
```