### PR TITLE
Fix Bug 285: Wrong codegen on optimized strlen()

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,9 @@
+2018-03-11  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* expr.cc (ExprVisitor::visit(StringExp)): Include null terminator
+	in length when calling build_String.  Generate static array string
+	literals as array constructors.
+
 2018-03-04  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-lang.cc (d_handle_option): Rename OPT_fintfc cases to OPT_H.

--- a/gcc/testsuite/gdc.dg/runnable.d
+++ b/gcc/testsuite/gdc.dg/runnable.d
@@ -1531,6 +1531,22 @@ void test273()
 
 /******************************************/
 
+// Bug 285
+
+inout(char)[] test285a(inout(char)* s) @nogc @system pure nothrow
+{
+    import core.stdc.string : strlen;
+    return s ? s[0 .. strlen(s)] : null;
+}
+
+void test285()
+{
+    assert(test285a(null) == null);
+    assert(test285a("foo") == "foo");
+}
+
+/******************************************/
+
 void main()
 {
     test2();
@@ -1564,6 +1580,7 @@ void main()
     test248();
     test250();
     test273();
+    test285();
 
     printf("Success!\n");
 }


### PR DESCRIPTION
- Adds the null terminator to the length in the compile-time string value.
- Rewrite static array string literals as constant constructors, eg: `"foo" -> {'f','o','o'}`.