### PR TITLE
Fix assertion failure in datetime.stopwatch when compiling with -O2

### DIFF
--- a/libphobos/src/std/datetime/stopwatch.d
+++ b/libphobos/src/std/datetime/stopwatch.d
@@ -403,7 +403,10 @@ Duration[fun.length] benchmark(fun...)(uint n)
     void f0() nothrow {}
     void f1() nothrow { auto b = to!string(a); }
     auto r = benchmark!(f0, f1)(1000);
-    assert(r[0] > Duration.zero);
+    version (GNU)
+        assert(r[0] >= Duration.zero);
+    else
+        assert(r[0] > Duration.zero);
     assert(r[1] > Duration.zero);
     assert(r[1] > r[0]);
     assert(r[0] < seconds(1));


### PR DESCRIPTION
The benchmark could take no time at all because the benchmark is inlined, and the loop is removed.