### PR TITLE
Fix Bug 289: Linking has wrong order of libraries.

### DIFF
--- a/libphobos/src/libgphobos.spec.in
+++ b/libphobos/src/libgphobos.spec.in
@@ -5,4 +5,4 @@
 #
 
 %rename lib liborig_gdc_renamed
-*lib: %(liborig_gdc_renamed) @SPEC_PHOBOS_DEPS@
+*lib: @SPEC_PHOBOS_DEPS@ %(liborig_gdc_renamed)


### PR DESCRIPTION
https://bugzilla.gdcproject.org/show_bug.cgi?id=289