### PR TITLE
Add doing_semantic_analysis_p gate.

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,11 @@
+2018-04-02  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-lang.cc (doing_semantic_analysis_p): New variable.
+	(d_parse_file): Set when in semantic pass.
+	* d-tree.h (doing_semantic_analysis_p): Add declaration.
+	* intrinsics.cc (maybe_expand_intrinsic): Test for
+	doing_semantic_analysis_p.
+
 2018-03-18  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-codegen.cc (stabilize_expr): Move modify expression rewrite...

--- a/gcc/d/d-lang.cc
+++ b/gcc/d/d-lang.cc
@@ -53,6 +53,9 @@ along with GCC; see the file COPYING3.  If not see
 /* Array of D frontend type/decl nodes.  */
 tree d_global_trees[DTI_MAX];
 
+/* True if compilation is currently inside the D frontend semantic passes.  */
+bool doing_semantic_analysis_p = false;
+
 /* Options handled by the compiler that are separate from the frontend.  */
 struct d_option_data
 {
@@ -1100,6 +1103,8 @@ d_parse_file (void)
     goto had_errors;
 
   /* Do semantic analysis.  */
+  doing_semantic_analysis_p = true;
+
   for (size_t i = 0; i < modules.dim; i++)
     {
       Module *m = modules[i];
@@ -1171,6 +1176,7 @@ d_parse_file (void)
     goto had_errors;
 
   /* Generate output files.  */
+  doing_semantic_analysis_p = false;
 
   if (Module::rootModule)
     {

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -461,6 +461,12 @@ enum libcall_fn
   LIBCALL_LAST,
 };
 
+/* Gate for when the D frontend make an early call into the codegen pass, such
+   as when it requires target information or CTFE evaluation.  As full semantic
+   may not be completed, we only want to build the superficial tree structure
+   without finishing any decls or types.  */
+extern bool doing_semantic_analysis_p;
+
 /* In d-attribs.c.  */
 extern tree insert_type_attribute (tree, const char *, tree = NULL_TREE);
 extern tree insert_decl_attribute (tree, const char *, tree = NULL_TREE);

--- a/gcc/d/intrinsics.cc
+++ b/gcc/d/intrinsics.cc
@@ -639,8 +639,8 @@ maybe_expand_intrinsic (tree callexp)
   if (TREE_CODE (callee) != FUNCTION_DECL)
     return callexp;
 
-  /* Need a better way to determine if we are compiling for CTFE or not.  */
-  if (DECL_BUILT_IN_CTFE (callee) && d_function_chain)
+  /* Don't expand CTFE-only intrinsics outside of semantic processing.  */
+  if (DECL_BUILT_IN_CTFE (callee) && !doing_semantic_analysis_p)
     {
       clear_intrinsic_flag (callexp);
       return callexp;


### PR DESCRIPTION
So full codegen is not done during any semantic passes.

Only used in `maybe_expand_intrinsic` for now.  Could be used for `build_ctype` and `get_symbol_decl` later.