### PR TITLE
Add build_unary_op, use it instead of stabilize_expr for various unary ops

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -2,6 +2,7 @@
 
 	* d-codegen.cc (build_unary_op): New function.
 	(build_nop): Use build_unary_op.
+	(build_address): Move expression handling to build_unary_op.
 
 2018-04-02  Iain Buclaw  <ibuclaw@gdcproject.org>
 

--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2018-05-01  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* d-codegen.cc (build_unary_op): New function.
+	(build_nop): Use build_unary_op.
+
 2018-04-02  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-lang.cc (doing_semantic_analysis_p): New variable.

--- a/gcc/d/d-codegen.cc
+++ b/gcc/d/d-codegen.cc
@@ -562,6 +562,21 @@ build_unary_op (tree_code code, tree type, tree arg)
    returned expression is evaluated before VALUEP.  */
 
 tree
+stabilize_expr2 (tree *valuep)
+{
+  tree expr = *valuep;
+
+  /* No side effects or expression has no value.  */
+  if (!TREE_SIDE_EFFECTS (expr) || VOID_TYPE_P (TREE_TYPE (expr)))
+    return NULL_TREE;
+
+  tree init = force_target_expr (expr);
+  *valuep = TARGET_EXPR_SLOT (init);
+
+  return init;
+}
+
+tree
 stabilize_expr (tree *valuep)
 {
   tree expr = *valuep;
@@ -1193,6 +1208,7 @@ find_aggregate_field (tree type, tree ident, tree offset)
 
   return NULL_TREE;
 }
+
 /* Return a constructor that matches the layout of the class expression EXP.  */
 
 tree
@@ -1530,7 +1546,7 @@ indirect_ref (tree type, tree exp)
     return exp;
 
   /* Maybe rewrite: *(e1, e2) => (e1, *e2)  */
-  tree init = stabilize_expr (&exp);
+  tree init = stabilize_expr2 (&exp);
 
   if (TREE_CODE (TREE_TYPE (exp)) == REFERENCE_TYPE)
     exp = fold_build1 (INDIRECT_REF, type, exp);
@@ -1552,7 +1568,7 @@ build_deref (tree exp)
     return exp;
 
   /* Maybe rewrite: *(e1, e2) => (e1, *e2)  */
-  tree init = stabilize_expr (&exp);
+  tree init = stabilize_expr2 (&exp);
 
   gcc_assert (POINTER_TYPE_P (TREE_TYPE (exp)));
 

--- a/gcc/d/d-tree.h
+++ b/gcc/d/d-tree.h
@@ -508,6 +508,7 @@ extern void extract_from_method_call (tree, tree &, tree &);
 extern tree build_vindex_ref (tree, tree, size_t);
 extern tree d_save_expr (tree);
 extern tree stabilize_expr (tree *);
+extern tree stabilize_expr2 (tree *);
 extern tree build_target_expr (tree, tree);
 extern tree force_target_expr (tree);
 extern tree build_address (tree);


### PR DESCRIPTION
From discussion in #640, `stabilize_expr` should be repurposed into two kinds of functions.  The first that applies operations on complex/compound lvalue expressions, the second that removes all side effects from an expression and returns a single lvalue.

This is the first, will move other helper functions over to this in steps to make sure nothing gets broken.