### PR TITLE
Fix ICE compiling testexpression on SystemZ

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2018-05-21  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* expr.cc (ExprVisitor::binary_op): Don't do complex conversions if
+	already handling excess precision.
+
 2018-04-02  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* d-lang.cc (doing_semantic_analysis_p): New variable.

--- a/gcc/d/expr.cc
+++ b/gcc/d/expr.cc
@@ -143,14 +143,16 @@ class ExprVisitor : public Visitor
 	    arg1 = d_convert (eptype, arg1);
 	  }
 	else
-	  eptype = type;
+	  {
+	    /* Front-end does not do this conversion and GCC does not
+	       always do it right.  */
+	    if (COMPLEX_FLOAT_TYPE_P (t0) && !COMPLEX_FLOAT_TYPE_P (t1))
+	      arg1 = d_convert (t0, arg1);
+	    else if (COMPLEX_FLOAT_TYPE_P (t1) && !COMPLEX_FLOAT_TYPE_P (t0))
+	      arg0 = d_convert (t1, arg0);
 
-	/* Front-end does not do this conversion and GCC does not
-	   always do it right.  */
-	if (COMPLEX_FLOAT_TYPE_P (t0) && !COMPLEX_FLOAT_TYPE_P (t1))
-	  arg1 = d_convert (t0, arg1);
-	else if (COMPLEX_FLOAT_TYPE_P (t1) && !COMPLEX_FLOAT_TYPE_P (t0))
-	  arg0 = d_convert (t1, arg0);
+	    eptype = type;
+	  }
 
 	ret = fold_build2 (code, eptype, arg0, arg1);
       }


### PR DESCRIPTION
If excess precision was requested, then both expressions have already been converted to the right type.  Put this in the else block so that they don't get erroneously converted back.

Affects s390 backend as it requests that floats are promoted to double.