### PR TITLE
Don't attempt to execute programs when testing cross compilers

### DIFF
--- a/gcc/testsuite/gdc.dg/lto/ltotests_0.d
+++ b/gcc/testsuite/gdc.dg/lto/ltotests_0.d
@@ -1,3 +1,4 @@
+// { dg-lto-do link }
 module ltotests_0;
 
 import core.stdc.stdio;

--- a/gcc/testsuite/gdc.test/d_do_test.exp
+++ b/gcc/testsuite/gdc.test/d_do_test.exp
@@ -268,6 +268,13 @@ proc dmd2dg { base test } {
     # Fail compilable are successful if an output is not generated.
     # Runnable must compile, link, and return 0 to be successful by default.
     switch [file dirname $test] {
+        runnable {
+            if ![isnative] {
+                set out_line "// { dg-final { output-exists } }"
+                puts $fdout $out_line
+            }
+        }
+
         compilable {
             set out_line "// { dg-final { output-exists } }"
             puts $fdout $out_line
@@ -358,7 +365,11 @@ proc gdc-do-test { } {
             runnable {
                 for { set i 0 } { $i<[llength $options] } { incr i } {
                     set flags [lindex $options $i]
-                    set dg-do-what-default "run"
+                    if [isnative] {
+                        set dg-do-what-default "run"
+                    } else {
+                        set dg-do-what-default "link"
+                    }
                     gdc-dg-runtest $filename $flags $imports
                 }
             }


### PR DESCRIPTION
Rather, just make sure that all programs link.  So then runnable tests that fail point to a test file that needs porting.

From the buildbot-ci side, can remove installation of qemu and target board scripts from the images. Whilst it was an interesting experiment to see that all tests pass when running in a qemu-arm emulator, this should really only be done where we have the real hardware.