### PR TITLE
Make a copy of string AST value to a null terminated temporary

### DIFF
--- a/gcc/d/ChangeLog
+++ b/gcc/d/ChangeLog
@@ -1,3 +1,8 @@
+2018-05-28  Iain Buclaw  <ibuclaw@gdcproject.org>
+
+	* expr.cc (ExprVisitor::visit(StringExp)): Copy string literal from
+	the frontend to a null terminated string.
+
 2018-05-21  Iain Buclaw  <ibuclaw@gdcproject.org>
 
 	* expr.cc (ExprVisitor::binary_op): Don't do complex conversions if


### PR DESCRIPTION
As noted in #654, the D frontend no longer null terminates many strings internally.  As preparation for the switch, terminate the string ourselves.

FYI @jpf91 