### PR TITLE
Fix handling bootstrap libraries for D frontend

### DIFF
--- a/gcc/d/patches/patch-targetdm-9.patch
+++ b/gcc/d/patches/patch-targetdm-9.patch
@@ -1478,6 +1478,16 @@ The following OS versions are implemented:
  #include "confdefs.h"
  
  #if HAVE_DLFCN_H
+@@ -29762,6 +29781,9 @@ fi
+ 
+ 
+ 
++
++
++
+ 
+ 
+ 
 --- a/gcc/configure.ac
 +++ b/gcc/configure.ac
 @@ -1724,6 +1724,7 @@ AC_SUBST(build_subdir)

--- a/gcc/d/patches/patch-toplev-9.patch
+++ b/gcc/d/patches/patch-toplev-9.patch
@@ -1100,6 +1100,15 @@ This implements building of libphobos library in GCC.
    DLLTOOL_FOR_BUILD="\$(DLLTOOL)"
    LD_FOR_BUILD="\$(LD)"
    NM_FOR_BUILD="\$(NM)"
+@@ -6331,7 +6339,7 @@ $as_echo "$as_me: WARNING: ${language} n
+ 		  *) stage1_languages="${stage1_languages}${language}," ;;
+ 		esac
+ 		# We need to bootstrap any supporting libraries.
+-		bootstrap_target_libs="${bootstrap_target_libs}${target_libs},"
++		bootstrap_target_libs=`echo "${bootstrap_target_libs}${target_libs}," | sed "s/ /,/g"`
+ 		;;
+ 	    esac
+ 	    ;;
 @@ -7640,6 +7648,7 @@ done
  
  
@@ -1356,6 +1365,15 @@ This implements building of libphobos library in GCC.
    DLLTOOL_FOR_BUILD="\$(DLLTOOL)"
    LD_FOR_BUILD="\$(LD)"
    NM_FOR_BUILD="\$(NM)"
+@@ -2006,7 +2009,7 @@ directories, to avoid imposing the perfo
+ 		  *) stage1_languages="${stage1_languages}${language}," ;;
+ 		esac
+ 		# We need to bootstrap any supporting libraries.
+-		bootstrap_target_libs="${bootstrap_target_libs}${target_libs},"
++		bootstrap_target_libs=`echo "${bootstrap_target_libs}${target_libs}," | sed "s/ /,/g"`
+ 		;;
+ 	    esac
+ 	    ;;
 @@ -3225,6 +3228,7 @@ AC_SUBST(CXX_FOR_BUILD)
  AC_SUBST(DLLTOOL_FOR_BUILD)
  AC_SUBST(GFORTRAN_FOR_BUILD)

--- a/gcc/d/patches/patch-toplev-9.patch
+++ b/gcc/d/patches/patch-toplev-9.patch
@@ -78,17 +78,20 @@ This implements building of libphobos library in GCC.
  	AR="$(AR)"; export AR; \
  	AS="$(AS)"; export AS; \
  	CC_FOR_BUILD="$(CC_FOR_BUILD)"; export CC_FOR_BUILD; \
-@@ -256,6 +259,9 @@ POSTSTAGE1_HOST_EXPORTS = \
+@@ -256,6 +259,12 @@ POSTSTAGE1_HOST_EXPORTS = \
  	CC_FOR_BUILD="$$CC"; export CC_FOR_BUILD; \
  	$(POSTSTAGE1_CXX_EXPORT) \
  	$(LTO_EXPORTS) \
 +	GDC="$$r/$(HOST_SUBDIR)/prev-gcc/gdc$(exeext) -B$$r/$(HOST_SUBDIR)/prev-gcc/ \
-+	  -B$(build_tooldir)/bin/ $(GDC_FLAGS_FOR_TARGET)"; export GDC; \
++	  -B$(build_tooldir)/bin/ $(GDC_FLAGS_FOR_TARGET) \
++	  -I$$r/prev-$(TARGET_SUBDIR)/libphobos/libdruntime -I$$s/libphobos/libdruntime \
++	  -L$$r/prev-$(TARGET_SUBDIR)/libphobos/src/.libs"; \
++	export GDC; \
 +	GDC_FOR_BUILD="$$GDC"; export GDC_FOR_BUILD; \
  	GNATBIND="$$r/$(HOST_SUBDIR)/prev-gcc/gnatbind"; export GNATBIND; \
  	LDFLAGS="$(POSTSTAGE1_LDFLAGS) $(BOOT_LDFLAGS)"; export LDFLAGS; \
  	HOST_LIBS="$(POSTSTAGE1_LIBS)"; export HOST_LIBS;
-@@ -278,6 +284,7 @@ BASE_TARGET_EXPORTS = \
+@@ -278,6 +287,7 @@ BASE_TARGET_EXPORTS = \
  	CXXFLAGS="$(CXXFLAGS_FOR_TARGET)"; export CXXFLAGS; \
  	GFORTRAN="$(GFORTRAN_FOR_TARGET) $(XGCC_FLAGS_FOR_TARGET) $$TFLAGS"; export GFORTRAN; \
  	GOC="$(GOC_FOR_TARGET) $(XGCC_FLAGS_FOR_TARGET) $$TFLAGS"; export GOC; \
@@ -96,7 +99,7 @@ This implements building of libphobos library in GCC.
  	DLLTOOL="$(DLLTOOL_FOR_TARGET)"; export DLLTOOL; \
  	LD="$(COMPILER_LD_FOR_TARGET)"; export LD; \
  	LDFLAGS="$(LDFLAGS_FOR_TARGET)"; export LDFLAGS; \
-@@ -342,6 +349,7 @@ CXX_FOR_BUILD = @CXX_FOR_BUILD@
+@@ -342,6 +352,7 @@ CXX_FOR_BUILD = @CXX_FOR_BUILD@
  DLLTOOL_FOR_BUILD = @DLLTOOL_FOR_BUILD@
  GFORTRAN_FOR_BUILD = @GFORTRAN_FOR_BUILD@
  GOC_FOR_BUILD = @GOC_FOR_BUILD@
@@ -104,7 +107,7 @@ This implements building of libphobos library in GCC.
  LDFLAGS_FOR_BUILD = @LDFLAGS_FOR_BUILD@
  LD_FOR_BUILD = @LD_FOR_BUILD@
  NM_FOR_BUILD = @NM_FOR_BUILD@
-@@ -399,6 +407,7 @@ STRIP = @STRIP@
+@@ -399,6 +410,7 @@ STRIP = @STRIP@
  WINDRES = @WINDRES@
  WINDMC = @WINDMC@
  
@@ -112,7 +115,7 @@ This implements building of libphobos library in GCC.
  GNATBIND = @GNATBIND@
  GNATMAKE = @GNATMAKE@
  
-@@ -408,6 +417,7 @@ LIBCFLAGS = $(CFLAGS)
+@@ -408,6 +420,7 @@ LIBCFLAGS = $(CFLAGS)
  CXXFLAGS = @CXXFLAGS@
  LIBCXXFLAGS = $(CXXFLAGS) -fno-implicit-templates
  GOCFLAGS = $(CFLAGS)
@@ -120,7 +123,7 @@ This implements building of libphobos library in GCC.
  
  CREATE_GCOV = create_gcov
  
-@@ -574,6 +584,7 @@ CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @CXX_
+@@ -574,6 +587,7 @@ CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @CXX_
  RAW_CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @RAW_CXX_FOR_TARGET@
  GFORTRAN_FOR_TARGET=$(STAGE_CC_WRAPPER) @GFORTRAN_FOR_TARGET@
  GOC_FOR_TARGET=$(STAGE_CC_WRAPPER) @GOC_FOR_TARGET@
@@ -128,7 +131,7 @@ This implements building of libphobos library in GCC.
  DLLTOOL_FOR_TARGET=@DLLTOOL_FOR_TARGET@
  LD_FOR_TARGET=@LD_FOR_TARGET@
  
-@@ -598,6 +609,7 @@ LIBCFLAGS_FOR_TARGET = $(CFLAGS_FOR_TARG
+@@ -598,6 +612,7 @@ LIBCFLAGS_FOR_TARGET = $(CFLAGS_FOR_TARG
  LIBCXXFLAGS_FOR_TARGET = $(CXXFLAGS_FOR_TARGET) -fno-implicit-templates
  LDFLAGS_FOR_TARGET = @LDFLAGS_FOR_TARGET@
  GOCFLAGS_FOR_TARGET = -O2 -g
@@ -136,7 +139,7 @@ This implements building of libphobos library in GCC.
  
  FLAGS_FOR_TARGET = @FLAGS_FOR_TARGET@
  SYSROOT_CFLAGS_FOR_TARGET = @SYSROOT_CFLAGS_FOR_TARGET@
-@@ -622,7 +634,7 @@ all:
+@@ -622,7 +637,7 @@ all:
  
  # This is the list of directories that may be needed in RPATH_ENVVAR
  # so that programs built for the target machine work.
@@ -145,7 +148,7 @@ This implements building of libphobos library in GCC.
  
  @if target-libstdc++-v3
  TARGET_LIB_PATH_libstdc++-v3 = $$r/$(TARGET_SUBDIR)/libstdc++-v3/src/.libs:
-@@ -644,6 +656,10 @@ TARGET_LIB_PATH_liboffloadmic = $$r/$(TA
+@@ -644,6 +659,10 @@ TARGET_LIB_PATH_liboffloadmic = $$r/$(TA
  TARGET_LIB_PATH_libssp = $$r/$(TARGET_SUBDIR)/libssp/.libs:
  @endif target-libssp
  
@@ -156,7 +159,7 @@ This implements building of libphobos library in GCC.
  @if target-libgomp
  TARGET_LIB_PATH_libgomp = $$r/$(TARGET_SUBDIR)/libgomp/.libs:
  @endif target-libgomp
-@@ -778,6 +794,8 @@ BASE_FLAGS_TO_PASS = \
+@@ -778,6 +797,8 @@ BASE_FLAGS_TO_PASS = \
  	"STAGE1_LANGUAGES=$(STAGE1_LANGUAGES)" \
  	"GNATBIND=$(GNATBIND)" \
  	"GNATMAKE=$(GNATMAKE)" \
@@ -165,7 +168,7 @@ This implements building of libphobos library in GCC.
  	"AR_FOR_TARGET=$(AR_FOR_TARGET)" \
  	"AS_FOR_TARGET=$(AS_FOR_TARGET)" \
  	"CC_FOR_TARGET=$(CC_FOR_TARGET)" \
-@@ -789,6 +807,8 @@ BASE_FLAGS_TO_PASS = \
+@@ -789,6 +810,8 @@ BASE_FLAGS_TO_PASS = \
  	"GFORTRAN_FOR_TARGET=$(GFORTRAN_FOR_TARGET)" \
  	"GOC_FOR_TARGET=$(GOC_FOR_TARGET)" \
  	"GOCFLAGS_FOR_TARGET=$(GOCFLAGS_FOR_TARGET)" \
@@ -174,7 +177,7 @@ This implements building of libphobos library in GCC.
  	"LD_FOR_TARGET=$(LD_FOR_TARGET)" \
  	"LIPO_FOR_TARGET=$(LIPO_FOR_TARGET)" \
  	"LDFLAGS_FOR_TARGET=$(LDFLAGS_FOR_TARGET)" \
-@@ -851,6 +871,7 @@ EXTRA_HOST_FLAGS = \
+@@ -851,6 +874,7 @@ EXTRA_HOST_FLAGS = \
  	'DLLTOOL=$(DLLTOOL)' \
  	'GFORTRAN=$(GFORTRAN)' \
  	'GOC=$(GOC)' \
@@ -182,7 +185,7 @@ This implements building of libphobos library in GCC.
  	'LD=$(LD)' \
  	'LIPO=$(LIPO)' \
  	'NM=$(NM)' \
-@@ -875,6 +896,7 @@ STAGE1_FLAGS_TO_PASS = \
+@@ -875,6 +899,7 @@ STAGE1_FLAGS_TO_PASS = \
  POSTSTAGE1_FLAGS_TO_PASS = \
  	CC="$${CC}" CC_FOR_BUILD="$${CC_FOR_BUILD}" \
  	CXX="$${CXX}" CXX_FOR_BUILD="$${CXX_FOR_BUILD}" \
@@ -190,7 +193,7 @@ This implements building of libphobos library in GCC.
  	GNATBIND="$${GNATBIND}" \
  	LDFLAGS="$${LDFLAGS}" \
  	HOST_LIBS="$${HOST_LIBS}" \
-@@ -907,6 +929,8 @@ EXTRA_TARGET_FLAGS = \
+@@ -907,6 +932,8 @@ EXTRA_TARGET_FLAGS = \
  	'GFORTRAN=$$(GFORTRAN_FOR_TARGET) $$(XGCC_FLAGS_FOR_TARGET) $$(TFLAGS)' \
  	'GOC=$$(GOC_FOR_TARGET) $$(XGCC_FLAGS_FOR_TARGET) $$(TFLAGS)' \
  	'GOCFLAGS=$$(GOCFLAGS_FOR_TARGET)' \
@@ -199,7 +202,7 @@ This implements building of libphobos library in GCC.
  	'LD=$(COMPILER_LD_FOR_TARGET)' \
  	'LDFLAGS=$$(LDFLAGS_FOR_TARGET)' \
  	'LIBCFLAGS=$$(LIBCFLAGS_FOR_TARGET)' \
-@@ -1008,6 +1032,7 @@ configure-target:  \
+@@ -1008,6 +1035,7 @@ configure-target:  \
      maybe-configure-target-libobjc \
      maybe-configure-target-libgo \
      maybe-configure-target-libhsail-rt \
@@ -207,7 +210,7 @@ This implements building of libphobos library in GCC.
      maybe-configure-target-libtermcap \
      maybe-configure-target-winsup \
      maybe-configure-target-libgloss \
-@@ -1170,6 +1195,7 @@ all-target: maybe-all-target-libgfortran
+@@ -1170,6 +1198,7 @@ all-target: maybe-all-target-libgfortran
  all-target: maybe-all-target-libobjc
  all-target: maybe-all-target-libgo
  all-target: maybe-all-target-libhsail-rt
@@ -215,7 +218,7 @@ This implements building of libphobos library in GCC.
  all-target: maybe-all-target-libtermcap
  all-target: maybe-all-target-winsup
  all-target: maybe-all-target-libgloss
-@@ -1261,6 +1287,7 @@ info-target: maybe-info-target-libgfortr
+@@ -1261,6 +1290,7 @@ info-target: maybe-info-target-libgfortr
  info-target: maybe-info-target-libobjc
  info-target: maybe-info-target-libgo
  info-target: maybe-info-target-libhsail-rt
@@ -223,7 +226,7 @@ This implements building of libphobos library in GCC.
  info-target: maybe-info-target-libtermcap
  info-target: maybe-info-target-winsup
  info-target: maybe-info-target-libgloss
-@@ -1345,6 +1372,7 @@ dvi-target: maybe-dvi-target-libgfortran
+@@ -1345,6 +1375,7 @@ dvi-target: maybe-dvi-target-libgfortran
  dvi-target: maybe-dvi-target-libobjc
  dvi-target: maybe-dvi-target-libgo
  dvi-target: maybe-dvi-target-libhsail-rt
@@ -231,7 +234,7 @@ This implements building of libphobos library in GCC.
  dvi-target: maybe-dvi-target-libtermcap
  dvi-target: maybe-dvi-target-winsup
  dvi-target: maybe-dvi-target-libgloss
-@@ -1429,6 +1457,7 @@ pdf-target: maybe-pdf-target-libgfortran
+@@ -1429,6 +1460,7 @@ pdf-target: maybe-pdf-target-libgfortran
  pdf-target: maybe-pdf-target-libobjc
  pdf-target: maybe-pdf-target-libgo
  pdf-target: maybe-pdf-target-libhsail-rt
@@ -239,7 +242,7 @@ This implements building of libphobos library in GCC.
  pdf-target: maybe-pdf-target-libtermcap
  pdf-target: maybe-pdf-target-winsup
  pdf-target: maybe-pdf-target-libgloss
-@@ -1513,6 +1542,7 @@ html-target: maybe-html-target-libgfortr
+@@ -1513,6 +1545,7 @@ html-target: maybe-html-target-libgfortr
  html-target: maybe-html-target-libobjc
  html-target: maybe-html-target-libgo
  html-target: maybe-html-target-libhsail-rt
@@ -247,7 +250,7 @@ This implements building of libphobos library in GCC.
  html-target: maybe-html-target-libtermcap
  html-target: maybe-html-target-winsup
  html-target: maybe-html-target-libgloss
-@@ -1597,6 +1627,7 @@ TAGS-target: maybe-TAGS-target-libgfortr
+@@ -1597,6 +1630,7 @@ TAGS-target: maybe-TAGS-target-libgfortr
  TAGS-target: maybe-TAGS-target-libobjc
  TAGS-target: maybe-TAGS-target-libgo
  TAGS-target: maybe-TAGS-target-libhsail-rt
@@ -255,7 +258,7 @@ This implements building of libphobos library in GCC.
  TAGS-target: maybe-TAGS-target-libtermcap
  TAGS-target: maybe-TAGS-target-winsup
  TAGS-target: maybe-TAGS-target-libgloss
-@@ -1681,6 +1712,7 @@ install-info-target: maybe-install-info-
+@@ -1681,6 +1715,7 @@ install-info-target: maybe-install-info-
  install-info-target: maybe-install-info-target-libobjc
  install-info-target: maybe-install-info-target-libgo
  install-info-target: maybe-install-info-target-libhsail-rt
@@ -263,7 +266,7 @@ This implements building of libphobos library in GCC.
  install-info-target: maybe-install-info-target-libtermcap
  install-info-target: maybe-install-info-target-winsup
  install-info-target: maybe-install-info-target-libgloss
-@@ -1765,6 +1797,7 @@ install-pdf-target: maybe-install-pdf-ta
+@@ -1765,6 +1800,7 @@ install-pdf-target: maybe-install-pdf-ta
  install-pdf-target: maybe-install-pdf-target-libobjc
  install-pdf-target: maybe-install-pdf-target-libgo
  install-pdf-target: maybe-install-pdf-target-libhsail-rt
@@ -271,7 +274,7 @@ This implements building of libphobos library in GCC.
  install-pdf-target: maybe-install-pdf-target-libtermcap
  install-pdf-target: maybe-install-pdf-target-winsup
  install-pdf-target: maybe-install-pdf-target-libgloss
-@@ -1849,6 +1882,7 @@ install-html-target: maybe-install-html-
+@@ -1849,6 +1885,7 @@ install-html-target: maybe-install-html-
  install-html-target: maybe-install-html-target-libobjc
  install-html-target: maybe-install-html-target-libgo
  install-html-target: maybe-install-html-target-libhsail-rt
@@ -279,7 +282,7 @@ This implements building of libphobos library in GCC.
  install-html-target: maybe-install-html-target-libtermcap
  install-html-target: maybe-install-html-target-winsup
  install-html-target: maybe-install-html-target-libgloss
-@@ -1933,6 +1967,7 @@ installcheck-target: maybe-installcheck-
+@@ -1933,6 +1970,7 @@ installcheck-target: maybe-installcheck-
  installcheck-target: maybe-installcheck-target-libobjc
  installcheck-target: maybe-installcheck-target-libgo
  installcheck-target: maybe-installcheck-target-libhsail-rt
@@ -287,7 +290,7 @@ This implements building of libphobos library in GCC.
  installcheck-target: maybe-installcheck-target-libtermcap
  installcheck-target: maybe-installcheck-target-winsup
  installcheck-target: maybe-installcheck-target-libgloss
-@@ -2017,6 +2052,7 @@ mostlyclean-target: maybe-mostlyclean-ta
+@@ -2017,6 +2055,7 @@ mostlyclean-target: maybe-mostlyclean-ta
  mostlyclean-target: maybe-mostlyclean-target-libobjc
  mostlyclean-target: maybe-mostlyclean-target-libgo
  mostlyclean-target: maybe-mostlyclean-target-libhsail-rt
@@ -295,7 +298,7 @@ This implements building of libphobos library in GCC.
  mostlyclean-target: maybe-mostlyclean-target-libtermcap
  mostlyclean-target: maybe-mostlyclean-target-winsup
  mostlyclean-target: maybe-mostlyclean-target-libgloss
-@@ -2101,6 +2137,7 @@ clean-target: maybe-clean-target-libgfor
+@@ -2101,6 +2140,7 @@ clean-target: maybe-clean-target-libgfor
  clean-target: maybe-clean-target-libobjc
  clean-target: maybe-clean-target-libgo
  clean-target: maybe-clean-target-libhsail-rt
@@ -303,7 +306,7 @@ This implements building of libphobos library in GCC.
  clean-target: maybe-clean-target-libtermcap
  clean-target: maybe-clean-target-winsup
  clean-target: maybe-clean-target-libgloss
-@@ -2185,6 +2222,7 @@ distclean-target: maybe-distclean-target
+@@ -2185,6 +2225,7 @@ distclean-target: maybe-distclean-target
  distclean-target: maybe-distclean-target-libobjc
  distclean-target: maybe-distclean-target-libgo
  distclean-target: maybe-distclean-target-libhsail-rt
@@ -311,7 +314,7 @@ This implements building of libphobos library in GCC.
  distclean-target: maybe-distclean-target-libtermcap
  distclean-target: maybe-distclean-target-winsup
  distclean-target: maybe-distclean-target-libgloss
-@@ -2269,6 +2307,7 @@ maintainer-clean-target: maybe-maintaine
+@@ -2269,6 +2310,7 @@ maintainer-clean-target: maybe-maintaine
  maintainer-clean-target: maybe-maintainer-clean-target-libobjc
  maintainer-clean-target: maybe-maintainer-clean-target-libgo
  maintainer-clean-target: maybe-maintainer-clean-target-libhsail-rt
@@ -319,7 +322,7 @@ This implements building of libphobos library in GCC.
  maintainer-clean-target: maybe-maintainer-clean-target-libtermcap
  maintainer-clean-target: maybe-maintainer-clean-target-winsup
  maintainer-clean-target: maybe-maintainer-clean-target-libgloss
-@@ -2409,6 +2448,7 @@ check-target:  \
+@@ -2409,6 +2451,7 @@ check-target:  \
      maybe-check-target-libobjc \
      maybe-check-target-libgo \
      maybe-check-target-libhsail-rt \
@@ -327,7 +330,7 @@ This implements building of libphobos library in GCC.
      maybe-check-target-libtermcap \
      maybe-check-target-winsup \
      maybe-check-target-libgloss \
-@@ -2589,6 +2629,7 @@ install-target:  \
+@@ -2589,6 +2632,7 @@ install-target:  \
      maybe-install-target-libobjc \
      maybe-install-target-libgo \
      maybe-install-target-libhsail-rt \
@@ -335,7 +338,7 @@ This implements building of libphobos library in GCC.
      maybe-install-target-libtermcap \
      maybe-install-target-winsup \
      maybe-install-target-libgloss \
-@@ -2693,6 +2734,7 @@ install-strip-target:  \
+@@ -2693,6 +2737,7 @@ install-strip-target:  \
      maybe-install-strip-target-libobjc \
      maybe-install-strip-target-libgo \
      maybe-install-strip-target-libhsail-rt \
@@ -343,7 +346,7 @@ This implements building of libphobos library in GCC.
      maybe-install-strip-target-libtermcap \
      maybe-install-strip-target-winsup \
      maybe-install-strip-target-libgloss \
-@@ -46944,6 +46986,464 @@ maintainer-clean-target-libhsail-rt:
+@@ -46944,6 +46989,464 @@ maintainer-clean-target-libhsail-rt:
  
  
  
@@ -808,7 +811,7 @@ This implements building of libphobos library in GCC.
  .PHONY: configure-target-libtermcap maybe-configure-target-libtermcap
  maybe-configure-target-libtermcap:
  @if gcc-bootstrap
-@@ -52325,6 +52825,14 @@ check-gcc-brig:
+@@ -52325,6 +52828,14 @@ check-gcc-brig:
  	(cd gcc && $(MAKE) $(GCC_FLAGS_TO_PASS) check-brig);
  check-brig: check-gcc-brig check-target-libhsail-rt
  
@@ -823,7 +826,7 @@ This implements building of libphobos library in GCC.
  
  # The gcc part of install-no-fixedincludes, which relies on an intimate
  # knowledge of how a number of gcc internal targets (inter)operate.  Delegate.
-@@ -55517,6 +56025,7 @@ configure-target-libgfortran: stage_last
+@@ -55517,6 +56028,7 @@ configure-target-libgfortran: stage_last
  configure-target-libobjc: stage_last
  configure-target-libgo: stage_last
  configure-target-libhsail-rt: stage_last
@@ -831,7 +834,7 @@ This implements building of libphobos library in GCC.
  configure-target-libtermcap: stage_last
  configure-target-winsup: stage_last
  configure-target-libgloss: stage_last
-@@ -55551,6 +56060,7 @@ configure-target-libgfortran: maybe-all-
+@@ -55551,6 +56063,7 @@ configure-target-libgfortran: maybe-all-
  configure-target-libobjc: maybe-all-gcc
  configure-target-libgo: maybe-all-gcc
  configure-target-libhsail-rt: maybe-all-gcc
@@ -839,7 +842,7 @@ This implements building of libphobos library in GCC.
  configure-target-libtermcap: maybe-all-gcc
  configure-target-winsup: maybe-all-gcc
  configure-target-libgloss: maybe-all-gcc
-@@ -56667,6 +57177,11 @@ configure-target-libgo: maybe-all-target
+@@ -56667,6 +57180,11 @@ configure-target-libgo: maybe-all-target
  all-target-libgo: maybe-all-target-libbacktrace
  all-target-libgo: maybe-all-target-libffi
  all-target-libgo: maybe-all-target-libatomic
@@ -851,7 +854,7 @@ This implements building of libphobos library in GCC.
  configure-target-libstdc++-v3: maybe-configure-target-libgomp
  
  configure-stage1-target-libstdc++-v3: maybe-configure-stage1-target-libgomp
-@@ -56716,6 +57231,7 @@ all-target-liboffloadmic: maybe-all-targ
+@@ -56716,6 +57234,7 @@ all-target-liboffloadmic: maybe-all-targ
  install-target-libgo: maybe-install-target-libatomic
  install-target-libgfortran: maybe-install-target-libquadmath
  install-target-libgfortran: maybe-install-target-libgcc
@@ -859,7 +862,7 @@ This implements building of libphobos library in GCC.
  install-target-libsanitizer: maybe-install-target-libstdc++-v3
  install-target-libsanitizer: maybe-install-target-libgcc
  install-target-libvtv: maybe-install-target-libstdc++-v3
-@@ -56790,6 +57306,7 @@ configure-target-libgfortran: maybe-all-
+@@ -56790,6 +57309,7 @@ configure-target-libgfortran: maybe-all-
  configure-target-libobjc: maybe-all-target-libgcc
  configure-target-libgo: maybe-all-target-libgcc
  configure-target-libhsail-rt: maybe-all-target-libgcc
@@ -867,7 +870,7 @@ This implements building of libphobos library in GCC.
  configure-target-libtermcap: maybe-all-target-libgcc
  configure-target-winsup: maybe-all-target-libgcc
  configure-target-libgloss: maybe-all-target-libgcc
-@@ -56828,6 +57345,8 @@ configure-target-libgo: maybe-all-target
+@@ -56828,6 +57348,8 @@ configure-target-libgo: maybe-all-target
  
  configure-target-libhsail-rt: maybe-all-target-newlib maybe-all-target-libgloss
  
@@ -895,17 +898,20 @@ This implements building of libphobos library in GCC.
  	AR="$(AR)"; export AR; \
  	AS="$(AS)"; export AS; \
  	CC_FOR_BUILD="$(CC_FOR_BUILD)"; export CC_FOR_BUILD; \
-@@ -259,6 +262,9 @@ POSTSTAGE1_HOST_EXPORTS = \
+@@ -259,6 +262,12 @@ POSTSTAGE1_HOST_EXPORTS = \
  	CC_FOR_BUILD="$$CC"; export CC_FOR_BUILD; \
  	$(POSTSTAGE1_CXX_EXPORT) \
  	$(LTO_EXPORTS) \
 +	GDC="$$r/$(HOST_SUBDIR)/prev-gcc/gdc$(exeext) -B$$r/$(HOST_SUBDIR)/prev-gcc/ \
-+	  -B$(build_tooldir)/bin/ $(GDC_FLAGS_FOR_TARGET)"; export GDC; \
++	  -B$(build_tooldir)/bin/ $(GDC_FLAGS_FOR_TARGET) \
++	  -I$$r/prev-$(TARGET_SUBDIR)/libphobos/libdruntime -I$$s/libphobos/libdruntime \
++	  -L$$r/prev-$(TARGET_SUBDIR)/libphobos/src/.libs"; \
++	export GDC; \
 +	GDC_FOR_BUILD="$$GDC"; export GDC_FOR_BUILD; \
  	GNATBIND="$$r/$(HOST_SUBDIR)/prev-gcc/gnatbind"; export GNATBIND; \
  	LDFLAGS="$(POSTSTAGE1_LDFLAGS) $(BOOT_LDFLAGS)"; export LDFLAGS; \
  	HOST_LIBS="$(POSTSTAGE1_LIBS)"; export HOST_LIBS;
-@@ -281,6 +287,7 @@ BASE_TARGET_EXPORTS = \
+@@ -281,6 +290,7 @@ BASE_TARGET_EXPORTS = \
  	CXXFLAGS="$(CXXFLAGS_FOR_TARGET)"; export CXXFLAGS; \
  	GFORTRAN="$(GFORTRAN_FOR_TARGET) $(XGCC_FLAGS_FOR_TARGET) $$TFLAGS"; export GFORTRAN; \
  	GOC="$(GOC_FOR_TARGET) $(XGCC_FLAGS_FOR_TARGET) $$TFLAGS"; export GOC; \
@@ -913,7 +919,7 @@ This implements building of libphobos library in GCC.
  	DLLTOOL="$(DLLTOOL_FOR_TARGET)"; export DLLTOOL; \
  	LD="$(COMPILER_LD_FOR_TARGET)"; export LD; \
  	LDFLAGS="$(LDFLAGS_FOR_TARGET)"; export LDFLAGS; \
-@@ -345,6 +352,7 @@ CXX_FOR_BUILD = @CXX_FOR_BUILD@
+@@ -345,6 +355,7 @@ CXX_FOR_BUILD = @CXX_FOR_BUILD@
  DLLTOOL_FOR_BUILD = @DLLTOOL_FOR_BUILD@
  GFORTRAN_FOR_BUILD = @GFORTRAN_FOR_BUILD@
  GOC_FOR_BUILD = @GOC_FOR_BUILD@
@@ -921,7 +927,7 @@ This implements building of libphobos library in GCC.
  LDFLAGS_FOR_BUILD = @LDFLAGS_FOR_BUILD@
  LD_FOR_BUILD = @LD_FOR_BUILD@
  NM_FOR_BUILD = @NM_FOR_BUILD@
-@@ -402,6 +410,7 @@ STRIP = @STRIP@
+@@ -402,6 +413,7 @@ STRIP = @STRIP@
  WINDRES = @WINDRES@
  WINDMC = @WINDMC@
  
@@ -929,7 +935,7 @@ This implements building of libphobos library in GCC.
  GNATBIND = @GNATBIND@
  GNATMAKE = @GNATMAKE@
  
-@@ -411,6 +420,7 @@ LIBCFLAGS = $(CFLAGS)
+@@ -411,6 +423,7 @@ LIBCFLAGS = $(CFLAGS)
  CXXFLAGS = @CXXFLAGS@
  LIBCXXFLAGS = $(CXXFLAGS) -fno-implicit-templates
  GOCFLAGS = $(CFLAGS)
@@ -937,7 +943,7 @@ This implements building of libphobos library in GCC.
  
  CREATE_GCOV = create_gcov
  
-@@ -497,6 +507,7 @@ CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @CXX_
+@@ -497,6 +510,7 @@ CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @CXX_
  RAW_CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @RAW_CXX_FOR_TARGET@
  GFORTRAN_FOR_TARGET=$(STAGE_CC_WRAPPER) @GFORTRAN_FOR_TARGET@
  GOC_FOR_TARGET=$(STAGE_CC_WRAPPER) @GOC_FOR_TARGET@
@@ -945,7 +951,7 @@ This implements building of libphobos library in GCC.
  DLLTOOL_FOR_TARGET=@DLLTOOL_FOR_TARGET@
  LD_FOR_TARGET=@LD_FOR_TARGET@
  
-@@ -521,6 +532,7 @@ LIBCFLAGS_FOR_TARGET = $(CFLAGS_FOR_TARG
+@@ -521,6 +535,7 @@ LIBCFLAGS_FOR_TARGET = $(CFLAGS_FOR_TARG
  LIBCXXFLAGS_FOR_TARGET = $(CXXFLAGS_FOR_TARGET) -fno-implicit-templates
  LDFLAGS_FOR_TARGET = @LDFLAGS_FOR_TARGET@
  GOCFLAGS_FOR_TARGET = -O2 -g
@@ -953,7 +959,7 @@ This implements building of libphobos library in GCC.
  
  FLAGS_FOR_TARGET = @FLAGS_FOR_TARGET@
  SYSROOT_CFLAGS_FOR_TARGET = @SYSROOT_CFLAGS_FOR_TARGET@
-@@ -622,6 +634,7 @@ EXTRA_HOST_FLAGS = \
+@@ -622,6 +637,7 @@ EXTRA_HOST_FLAGS = \
  	'DLLTOOL=$(DLLTOOL)' \
  	'GFORTRAN=$(GFORTRAN)' \
  	'GOC=$(GOC)' \
@@ -961,7 +967,7 @@ This implements building of libphobos library in GCC.
  	'LD=$(LD)' \
  	'LIPO=$(LIPO)' \
  	'NM=$(NM)' \
-@@ -646,6 +659,7 @@ STAGE1_FLAGS_TO_PASS = \
+@@ -646,6 +662,7 @@ STAGE1_FLAGS_TO_PASS = \
  POSTSTAGE1_FLAGS_TO_PASS = \
  	CC="$${CC}" CC_FOR_BUILD="$${CC_FOR_BUILD}" \
  	CXX="$${CXX}" CXX_FOR_BUILD="$${CXX_FOR_BUILD}" \
@@ -969,7 +975,7 @@ This implements building of libphobos library in GCC.
  	GNATBIND="$${GNATBIND}" \
  	LDFLAGS="$${LDFLAGS}" \
  	HOST_LIBS="$${HOST_LIBS}" \
-@@ -678,6 +692,8 @@ EXTRA_TARGET_FLAGS = \
+@@ -678,6 +695,8 @@ EXTRA_TARGET_FLAGS = \
  	'GFORTRAN=$$(GFORTRAN_FOR_TARGET) $$(XGCC_FLAGS_FOR_TARGET) $$(TFLAGS)' \
  	'GOC=$$(GOC_FOR_TARGET) $$(XGCC_FLAGS_FOR_TARGET) $$(TFLAGS)' \
  	'GOCFLAGS=$$(GOCFLAGS_FOR_TARGET)' \

--- a/gcc/d/patches/patch-toplev-9.patch
+++ b/gcc/d/patches/patch-toplev-9.patch
@@ -3,15 +3,16 @@ This implements building of libphobos library in GCC.
 
 --- a/Makefile.def
 +++ b/Makefile.def
-@@ -153,6 +153,7 @@ target_modules = { module= libgfortran;
+@@ -153,6 +153,8 @@ target_modules = { module= libgfortran;
  target_modules = { module= libobjc; };
  target_modules = { module= libgo; };
  target_modules = { module= libhsail-rt; };
-+target_modules = { module= libphobos; };
++target_modules = { module= libphobos;
++		   lib_path=src/.libs; };
  target_modules = { module= libtermcap; no_check=true;
                     missing=mostlyclean;
                     missing=clean;
-@@ -265,6 +266,8 @@ flags_to_pass = { flag= STAGE1_CHECKING
+@@ -265,6 +267,8 @@ flags_to_pass = { flag= STAGE1_CHECKING
  flags_to_pass = { flag= STAGE1_LANGUAGES ; };
  flags_to_pass = { flag= GNATBIND ; };
  flags_to_pass = { flag= GNATMAKE ; };
@@ -20,7 +21,7 @@ This implements building of libphobos library in GCC.
  
  // Target tools
  flags_to_pass = { flag= AR_FOR_TARGET ; };
-@@ -278,6 +281,8 @@ flags_to_pass = { flag= FLAGS_FOR_TARGET
+@@ -278,6 +282,8 @@ flags_to_pass = { flag= FLAGS_FOR_TARGET
  flags_to_pass = { flag= GFORTRAN_FOR_TARGET ; };
  flags_to_pass = { flag= GOC_FOR_TARGET ; };
  flags_to_pass = { flag= GOCFLAGS_FOR_TARGET ; };
@@ -29,7 +30,7 @@ This implements building of libphobos library in GCC.
  flags_to_pass = { flag= LD_FOR_TARGET ; };
  flags_to_pass = { flag= LIPO_FOR_TARGET ; };
  flags_to_pass = { flag= LDFLAGS_FOR_TARGET ; };
-@@ -544,6 +549,11 @@ dependencies = { module=configure-target
+@@ -544,6 +550,11 @@ dependencies = { module=configure-target
  dependencies = { module=all-target-libgo; on=all-target-libbacktrace; };
  dependencies = { module=all-target-libgo; on=all-target-libffi; };
  dependencies = { module=all-target-libgo; on=all-target-libatomic; };
@@ -41,7 +42,7 @@ This implements building of libphobos library in GCC.
  dependencies = { module=configure-target-libstdc++-v3; on=configure-target-libgomp; };
  dependencies = { module=configure-target-liboffloadmic; on=configure-target-libgomp; };
  dependencies = { module=configure-target-libsanitizer; on=all-target-libstdc++-v3; };
-@@ -557,6 +567,7 @@ dependencies = { module=all-target-libof
+@@ -557,6 +568,7 @@ dependencies = { module=all-target-libof
  dependencies = { module=install-target-libgo; on=install-target-libatomic; };
  dependencies = { module=install-target-libgfortran; on=install-target-libquadmath; };
  dependencies = { module=install-target-libgfortran; on=install-target-libgcc; };
@@ -49,7 +50,7 @@ This implements building of libphobos library in GCC.
  dependencies = { module=install-target-libsanitizer; on=install-target-libstdc++-v3; };
  dependencies = { module=install-target-libsanitizer; on=install-target-libgcc; };
  dependencies = { module=install-target-libvtv; on=install-target-libstdc++-v3; };
-@@ -597,6 +608,8 @@ languages = { language=go;	gcc-check-tar
+@@ -597,6 +609,8 @@ languages = { language=go;	gcc-check-tar
  				lib-check-target=check-gotools; };
  languages = { language=brig;	gcc-check-target=check-brig;
  				lib-check-target=check-target-libhsail-rt; };
@@ -135,7 +136,27 @@ This implements building of libphobos library in GCC.
  
  FLAGS_FOR_TARGET = @FLAGS_FOR_TARGET@
  SYSROOT_CFLAGS_FOR_TARGET = @SYSROOT_CFLAGS_FOR_TARGET@
-@@ -778,6 +790,8 @@ BASE_FLAGS_TO_PASS = \
+@@ -622,7 +634,7 @@ all:
+ 
+ # This is the list of directories that may be needed in RPATH_ENVVAR
+ # so that programs built for the target machine work.
+-TARGET_LIB_PATH = $(TARGET_LIB_PATH_libstdc++-v3)$(TARGET_LIB_PATH_libsanitizer)$(TARGET_LIB_PATH_libvtv)$(TARGET_LIB_PATH_liboffloadmic)$(TARGET_LIB_PATH_libssp)$(TARGET_LIB_PATH_libgomp)$(TARGET_LIB_PATH_libitm)$(TARGET_LIB_PATH_libatomic)$(HOST_LIB_PATH_gcc)
++TARGET_LIB_PATH = $(TARGET_LIB_PATH_libstdc++-v3)$(TARGET_LIB_PATH_libsanitizer)$(TARGET_LIB_PATH_libvtv)$(TARGET_LIB_PATH_liboffloadmic)$(TARGET_LIB_PATH_libssp)$(TARGET_LIB_PATH_libphobos)$(TARGET_LIB_PATH_libgomp)$(TARGET_LIB_PATH_libitm)$(TARGET_LIB_PATH_libatomic)$(HOST_LIB_PATH_gcc)
+ 
+ @if target-libstdc++-v3
+ TARGET_LIB_PATH_libstdc++-v3 = $$r/$(TARGET_SUBDIR)/libstdc++-v3/src/.libs:
+@@ -644,6 +656,10 @@ TARGET_LIB_PATH_liboffloadmic = $$r/$(TA
+ TARGET_LIB_PATH_libssp = $$r/$(TARGET_SUBDIR)/libssp/.libs:
+ @endif target-libssp
+ 
++@if target-libphobos
++TARGET_LIB_PATH_libphobos = $$r/$(TARGET_SUBDIR)/libphobos/src/.libs:
++@endif target-libphobos
++
+ @if target-libgomp
+ TARGET_LIB_PATH_libgomp = $$r/$(TARGET_SUBDIR)/libgomp/.libs:
+ @endif target-libgomp
+@@ -778,6 +794,8 @@ BASE_FLAGS_TO_PASS = \
  	"STAGE1_LANGUAGES=$(STAGE1_LANGUAGES)" \
  	"GNATBIND=$(GNATBIND)" \
  	"GNATMAKE=$(GNATMAKE)" \
@@ -144,7 +165,7 @@ This implements building of libphobos library in GCC.
  	"AR_FOR_TARGET=$(AR_FOR_TARGET)" \
  	"AS_FOR_TARGET=$(AS_FOR_TARGET)" \
  	"CC_FOR_TARGET=$(CC_FOR_TARGET)" \
-@@ -789,6 +803,8 @@ BASE_FLAGS_TO_PASS = \
+@@ -789,6 +807,8 @@ BASE_FLAGS_TO_PASS = \
  	"GFORTRAN_FOR_TARGET=$(GFORTRAN_FOR_TARGET)" \
  	"GOC_FOR_TARGET=$(GOC_FOR_TARGET)" \
  	"GOCFLAGS_FOR_TARGET=$(GOCFLAGS_FOR_TARGET)" \
@@ -153,7 +174,7 @@ This implements building of libphobos library in GCC.
  	"LD_FOR_TARGET=$(LD_FOR_TARGET)" \
  	"LIPO_FOR_TARGET=$(LIPO_FOR_TARGET)" \
  	"LDFLAGS_FOR_TARGET=$(LDFLAGS_FOR_TARGET)" \
-@@ -851,6 +867,7 @@ EXTRA_HOST_FLAGS = \
+@@ -851,6 +871,7 @@ EXTRA_HOST_FLAGS = \
  	'DLLTOOL=$(DLLTOOL)' \
  	'GFORTRAN=$(GFORTRAN)' \
  	'GOC=$(GOC)' \
@@ -161,7 +182,7 @@ This implements building of libphobos library in GCC.
  	'LD=$(LD)' \
  	'LIPO=$(LIPO)' \
  	'NM=$(NM)' \
-@@ -875,6 +892,7 @@ STAGE1_FLAGS_TO_PASS = \
+@@ -875,6 +896,7 @@ STAGE1_FLAGS_TO_PASS = \
  POSTSTAGE1_FLAGS_TO_PASS = \
  	CC="$${CC}" CC_FOR_BUILD="$${CC_FOR_BUILD}" \
  	CXX="$${CXX}" CXX_FOR_BUILD="$${CXX_FOR_BUILD}" \
@@ -169,7 +190,7 @@ This implements building of libphobos library in GCC.
  	GNATBIND="$${GNATBIND}" \
  	LDFLAGS="$${LDFLAGS}" \
  	HOST_LIBS="$${HOST_LIBS}" \
-@@ -907,6 +925,8 @@ EXTRA_TARGET_FLAGS = \
+@@ -907,6 +929,8 @@ EXTRA_TARGET_FLAGS = \
  	'GFORTRAN=$$(GFORTRAN_FOR_TARGET) $$(XGCC_FLAGS_FOR_TARGET) $$(TFLAGS)' \
  	'GOC=$$(GOC_FOR_TARGET) $$(XGCC_FLAGS_FOR_TARGET) $$(TFLAGS)' \
  	'GOCFLAGS=$$(GOCFLAGS_FOR_TARGET)' \
@@ -178,7 +199,7 @@ This implements building of libphobos library in GCC.
  	'LD=$(COMPILER_LD_FOR_TARGET)' \
  	'LDFLAGS=$$(LDFLAGS_FOR_TARGET)' \
  	'LIBCFLAGS=$$(LIBCFLAGS_FOR_TARGET)' \
-@@ -1008,6 +1028,7 @@ configure-target:  \
+@@ -1008,6 +1032,7 @@ configure-target:  \
      maybe-configure-target-libobjc \
      maybe-configure-target-libgo \
      maybe-configure-target-libhsail-rt \
@@ -186,7 +207,7 @@ This implements building of libphobos library in GCC.
      maybe-configure-target-libtermcap \
      maybe-configure-target-winsup \
      maybe-configure-target-libgloss \
-@@ -1170,6 +1191,7 @@ all-target: maybe-all-target-libgfortran
+@@ -1170,6 +1195,7 @@ all-target: maybe-all-target-libgfortran
  all-target: maybe-all-target-libobjc
  all-target: maybe-all-target-libgo
  all-target: maybe-all-target-libhsail-rt
@@ -194,7 +215,7 @@ This implements building of libphobos library in GCC.
  all-target: maybe-all-target-libtermcap
  all-target: maybe-all-target-winsup
  all-target: maybe-all-target-libgloss
-@@ -1261,6 +1283,7 @@ info-target: maybe-info-target-libgfortr
+@@ -1261,6 +1287,7 @@ info-target: maybe-info-target-libgfortr
  info-target: maybe-info-target-libobjc
  info-target: maybe-info-target-libgo
  info-target: maybe-info-target-libhsail-rt
@@ -202,7 +223,7 @@ This implements building of libphobos library in GCC.
  info-target: maybe-info-target-libtermcap
  info-target: maybe-info-target-winsup
  info-target: maybe-info-target-libgloss
-@@ -1345,6 +1368,7 @@ dvi-target: maybe-dvi-target-libgfortran
+@@ -1345,6 +1372,7 @@ dvi-target: maybe-dvi-target-libgfortran
  dvi-target: maybe-dvi-target-libobjc
  dvi-target: maybe-dvi-target-libgo
  dvi-target: maybe-dvi-target-libhsail-rt
@@ -210,7 +231,7 @@ This implements building of libphobos library in GCC.
  dvi-target: maybe-dvi-target-libtermcap
  dvi-target: maybe-dvi-target-winsup
  dvi-target: maybe-dvi-target-libgloss
-@@ -1429,6 +1453,7 @@ pdf-target: maybe-pdf-target-libgfortran
+@@ -1429,6 +1457,7 @@ pdf-target: maybe-pdf-target-libgfortran
  pdf-target: maybe-pdf-target-libobjc
  pdf-target: maybe-pdf-target-libgo
  pdf-target: maybe-pdf-target-libhsail-rt
@@ -218,7 +239,7 @@ This implements building of libphobos library in GCC.
  pdf-target: maybe-pdf-target-libtermcap
  pdf-target: maybe-pdf-target-winsup
  pdf-target: maybe-pdf-target-libgloss
-@@ -1513,6 +1538,7 @@ html-target: maybe-html-target-libgfortr
+@@ -1513,6 +1542,7 @@ html-target: maybe-html-target-libgfortr
  html-target: maybe-html-target-libobjc
  html-target: maybe-html-target-libgo
  html-target: maybe-html-target-libhsail-rt
@@ -226,7 +247,7 @@ This implements building of libphobos library in GCC.
  html-target: maybe-html-target-libtermcap
  html-target: maybe-html-target-winsup
  html-target: maybe-html-target-libgloss
-@@ -1597,6 +1623,7 @@ TAGS-target: maybe-TAGS-target-libgfortr
+@@ -1597,6 +1627,7 @@ TAGS-target: maybe-TAGS-target-libgfortr
  TAGS-target: maybe-TAGS-target-libobjc
  TAGS-target: maybe-TAGS-target-libgo
  TAGS-target: maybe-TAGS-target-libhsail-rt
@@ -234,7 +255,7 @@ This implements building of libphobos library in GCC.
  TAGS-target: maybe-TAGS-target-libtermcap
  TAGS-target: maybe-TAGS-target-winsup
  TAGS-target: maybe-TAGS-target-libgloss
-@@ -1681,6 +1708,7 @@ install-info-target: maybe-install-info-
+@@ -1681,6 +1712,7 @@ install-info-target: maybe-install-info-
  install-info-target: maybe-install-info-target-libobjc
  install-info-target: maybe-install-info-target-libgo
  install-info-target: maybe-install-info-target-libhsail-rt
@@ -242,7 +263,7 @@ This implements building of libphobos library in GCC.
  install-info-target: maybe-install-info-target-libtermcap
  install-info-target: maybe-install-info-target-winsup
  install-info-target: maybe-install-info-target-libgloss
-@@ -1765,6 +1793,7 @@ install-pdf-target: maybe-install-pdf-ta
+@@ -1765,6 +1797,7 @@ install-pdf-target: maybe-install-pdf-ta
  install-pdf-target: maybe-install-pdf-target-libobjc
  install-pdf-target: maybe-install-pdf-target-libgo
  install-pdf-target: maybe-install-pdf-target-libhsail-rt
@@ -250,7 +271,7 @@ This implements building of libphobos library in GCC.
  install-pdf-target: maybe-install-pdf-target-libtermcap
  install-pdf-target: maybe-install-pdf-target-winsup
  install-pdf-target: maybe-install-pdf-target-libgloss
-@@ -1849,6 +1878,7 @@ install-html-target: maybe-install-html-
+@@ -1849,6 +1882,7 @@ install-html-target: maybe-install-html-
  install-html-target: maybe-install-html-target-libobjc
  install-html-target: maybe-install-html-target-libgo
  install-html-target: maybe-install-html-target-libhsail-rt
@@ -258,7 +279,7 @@ This implements building of libphobos library in GCC.
  install-html-target: maybe-install-html-target-libtermcap
  install-html-target: maybe-install-html-target-winsup
  install-html-target: maybe-install-html-target-libgloss
-@@ -1933,6 +1963,7 @@ installcheck-target: maybe-installcheck-
+@@ -1933,6 +1967,7 @@ installcheck-target: maybe-installcheck-
  installcheck-target: maybe-installcheck-target-libobjc
  installcheck-target: maybe-installcheck-target-libgo
  installcheck-target: maybe-installcheck-target-libhsail-rt
@@ -266,7 +287,7 @@ This implements building of libphobos library in GCC.
  installcheck-target: maybe-installcheck-target-libtermcap
  installcheck-target: maybe-installcheck-target-winsup
  installcheck-target: maybe-installcheck-target-libgloss
-@@ -2017,6 +2048,7 @@ mostlyclean-target: maybe-mostlyclean-ta
+@@ -2017,6 +2052,7 @@ mostlyclean-target: maybe-mostlyclean-ta
  mostlyclean-target: maybe-mostlyclean-target-libobjc
  mostlyclean-target: maybe-mostlyclean-target-libgo
  mostlyclean-target: maybe-mostlyclean-target-libhsail-rt
@@ -274,7 +295,7 @@ This implements building of libphobos library in GCC.
  mostlyclean-target: maybe-mostlyclean-target-libtermcap
  mostlyclean-target: maybe-mostlyclean-target-winsup
  mostlyclean-target: maybe-mostlyclean-target-libgloss
-@@ -2101,6 +2133,7 @@ clean-target: maybe-clean-target-libgfor
+@@ -2101,6 +2137,7 @@ clean-target: maybe-clean-target-libgfor
  clean-target: maybe-clean-target-libobjc
  clean-target: maybe-clean-target-libgo
  clean-target: maybe-clean-target-libhsail-rt
@@ -282,7 +303,7 @@ This implements building of libphobos library in GCC.
  clean-target: maybe-clean-target-libtermcap
  clean-target: maybe-clean-target-winsup
  clean-target: maybe-clean-target-libgloss
-@@ -2185,6 +2218,7 @@ distclean-target: maybe-distclean-target
+@@ -2185,6 +2222,7 @@ distclean-target: maybe-distclean-target
  distclean-target: maybe-distclean-target-libobjc
  distclean-target: maybe-distclean-target-libgo
  distclean-target: maybe-distclean-target-libhsail-rt
@@ -290,7 +311,7 @@ This implements building of libphobos library in GCC.
  distclean-target: maybe-distclean-target-libtermcap
  distclean-target: maybe-distclean-target-winsup
  distclean-target: maybe-distclean-target-libgloss
-@@ -2269,6 +2303,7 @@ maintainer-clean-target: maybe-maintaine
+@@ -2269,6 +2307,7 @@ maintainer-clean-target: maybe-maintaine
  maintainer-clean-target: maybe-maintainer-clean-target-libobjc
  maintainer-clean-target: maybe-maintainer-clean-target-libgo
  maintainer-clean-target: maybe-maintainer-clean-target-libhsail-rt
@@ -298,7 +319,7 @@ This implements building of libphobos library in GCC.
  maintainer-clean-target: maybe-maintainer-clean-target-libtermcap
  maintainer-clean-target: maybe-maintainer-clean-target-winsup
  maintainer-clean-target: maybe-maintainer-clean-target-libgloss
-@@ -2409,6 +2444,7 @@ check-target:  \
+@@ -2409,6 +2448,7 @@ check-target:  \
      maybe-check-target-libobjc \
      maybe-check-target-libgo \
      maybe-check-target-libhsail-rt \
@@ -306,7 +327,7 @@ This implements building of libphobos library in GCC.
      maybe-check-target-libtermcap \
      maybe-check-target-winsup \
      maybe-check-target-libgloss \
-@@ -2589,6 +2625,7 @@ install-target:  \
+@@ -2589,6 +2629,7 @@ install-target:  \
      maybe-install-target-libobjc \
      maybe-install-target-libgo \
      maybe-install-target-libhsail-rt \
@@ -314,7 +335,7 @@ This implements building of libphobos library in GCC.
      maybe-install-target-libtermcap \
      maybe-install-target-winsup \
      maybe-install-target-libgloss \
-@@ -2693,6 +2730,7 @@ install-strip-target:  \
+@@ -2693,6 +2734,7 @@ install-strip-target:  \
      maybe-install-strip-target-libobjc \
      maybe-install-strip-target-libgo \
      maybe-install-strip-target-libhsail-rt \
@@ -322,7 +343,7 @@ This implements building of libphobos library in GCC.
      maybe-install-strip-target-libtermcap \
      maybe-install-strip-target-winsup \
      maybe-install-strip-target-libgloss \
-@@ -46944,6 +46982,464 @@ maintainer-clean-target-libhsail-rt:
+@@ -46944,6 +46986,464 @@ maintainer-clean-target-libhsail-rt:
  
  
  
@@ -787,7 +808,7 @@ This implements building of libphobos library in GCC.
  .PHONY: configure-target-libtermcap maybe-configure-target-libtermcap
  maybe-configure-target-libtermcap:
  @if gcc-bootstrap
-@@ -52325,6 +52821,14 @@ check-gcc-brig:
+@@ -52325,6 +52825,14 @@ check-gcc-brig:
  	(cd gcc && $(MAKE) $(GCC_FLAGS_TO_PASS) check-brig);
  check-brig: check-gcc-brig check-target-libhsail-rt
  
@@ -802,7 +823,7 @@ This implements building of libphobos library in GCC.
  
  # The gcc part of install-no-fixedincludes, which relies on an intimate
  # knowledge of how a number of gcc internal targets (inter)operate.  Delegate.
-@@ -55517,6 +56021,7 @@ configure-target-libgfortran: stage_last
+@@ -55517,6 +56025,7 @@ configure-target-libgfortran: stage_last
  configure-target-libobjc: stage_last
  configure-target-libgo: stage_last
  configure-target-libhsail-rt: stage_last
@@ -810,7 +831,7 @@ This implements building of libphobos library in GCC.
  configure-target-libtermcap: stage_last
  configure-target-winsup: stage_last
  configure-target-libgloss: stage_last
-@@ -55551,6 +56056,7 @@ configure-target-libgfortran: maybe-all-
+@@ -55551,6 +56060,7 @@ configure-target-libgfortran: maybe-all-
  configure-target-libobjc: maybe-all-gcc
  configure-target-libgo: maybe-all-gcc
  configure-target-libhsail-rt: maybe-all-gcc
@@ -818,7 +839,7 @@ This implements building of libphobos library in GCC.
  configure-target-libtermcap: maybe-all-gcc
  configure-target-winsup: maybe-all-gcc
  configure-target-libgloss: maybe-all-gcc
-@@ -56667,6 +57173,11 @@ configure-target-libgo: maybe-all-target
+@@ -56667,6 +57177,11 @@ configure-target-libgo: maybe-all-target
  all-target-libgo: maybe-all-target-libbacktrace
  all-target-libgo: maybe-all-target-libffi
  all-target-libgo: maybe-all-target-libatomic
@@ -830,7 +851,7 @@ This implements building of libphobos library in GCC.
  configure-target-libstdc++-v3: maybe-configure-target-libgomp
  
  configure-stage1-target-libstdc++-v3: maybe-configure-stage1-target-libgomp
-@@ -56716,6 +57227,7 @@ all-target-liboffloadmic: maybe-all-targ
+@@ -56716,6 +57231,7 @@ all-target-liboffloadmic: maybe-all-targ
  install-target-libgo: maybe-install-target-libatomic
  install-target-libgfortran: maybe-install-target-libquadmath
  install-target-libgfortran: maybe-install-target-libgcc
@@ -838,7 +859,7 @@ This implements building of libphobos library in GCC.
  install-target-libsanitizer: maybe-install-target-libstdc++-v3
  install-target-libsanitizer: maybe-install-target-libgcc
  install-target-libvtv: maybe-install-target-libstdc++-v3
-@@ -56790,6 +57302,7 @@ configure-target-libgfortran: maybe-all-
+@@ -56790,6 +57306,7 @@ configure-target-libgfortran: maybe-all-
  configure-target-libobjc: maybe-all-target-libgcc
  configure-target-libgo: maybe-all-target-libgcc
  configure-target-libhsail-rt: maybe-all-target-libgcc
@@ -846,7 +867,7 @@ This implements building of libphobos library in GCC.
  configure-target-libtermcap: maybe-all-target-libgcc
  configure-target-winsup: maybe-all-target-libgcc
  configure-target-libgloss: maybe-all-target-libgcc
-@@ -56828,6 +57341,8 @@ configure-target-libgo: maybe-all-target
+@@ -56828,6 +57345,8 @@ configure-target-libgo: maybe-all-target
  
  configure-target-libhsail-rt: maybe-all-target-newlib maybe-all-target-libgloss
  


### PR DESCRIPTION
One variable in the toplevel configure script expects target_libs to be delimited by spaces, whilst another expects to be by commas.

Pulled from ddmd patch as can be applied independently.