### PR TITLE
Test running with stack protector enabled

### DIFF
--- a/gcc/testsuite/gdc.dg/compilable.d
+++ b/gcc/testsuite/gdc.dg/compilable.d
@@ -1,5 +1,6 @@
 // { dg-options "-I $srcdir/gdc.dg -I $srcdir/gdc.dg/imports" }
 // { dg-additional-sources "imports/gdc27.d imports/gdc231.d" }
+// { dg-do compile }
 
 import core.simd;
 import gcc.attribute;

--- a/gcc/testsuite/gdc.dg/gdc254.d
+++ b/gcc/testsuite/gdc.dg/gdc254.d
@@ -1,5 +1,6 @@
 // { dg-options "-I $srcdir/gdc.dg" }
 // { dg-shouldfail "interface function is not implemented" }
+// { dg-do compile }
 
 import imports.gdc254a;
 

--- a/gcc/testsuite/gdc.dg/gdc260.d
+++ b/gcc/testsuite/gdc.dg/gdc260.d
@@ -1,4 +1,5 @@
 // { dg-options "-Wall -Werror" }
+// { dg-do compile }
 import gcc.builtins;
 
 char *bug260(char *buffer)

--- a/gcc/testsuite/gdc.dg/gdc270a.d
+++ b/gcc/testsuite/gdc.dg/gdc270a.d
@@ -1,3 +1,5 @@
+// { dg-do compile }
+
 // Bug 270
 
 module gdc270;

--- a/gcc/testsuite/gdc.dg/gdc270b.d
+++ b/gcc/testsuite/gdc.dg/gdc270b.d
@@ -1,3 +1,5 @@
+// { dg-do compile }
+
 // Bug 270
 
 module gdc270;

--- a/gcc/testsuite/gdc.dg/gdc282.d
+++ b/gcc/testsuite/gdc.dg/gdc282.d
@@ -1,4 +1,5 @@
 // { dg-shouldfail "conflicting methods in class" }
+// { dg-do compile }
 
 class C282a
 {

--- a/semaphoreci.sh
+++ b/semaphoreci.sh
@@ -119,7 +119,7 @@ alltests() {
 testsuite() {
     ## Run just the compiler testsuite.
     cd ${SEMAPHORE_PROJECT_DIR}/build
-    make -j$(nproc) check-gcc-d
+    make -j$(nproc) check-gcc-d RUNTESTFLAGS="--target_board=unix\{,-fstack-protector\}"
 
     ## Print out summaries of testsuite run after finishing.
     # Just omit testsuite PASSes from the summary file.
@@ -135,7 +135,7 @@ testsuite() {
 unittests() {
     ## Run just the library unittests.
     cd ${SEMAPHORE_PROJECT_DIR}/build
-    if ! make -j$(nproc) check-target-libphobos; then
+    if ! make -j$(nproc) check-target-libphobos RUNTESTFLAGS="--target_board=unix\{,-fstack-protector\}"; then
         echo "== Unittest has failures =="
         exit 1
     fi


### PR DESCRIPTION
Recent debian builds showed up failures, just cross checking this on semaphore / master.