### PR TITLE
Explicitly set test action as compile in all dg tests.

### DIFF
--- a/gcc/testsuite/gdc.dg/compilable.d
+++ b/gcc/testsuite/gdc.dg/compilable.d
@@ -1,5 +1,6 @@
 // { dg-options "-I $srcdir/gdc.dg -I $srcdir/gdc.dg/imports" }
 // { dg-additional-sources "imports/gdc27.d imports/gdc231.d" }
+// { dg-do compile }
 
 import core.simd;
 import gcc.attribute;

--- a/gcc/testsuite/gdc.dg/gdc254.d
+++ b/gcc/testsuite/gdc.dg/gdc254.d
@@ -1,5 +1,6 @@
 // { dg-options "-I $srcdir/gdc.dg" }
 // { dg-shouldfail "interface function is not implemented" }
+// { dg-do compile }
 
 import imports.gdc254a;
 

--- a/gcc/testsuite/gdc.dg/gdc260.d
+++ b/gcc/testsuite/gdc.dg/gdc260.d
@@ -1,4 +1,5 @@
 // { dg-options "-Wall -Werror" }
+// { dg-do compile }
 import gcc.builtins;
 
 char *bug260(char *buffer)

--- a/gcc/testsuite/gdc.dg/gdc270a.d
+++ b/gcc/testsuite/gdc.dg/gdc270a.d
@@ -1,3 +1,5 @@
+// { dg-do compile }
+
 // Bug 270
 
 module gdc270;

--- a/gcc/testsuite/gdc.dg/gdc270b.d
+++ b/gcc/testsuite/gdc.dg/gdc270b.d
@@ -1,3 +1,5 @@
+// { dg-do compile }
+
 // Bug 270
 
 module gdc270;

--- a/gcc/testsuite/gdc.dg/gdc282.d
+++ b/gcc/testsuite/gdc.dg/gdc282.d
@@ -1,4 +1,5 @@
 // { dg-shouldfail "conflicting methods in class" }
+// { dg-do compile }
 
 class C282a
 {


### PR DESCRIPTION
When running the testsuite with multiple `RUNTESTFLAGS` configurations, the last `dg-do-what` setting is carried over, meaning on the next iteration, tests are ran in a different way, resulting in bogus failures.  See #679.