### PR TITLE
Don't run unittester when testing cross compilers

### DIFF
--- a/libphobos/testsuite/libphobos.unittests/unittests.exp
+++ b/libphobos/testsuite/libphobos.unittests/unittests.exp
@@ -14,6 +14,11 @@
 # along with GCC; see the file COPYING3.  If not see
 # <http://www.gnu.org/licenses/>.
 
+# Immediately exit if we can't run target executables.
+if { ![isnative] } {
+    return
+}
+
 proc unittest_list_modules { prog } {
     # Running the test runner without arguments prints a list of all
     # modules that have unittests compiled in.


### PR DESCRIPTION
This test only works when the hardware is available.