### PR TITLE
Remove pipe and Wno-deprecated from phobos makefiles

### DIFF
--- a/libphobos/libdruntime/Makefile.am
+++ b/libphobos/libdruntime/Makefile.am
@@ -19,7 +19,7 @@
 include $(top_srcdir)/d_rules.am
 
 # Make sure GDC can find libdruntime include files
-D_EXTRA_DFLAGS=-nostdinc -pipe -Wno-deprecated -I $(srcdir) -I .
+D_EXTRA_DFLAGS=-nostdinc -I $(srcdir) -I .
 
 # D flags for compilation
 AM_DFLAGS=$(phobos_compiler_pic_flag)

--- a/libphobos/libdruntime/Makefile.in
+++ b/libphobos/libdruntime/Makefile.in
@@ -634,7 +634,7 @@ libgphobos_t_la_LINK = $(LIBTOOL) --tag=D \
 # Include D build rules
 
 # Make sure GDC can find libdruntime include files
-D_EXTRA_DFLAGS = -nostdinc -pipe -Wno-deprecated -I $(srcdir) -I .
+D_EXTRA_DFLAGS = -nostdinc -I $(srcdir) -I .
 
 # D flags for compilation
 AM_DFLAGS = $(phobos_compiler_pic_flag)

--- a/libphobos/src/Makefile.am
+++ b/libphobos/src/Makefile.am
@@ -19,7 +19,7 @@
 include $(top_srcdir)/d_rules.am
 
 # Make sure GDC can find libdruntime and libphobos include files
-D_EXTRA_DFLAGS=-nostdinc -pipe -Wno-deprecated -I $(srcdir) \
+D_EXTRA_DFLAGS=-nostdinc -I $(srcdir) \
 	-I $(top_srcdir)/libdruntime -I ../libdruntime -I .
 
 # C flags for zlib compilation

--- a/libphobos/src/Makefile.in
+++ b/libphobos/src/Makefile.in
@@ -623,7 +623,7 @@ libgphobos_t_la_LINK = $(LIBTOOL) --tag=D \
 # Include D build rules
 
 # Make sure GDC can find libdruntime and libphobos include files
-D_EXTRA_DFLAGS = -nostdinc -pipe -Wno-deprecated -I $(srcdir) \
+D_EXTRA_DFLAGS = -nostdinc -I $(srcdir) \
 	-I $(top_srcdir)/libdruntime -I ../libdruntime -I .
 
 


### PR DESCRIPTION
The former is an old artefact and the latter should no longer be necessary.