### PR TITLE
[gdc-8] Sync toplevel patches with master and regenerate

### DIFF
--- a/gcc/d/patches/patch-gcc-8.patch
+++ b/gcc/d/patches/patch-gcc-8.patch
@@ -4,7 +4,7 @@ relevant documentation about the GDC front end.
 
 --- a/gcc/config/powerpcspe/powerpcspe.c
 +++ b/gcc/config/powerpcspe/powerpcspe.c
-@@ -32035,11 +32035,12 @@ rs6000_output_function_epilogue (FILE *f
+@@ -32034,11 +32034,12 @@ rs6000_output_function_epilogue (FILE *f
  	 use language_string.
  	 C is 0.  Fortran is 1.  Pascal is 2.  Ada is 3.  C++ is 9.
  	 Java is 13.  Objective-C is 14.  Objective-C++ isn't assigned
@@ -21,7 +21,7 @@ relevant documentation about the GDC front end.
        else if (! strcmp (language_string, "GNU F77")
 --- a/gcc/config/rs6000/rs6000.c
 +++ b/gcc/config/rs6000/rs6000.c
-@@ -29228,11 +29228,12 @@ rs6000_output_function_epilogue (FILE *f
+@@ -29305,11 +29305,12 @@ rs6000_output_function_epilogue (FILE *f
  	 use language_string.
  	 C is 0.  Fortran is 1.  Pascal is 2.  Ada is 3.  C++ is 9.
  	 Java is 13.  Objective-C is 14.  Objective-C++ isn't assigned
@@ -164,7 +164,7 @@ relevant documentation about the GDC front end.
  /* Remove the specified attribute if present.  Return TRUE if removal
     was successful.  */
  
-@@ -24403,6 +24413,8 @@ gen_compile_unit_die (const char *filena
+@@ -24417,6 +24427,8 @@ gen_compile_unit_die (const char *filena
  	language = DW_LANG_ObjC;
        else if (strcmp (language_string, "GNU Objective-C++") == 0)
  	language = DW_LANG_ObjC_plus_plus;
@@ -173,7 +173,7 @@ relevant documentation about the GDC front end.
        else if (dwarf_version >= 5 || !dwarf_strict)
  	{
  	  if (strcmp (language_string, "GNU Go") == 0)
-@@ -26006,7 +26018,7 @@ declare_in_namespace (tree thing, dw_die
+@@ -26017,7 +26029,7 @@ declare_in_namespace (tree thing, dw_die
  
    if (ns_context != context_die)
      {
@@ -182,7 +182,7 @@ relevant documentation about the GDC front end.
  	return ns_context;
        if (DECL_P (thing))
  	gen_decl_die (thing, NULL, NULL, ns_context);
-@@ -26029,7 +26041,7 @@ gen_namespace_die (tree decl, dw_die_ref
+@@ -26040,7 +26052,7 @@ gen_namespace_die (tree decl, dw_die_ref
      {
        /* Output a real namespace or module.  */
        context_die = setup_namespace_context (decl, comp_unit_die ());
@@ -191,7 +191,7 @@ relevant documentation about the GDC front end.
  			       ? DW_TAG_module : DW_TAG_namespace,
  			       context_die, decl);
        /* For Fortran modules defined in different CU don't add src coords.  */
-@@ -26101,7 +26113,7 @@ gen_decl_die (tree decl, tree origin, st
+@@ -26112,7 +26124,7 @@ gen_decl_die (tree decl, tree origin, st
        break;
  
      case CONST_DECL:
@@ -200,7 +200,7 @@ relevant documentation about the GDC front end.
  	{
  	  /* The individual enumerators of an enum type get output when we output
  	     the Dwarf representation of the relevant enum type itself.  */
-@@ -26698,7 +26710,7 @@ dwarf2out_decl (tree decl)
+@@ -26709,7 +26721,7 @@ dwarf2out_decl (tree decl)
      case CONST_DECL:
        if (debug_info_level <= DINFO_LEVEL_TERSE)
  	return;
@@ -209,7 +209,7 @@ relevant documentation about the GDC front end.
  	return;
        if (TREE_STATIC (decl) && decl_function_context (decl))
  	context_die = lookup_decl_die (DECL_CONTEXT (decl));
-@@ -29110,6 +29122,7 @@ prune_unused_types_walk_local_classes (d
+@@ -29054,6 +29066,7 @@ prune_unused_types_walk_local_classes (d
      case DW_TAG_structure_type:
      case DW_TAG_union_type:
      case DW_TAG_class_type:
@@ -217,7 +217,7 @@ relevant documentation about the GDC front end.
        break;
  
      case DW_TAG_subprogram:
-@@ -29143,6 +29156,7 @@ prune_unused_types_walk (dw_die_ref die)
+@@ -29087,6 +29100,7 @@ prune_unused_types_walk (dw_die_ref die)
      case DW_TAG_structure_type:
      case DW_TAG_union_type:
      case DW_TAG_class_type:
@@ -225,7 +225,7 @@ relevant documentation about the GDC front end.
        if (die->die_perennial_p)
  	break;
  
-@@ -29169,7 +29183,6 @@ prune_unused_types_walk (dw_die_ref die)
+@@ -29113,7 +29127,6 @@ prune_unused_types_walk (dw_die_ref die)
      case DW_TAG_volatile_type:
      case DW_TAG_typedef:
      case DW_TAG_array_type:
@@ -235,7 +235,7 @@ relevant documentation about the GDC front end.
      case DW_TAG_subroutine_type:
 --- a/gcc/gcc.c
 +++ b/gcc/gcc.c
-@@ -1306,6 +1306,7 @@ static const struct compiler default_com
+@@ -1301,6 +1301,7 @@ static const struct compiler default_com
    {".f08", "#Fortran", 0, 0, 0}, {".F08", "#Fortran", 0, 0, 0},
    {".r", "#Ratfor", 0, 0, 0},
    {".go", "#Go", 0, 1, 0},

--- a/gcc/d/patches/patch-targetdm-8.patch
+++ b/gcc/d/patches/patch-targetdm-8.patch
@@ -308,7 +308,7 @@ The following OS versions are implemented:
    ;;
  *-*-netbsd*)
    tm_p_file="${tm_p_file} netbsd-protos.h"
-@@ -3183,6 +3207,10 @@ if [ "$common_out_file" = "" ]; then
+@@ -3185,6 +3209,10 @@ if [ "$common_out_file" = "" ]; then
    fi
  fi
  
@@ -319,7 +319,7 @@ The following OS versions are implemented:
  # Support for --with-cpu and related options (and a few unrelated options,
  # too).
  case ${with_cpu} in
-@@ -4734,6 +4762,7 @@ case ${target} in
+@@ -4726,6 +4754,7 @@ case ${target} in
  		out_file="${cpu_type}/${cpu_type}.c"
  		c_target_objs="${c_target_objs} ${cpu_type}-c.o"
  		cxx_target_objs="${cxx_target_objs} ${cpu_type}-c.o"
@@ -1138,7 +1138,7 @@ The following OS versions are implemented:
  
 --- a/gcc/config/rs6000/linux64.h
 +++ b/gcc/config/rs6000/linux64.h
-@@ -398,6 +398,19 @@ extern int dot_symbols;
+@@ -391,6 +391,19 @@ extern int dot_symbols;
      }							\
    while (0)
  
@@ -1220,7 +1220,7 @@ The following OS versions are implemented:
  #endif
 --- a/gcc/config/rs6000/rs6000.h
 +++ b/gcc/config/rs6000/rs6000.h
-@@ -797,6 +797,9 @@ extern unsigned char rs6000_recip_bits[]
+@@ -800,6 +800,9 @@ extern unsigned char rs6000_recip_bits[]
  #define TARGET_CPU_CPP_BUILTINS() \
    rs6000_cpu_cpp_builtins (pfile)
  
@@ -1232,7 +1232,7 @@ The following OS versions are implemented:
  #define RS6000_CPU_CPP_ENDIAN_BUILTINS()	\
 --- a/gcc/config/rs6000/t-rs6000
 +++ b/gcc/config/rs6000/t-rs6000
-@@ -34,6 +34,10 @@ rs6000-p8swap.o: $(srcdir)/config/rs6000
+@@ -35,6 +35,10 @@ rs6000-p8swap.o: $(srcdir)/config/rs6000
  	$(COMPILE) $<
  	$(POSTCOMPILE)
  

--- a/gcc/d/patches/patch-toplev-8.patch
+++ b/gcc/d/patches/patch-toplev-8.patch
@@ -1109,15 +1109,6 @@ This implements building of libphobos library in GCC.
  		;;
  	    esac
  	    ;;
-@@ -6652,7 +6660,7 @@ fi
- # Check whether --with-gcc-major-version-only was given.
- if test "${with_gcc_major_version_only+set}" = set; then :
-   withval=$with_gcc_major_version_only; if test x$with_gcc_major_version_only = xyes ; then
--        get_gcc_base_ver="sed -e 's/^\([0-9]*\).*\$\$/\1/'"
-+        get_gcc_base_ver="sed -e 's/^\([0-9]*\).*/\1/'"
-       fi
- 
- fi
 @@ -7666,6 +7674,7 @@ done
  
  


### PR DESCRIPTION
The toplev patches are needed to ensure bootstrapping works.