### PR TITLE
[gdc-7] Sync toplevel patches with master and regenerate

### DIFF
--- a/gcc/d/patches/patch-toplev-7.patch
+++ b/gcc/d/patches/patch-toplev-7.patch
@@ -12,7 +12,16 @@ This implements building of libphobos library in GCC.
  target_modules = { module= libtermcap; no_check=true;
                     missing=mostlyclean;
                     missing=clean;
-@@ -283,6 +285,8 @@ flags_to_pass = { flag= FLAGS_FOR_TARGET
+@@ -270,6 +272,8 @@ flags_to_pass = { flag= STAGE1_CHECKING
+ flags_to_pass = { flag= STAGE1_LANGUAGES ; };
+ flags_to_pass = { flag= GNATBIND ; };
+ flags_to_pass = { flag= GNATMAKE ; };
++flags_to_pass = { flag= GDC ; };
++flags_to_pass = { flag= GDCFLAGS ; };
+ 
+ // Target tools
+ flags_to_pass = { flag= AR_FOR_TARGET ; };
+@@ -283,6 +287,8 @@ flags_to_pass = { flag= FLAGS_FOR_TARGET
  flags_to_pass = { flag= GFORTRAN_FOR_TARGET ; };
  flags_to_pass = { flag= GOC_FOR_TARGET ; };
  flags_to_pass = { flag= GOCFLAGS_FOR_TARGET ; };
@@ -21,7 +30,7 @@ This implements building of libphobos library in GCC.
  flags_to_pass = { flag= LD_FOR_TARGET ; };
  flags_to_pass = { flag= LIPO_FOR_TARGET ; };
  flags_to_pass = { flag= LDFLAGS_FOR_TARGET ; };
-@@ -550,6 +554,11 @@ dependencies = { module=configure-target
+@@ -550,6 +556,11 @@ dependencies = { module=configure-target
  dependencies = { module=all-target-libgo; on=all-target-libbacktrace; };
  dependencies = { module=all-target-libgo; on=all-target-libffi; };
  dependencies = { module=all-target-libgo; on=all-target-libatomic; };
@@ -33,7 +42,7 @@ This implements building of libphobos library in GCC.
  dependencies = { module=configure-target-libstdc++-v3; on=configure-target-libgomp; };
  dependencies = { module=configure-target-liboffloadmic; on=configure-target-libgomp; };
  dependencies = { module=configure-target-libsanitizer; on=all-target-libstdc++-v3; };
-@@ -563,6 +572,7 @@ dependencies = { module=all-target-libof
+@@ -563,6 +574,7 @@ dependencies = { module=all-target-libof
  dependencies = { module=install-target-libgo; on=install-target-libatomic; };
  dependencies = { module=install-target-libgfortran; on=install-target-libquadmath; };
  dependencies = { module=install-target-libgfortran; on=install-target-libgcc; };
@@ -41,7 +50,7 @@ This implements building of libphobos library in GCC.
  dependencies = { module=install-target-libsanitizer; on=install-target-libstdc++-v3; };
  dependencies = { module=install-target-libsanitizer; on=install-target-libgcc; };
  dependencies = { module=install-target-libvtv; on=install-target-libstdc++-v3; };
-@@ -604,6 +614,8 @@ languages = { language=go;	gcc-check-tar
+@@ -604,6 +616,8 @@ languages = { language=go;	gcc-check-tar
  				lib-check-target=check-target-libgo; };
  languages = { language=brig;	gcc-check-target=check-brig;
  				lib-check-target=check-target-libhsail-rt; };
@@ -78,7 +87,7 @@ This implements building of libphobos library in GCC.
 +	  -I$$r/prev-$(TARGET_SUBDIR)/libphobos/libdruntime -I$$s/libphobos/libdruntime \
 +	  -L$$r/prev-$(TARGET_SUBDIR)/libphobos/src/.libs"; \
 +	export GDC; \
-+ 	GDC_FOR_BUILD="$$GDC"; export GDC_FOR_BUILD; \
++	GDC_FOR_BUILD="$$GDC"; export GDC_FOR_BUILD; \
  	GNATBIND="$$r/$(HOST_SUBDIR)/prev-gcc/gnatbind"; export GNATBIND; \
  	LDFLAGS="$(POSTSTAGE1_LDFLAGS) $(BOOT_LDFLAGS)"; export LDFLAGS; \
  	HOST_LIBS="$(POSTSTAGE1_LIBS)"; export HOST_LIBS;
@@ -98,7 +107,15 @@ This implements building of libphobos library in GCC.
  LDFLAGS_FOR_BUILD = @LDFLAGS_FOR_BUILD@
  LD_FOR_BUILD = @LD_FOR_BUILD@
  NM_FOR_BUILD = @NM_FOR_BUILD@
-@@ -408,6 +419,7 @@ LIBCFLAGS = $(CFLAGS)
+@@ -399,6 +410,7 @@ STRIP = @STRIP@
+ WINDRES = @WINDRES@
+ WINDMC = @WINDMC@
+ 
++GDC = @GDC@
+ GNATBIND = @GNATBIND@
+ GNATMAKE = @GNATMAKE@
+ 
+@@ -408,6 +420,7 @@ LIBCFLAGS = $(CFLAGS)
  CXXFLAGS = @CXXFLAGS@
  LIBCXXFLAGS = $(CXXFLAGS) -fno-implicit-templates
  GOCFLAGS = $(CFLAGS)
@@ -106,7 +123,7 @@ This implements building of libphobos library in GCC.
  
  CREATE_GCOV = create_gcov
  
-@@ -551,6 +563,7 @@ CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @CXX_
+@@ -551,6 +564,7 @@ CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @CXX_
  RAW_CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @RAW_CXX_FOR_TARGET@
  GFORTRAN_FOR_TARGET=$(STAGE_CC_WRAPPER) @GFORTRAN_FOR_TARGET@
  GOC_FOR_TARGET=$(STAGE_CC_WRAPPER) @GOC_FOR_TARGET@
@@ -114,7 +131,7 @@ This implements building of libphobos library in GCC.
  DLLTOOL_FOR_TARGET=@DLLTOOL_FOR_TARGET@
  LD_FOR_TARGET=@LD_FOR_TARGET@
  
-@@ -575,6 +588,7 @@ LIBCFLAGS_FOR_TARGET = $(CFLAGS_FOR_TARG
+@@ -575,6 +589,7 @@ LIBCFLAGS_FOR_TARGET = $(CFLAGS_FOR_TARG
  LIBCXXFLAGS_FOR_TARGET = $(CXXFLAGS_FOR_TARGET) -fno-implicit-templates
  LDFLAGS_FOR_TARGET = @LDFLAGS_FOR_TARGET@
  GOCFLAGS_FOR_TARGET = -O2 -g
@@ -122,7 +139,7 @@ This implements building of libphobos library in GCC.
  
  FLAGS_FOR_TARGET = @FLAGS_FOR_TARGET@
  SYSROOT_CFLAGS_FOR_TARGET = @SYSROOT_CFLAGS_FOR_TARGET@
-@@ -599,7 +613,7 @@ all:
+@@ -599,7 +614,7 @@ all:
  
  # This is the list of directories that may be needed in RPATH_ENVVAR
  # so that programs built for the target machine work.
@@ -131,7 +148,7 @@ This implements building of libphobos library in GCC.
  
  @if target-libstdc++-v3
  TARGET_LIB_PATH_libstdc++-v3 = $$r/$(TARGET_SUBDIR)/libstdc++-v3/src/.libs:
-@@ -629,6 +643,10 @@ TARGET_LIB_PATH_liboffloadmic = $$r/$(TA
+@@ -629,6 +644,10 @@ TARGET_LIB_PATH_liboffloadmic = $$r/$(TA
  TARGET_LIB_PATH_libssp = $$r/$(TARGET_SUBDIR)/libssp/.libs:
  @endif target-libssp
  
@@ -142,7 +159,16 @@ This implements building of libphobos library in GCC.
  @if target-libgomp
  TARGET_LIB_PATH_libgomp = $$r/$(TARGET_SUBDIR)/libgomp/.libs:
  @endif target-libgomp
-@@ -774,6 +792,8 @@ BASE_FLAGS_TO_PASS = \
+@@ -763,6 +782,8 @@ BASE_FLAGS_TO_PASS = \
+ 	"STAGE1_LANGUAGES=$(STAGE1_LANGUAGES)" \
+ 	"GNATBIND=$(GNATBIND)" \
+ 	"GNATMAKE=$(GNATMAKE)" \
++	"GDC=$(GDC)" \
++	"GDCFLAGS=$(GDCFLAGS)" \
+ 	"AR_FOR_TARGET=$(AR_FOR_TARGET)" \
+ 	"AS_FOR_TARGET=$(AS_FOR_TARGET)" \
+ 	"CC_FOR_TARGET=$(CC_FOR_TARGET)" \
+@@ -774,6 +795,8 @@ BASE_FLAGS_TO_PASS = \
  	"GFORTRAN_FOR_TARGET=$(GFORTRAN_FOR_TARGET)" \
  	"GOC_FOR_TARGET=$(GOC_FOR_TARGET)" \
  	"GOCFLAGS_FOR_TARGET=$(GOCFLAGS_FOR_TARGET)" \
@@ -151,7 +177,7 @@ This implements building of libphobos library in GCC.
  	"LD_FOR_TARGET=$(LD_FOR_TARGET)" \
  	"LIPO_FOR_TARGET=$(LIPO_FOR_TARGET)" \
  	"LDFLAGS_FOR_TARGET=$(LDFLAGS_FOR_TARGET)" \
-@@ -833,6 +853,7 @@ EXTRA_HOST_FLAGS = \
+@@ -833,6 +856,7 @@ EXTRA_HOST_FLAGS = \
  	'DLLTOOL=$(DLLTOOL)' \
  	'GFORTRAN=$(GFORTRAN)' \
  	'GOC=$(GOC)' \
@@ -159,7 +185,15 @@ This implements building of libphobos library in GCC.
  	'LD=$(LD)' \
  	'LIPO=$(LIPO)' \
  	'NM=$(NM)' \
-@@ -889,6 +910,8 @@ EXTRA_TARGET_FLAGS = \
+@@ -857,6 +881,7 @@ STAGE1_FLAGS_TO_PASS = \
+ POSTSTAGE1_FLAGS_TO_PASS = \
+ 	CC="$${CC}" CC_FOR_BUILD="$${CC_FOR_BUILD}" \
+ 	CXX="$${CXX}" CXX_FOR_BUILD="$${CXX_FOR_BUILD}" \
++	GDC="$${GDC}" GDC_FOR_BUILD="$${GDC_FOR_BUILD}" \
+ 	GNATBIND="$${GNATBIND}" \
+ 	LDFLAGS="$${LDFLAGS}" \
+ 	HOST_LIBS="$${HOST_LIBS}" \
+@@ -889,6 +914,8 @@ EXTRA_TARGET_FLAGS = \
  	'GFORTRAN=$$(GFORTRAN_FOR_TARGET) $$(XGCC_FLAGS_FOR_TARGET) $$(TFLAGS)' \
  	'GOC=$$(GOC_FOR_TARGET) $$(XGCC_FLAGS_FOR_TARGET) $$(TFLAGS)' \
  	'GOCFLAGS=$$(GOCFLAGS_FOR_TARGET)' \
@@ -168,7 +202,7 @@ This implements building of libphobos library in GCC.
  	'LD=$(COMPILER_LD_FOR_TARGET)' \
  	'LDFLAGS=$$(LDFLAGS_FOR_TARGET)' \
  	'LIBCFLAGS=$$(LIBCFLAGS_FOR_TARGET)' \
-@@ -992,6 +1015,7 @@ configure-target:  \
+@@ -992,6 +1019,7 @@ configure-target:  \
      maybe-configure-target-libobjc \
      maybe-configure-target-libgo \
      maybe-configure-target-libhsail-rt \
@@ -176,7 +210,7 @@ This implements building of libphobos library in GCC.
      maybe-configure-target-libtermcap \
      maybe-configure-target-winsup \
      maybe-configure-target-libgloss \
-@@ -1158,6 +1182,7 @@ all-target: maybe-all-target-libgfortran
+@@ -1158,6 +1186,7 @@ all-target: maybe-all-target-libgfortran
  all-target: maybe-all-target-libobjc
  all-target: maybe-all-target-libgo
  all-target: maybe-all-target-libhsail-rt
@@ -184,7 +218,7 @@ This implements building of libphobos library in GCC.
  all-target: maybe-all-target-libtermcap
  all-target: maybe-all-target-winsup
  all-target: maybe-all-target-libgloss
-@@ -1251,6 +1276,7 @@ info-target: maybe-info-target-libgfortr
+@@ -1251,6 +1280,7 @@ info-target: maybe-info-target-libgfortr
  info-target: maybe-info-target-libobjc
  info-target: maybe-info-target-libgo
  info-target: maybe-info-target-libhsail-rt
@@ -192,7 +226,7 @@ This implements building of libphobos library in GCC.
  info-target: maybe-info-target-libtermcap
  info-target: maybe-info-target-winsup
  info-target: maybe-info-target-libgloss
-@@ -1337,6 +1363,7 @@ dvi-target: maybe-dvi-target-libgfortran
+@@ -1337,6 +1367,7 @@ dvi-target: maybe-dvi-target-libgfortran
  dvi-target: maybe-dvi-target-libobjc
  dvi-target: maybe-dvi-target-libgo
  dvi-target: maybe-dvi-target-libhsail-rt
@@ -200,7 +234,7 @@ This implements building of libphobos library in GCC.
  dvi-target: maybe-dvi-target-libtermcap
  dvi-target: maybe-dvi-target-winsup
  dvi-target: maybe-dvi-target-libgloss
-@@ -1423,6 +1450,7 @@ pdf-target: maybe-pdf-target-libgfortran
+@@ -1423,6 +1454,7 @@ pdf-target: maybe-pdf-target-libgfortran
  pdf-target: maybe-pdf-target-libobjc
  pdf-target: maybe-pdf-target-libgo
  pdf-target: maybe-pdf-target-libhsail-rt
@@ -208,7 +242,7 @@ This implements building of libphobos library in GCC.
  pdf-target: maybe-pdf-target-libtermcap
  pdf-target: maybe-pdf-target-winsup
  pdf-target: maybe-pdf-target-libgloss
-@@ -1509,6 +1537,7 @@ html-target: maybe-html-target-libgfortr
+@@ -1509,6 +1541,7 @@ html-target: maybe-html-target-libgfortr
  html-target: maybe-html-target-libobjc
  html-target: maybe-html-target-libgo
  html-target: maybe-html-target-libhsail-rt
@@ -216,7 +250,7 @@ This implements building of libphobos library in GCC.
  html-target: maybe-html-target-libtermcap
  html-target: maybe-html-target-winsup
  html-target: maybe-html-target-libgloss
-@@ -1595,6 +1624,7 @@ TAGS-target: maybe-TAGS-target-libgfortr
+@@ -1595,6 +1628,7 @@ TAGS-target: maybe-TAGS-target-libgfortr
  TAGS-target: maybe-TAGS-target-libobjc
  TAGS-target: maybe-TAGS-target-libgo
  TAGS-target: maybe-TAGS-target-libhsail-rt
@@ -224,7 +258,7 @@ This implements building of libphobos library in GCC.
  TAGS-target: maybe-TAGS-target-libtermcap
  TAGS-target: maybe-TAGS-target-winsup
  TAGS-target: maybe-TAGS-target-libgloss
-@@ -1681,6 +1711,7 @@ install-info-target: maybe-install-info-
+@@ -1681,6 +1715,7 @@ install-info-target: maybe-install-info-
  install-info-target: maybe-install-info-target-libobjc
  install-info-target: maybe-install-info-target-libgo
  install-info-target: maybe-install-info-target-libhsail-rt
@@ -232,7 +266,7 @@ This implements building of libphobos library in GCC.
  install-info-target: maybe-install-info-target-libtermcap
  install-info-target: maybe-install-info-target-winsup
  install-info-target: maybe-install-info-target-libgloss
-@@ -1767,6 +1798,7 @@ install-pdf-target: maybe-install-pdf-ta
+@@ -1767,6 +1802,7 @@ install-pdf-target: maybe-install-pdf-ta
  install-pdf-target: maybe-install-pdf-target-libobjc
  install-pdf-target: maybe-install-pdf-target-libgo
  install-pdf-target: maybe-install-pdf-target-libhsail-rt
@@ -240,7 +274,7 @@ This implements building of libphobos library in GCC.
  install-pdf-target: maybe-install-pdf-target-libtermcap
  install-pdf-target: maybe-install-pdf-target-winsup
  install-pdf-target: maybe-install-pdf-target-libgloss
-@@ -1853,6 +1885,7 @@ install-html-target: maybe-install-html-
+@@ -1853,6 +1889,7 @@ install-html-target: maybe-install-html-
  install-html-target: maybe-install-html-target-libobjc
  install-html-target: maybe-install-html-target-libgo
  install-html-target: maybe-install-html-target-libhsail-rt
@@ -248,7 +282,7 @@ This implements building of libphobos library in GCC.
  install-html-target: maybe-install-html-target-libtermcap
  install-html-target: maybe-install-html-target-winsup
  install-html-target: maybe-install-html-target-libgloss
-@@ -1939,6 +1972,7 @@ installcheck-target: maybe-installcheck-
+@@ -1939,6 +1976,7 @@ installcheck-target: maybe-installcheck-
  installcheck-target: maybe-installcheck-target-libobjc
  installcheck-target: maybe-installcheck-target-libgo
  installcheck-target: maybe-installcheck-target-libhsail-rt
@@ -256,7 +290,7 @@ This implements building of libphobos library in GCC.
  installcheck-target: maybe-installcheck-target-libtermcap
  installcheck-target: maybe-installcheck-target-winsup
  installcheck-target: maybe-installcheck-target-libgloss
-@@ -2025,6 +2059,7 @@ mostlyclean-target: maybe-mostlyclean-ta
+@@ -2025,6 +2063,7 @@ mostlyclean-target: maybe-mostlyclean-ta
  mostlyclean-target: maybe-mostlyclean-target-libobjc
  mostlyclean-target: maybe-mostlyclean-target-libgo
  mostlyclean-target: maybe-mostlyclean-target-libhsail-rt
@@ -264,7 +298,7 @@ This implements building of libphobos library in GCC.
  mostlyclean-target: maybe-mostlyclean-target-libtermcap
  mostlyclean-target: maybe-mostlyclean-target-winsup
  mostlyclean-target: maybe-mostlyclean-target-libgloss
-@@ -2111,6 +2146,7 @@ clean-target: maybe-clean-target-libgfor
+@@ -2111,6 +2150,7 @@ clean-target: maybe-clean-target-libgfor
  clean-target: maybe-clean-target-libobjc
  clean-target: maybe-clean-target-libgo
  clean-target: maybe-clean-target-libhsail-rt
@@ -272,7 +306,7 @@ This implements building of libphobos library in GCC.
  clean-target: maybe-clean-target-libtermcap
  clean-target: maybe-clean-target-winsup
  clean-target: maybe-clean-target-libgloss
-@@ -2197,6 +2233,7 @@ distclean-target: maybe-distclean-target
+@@ -2197,6 +2237,7 @@ distclean-target: maybe-distclean-target
  distclean-target: maybe-distclean-target-libobjc
  distclean-target: maybe-distclean-target-libgo
  distclean-target: maybe-distclean-target-libhsail-rt
@@ -280,7 +314,7 @@ This implements building of libphobos library in GCC.
  distclean-target: maybe-distclean-target-libtermcap
  distclean-target: maybe-distclean-target-winsup
  distclean-target: maybe-distclean-target-libgloss
-@@ -2283,6 +2320,7 @@ maintainer-clean-target: maybe-maintaine
+@@ -2283,6 +2324,7 @@ maintainer-clean-target: maybe-maintaine
  maintainer-clean-target: maybe-maintainer-clean-target-libobjc
  maintainer-clean-target: maybe-maintainer-clean-target-libgo
  maintainer-clean-target: maybe-maintainer-clean-target-libhsail-rt
@@ -288,7 +322,7 @@ This implements building of libphobos library in GCC.
  maintainer-clean-target: maybe-maintainer-clean-target-libtermcap
  maintainer-clean-target: maybe-maintainer-clean-target-winsup
  maintainer-clean-target: maybe-maintainer-clean-target-libgloss
-@@ -2425,6 +2463,7 @@ check-target:  \
+@@ -2425,6 +2467,7 @@ check-target:  \
      maybe-check-target-libobjc \
      maybe-check-target-libgo \
      maybe-check-target-libhsail-rt \
@@ -296,7 +330,7 @@ This implements building of libphobos library in GCC.
      maybe-check-target-libtermcap \
      maybe-check-target-winsup \
      maybe-check-target-libgloss \
-@@ -2607,6 +2646,7 @@ install-target:  \
+@@ -2607,6 +2650,7 @@ install-target:  \
      maybe-install-target-libobjc \
      maybe-install-target-libgo \
      maybe-install-target-libhsail-rt \
@@ -304,7 +338,7 @@ This implements building of libphobos library in GCC.
      maybe-install-target-libtermcap \
      maybe-install-target-winsup \
      maybe-install-target-libgloss \
-@@ -2713,6 +2753,7 @@ install-strip-target:  \
+@@ -2713,6 +2757,7 @@ install-strip-target:  \
      maybe-install-strip-target-libobjc \
      maybe-install-strip-target-libgo \
      maybe-install-strip-target-libhsail-rt \
@@ -312,7 +346,7 @@ This implements building of libphobos library in GCC.
      maybe-install-strip-target-libtermcap \
      maybe-install-strip-target-winsup \
      maybe-install-strip-target-libgloss \
-@@ -46570,6 +46611,464 @@ maintainer-clean-target-libhsail-rt:
+@@ -46570,6 +46615,464 @@ maintainer-clean-target-libhsail-rt:
  
  
  
@@ -777,7 +811,7 @@ This implements building of libphobos library in GCC.
  .PHONY: configure-target-libtermcap maybe-configure-target-libtermcap
  maybe-configure-target-libtermcap:
  @if gcc-bootstrap
-@@ -51864,6 +52363,14 @@ check-gcc-brig:
+@@ -51864,6 +52367,14 @@ check-gcc-brig:
  	(cd gcc && $(MAKE) $(GCC_FLAGS_TO_PASS) check-brig);
  check-brig: check-gcc-brig check-target-libhsail-rt
  
@@ -792,7 +826,7 @@ This implements building of libphobos library in GCC.
  
  # The gcc part of install-no-fixedincludes, which relies on an intimate
  # knowledge of how a number of gcc internal targets (inter)operate.  Delegate.
-@@ -54742,6 +55249,7 @@ configure-target-libgfortran: stage_last
+@@ -54742,6 +55253,7 @@ configure-target-libgfortran: stage_last
  configure-target-libobjc: stage_last
  configure-target-libgo: stage_last
  configure-target-libhsail-rt: stage_last
@@ -800,7 +834,7 @@ This implements building of libphobos library in GCC.
  configure-target-libtermcap: stage_last
  configure-target-winsup: stage_last
  configure-target-libgloss: stage_last
-@@ -54777,6 +55285,7 @@ configure-target-libgfortran: maybe-all-
+@@ -54777,6 +55289,7 @@ configure-target-libgfortran: maybe-all-
  configure-target-libobjc: maybe-all-gcc
  configure-target-libgo: maybe-all-gcc
  configure-target-libhsail-rt: maybe-all-gcc
@@ -808,7 +842,7 @@ This implements building of libphobos library in GCC.
  configure-target-libtermcap: maybe-all-gcc
  configure-target-winsup: maybe-all-gcc
  configure-target-libgloss: maybe-all-gcc
-@@ -55803,6 +56312,11 @@ configure-target-libgo: maybe-all-target
+@@ -55803,6 +56316,11 @@ configure-target-libgo: maybe-all-target
  all-target-libgo: maybe-all-target-libbacktrace
  all-target-libgo: maybe-all-target-libffi
  all-target-libgo: maybe-all-target-libatomic
@@ -820,7 +854,7 @@ This implements building of libphobos library in GCC.
  configure-target-libstdc++-v3: maybe-configure-target-libgomp
  
  configure-stage1-target-libstdc++-v3: maybe-configure-stage1-target-libgomp
-@@ -55848,6 +56362,7 @@ all-target-liboffloadmic: maybe-all-targ
+@@ -55848,6 +56366,7 @@ all-target-liboffloadmic: maybe-all-targ
  install-target-libgo: maybe-install-target-libatomic
  install-target-libgfortran: maybe-install-target-libquadmath
  install-target-libgfortran: maybe-install-target-libgcc
@@ -828,7 +862,7 @@ This implements building of libphobos library in GCC.
  install-target-libsanitizer: maybe-install-target-libstdc++-v3
  install-target-libsanitizer: maybe-install-target-libgcc
  install-target-libvtv: maybe-install-target-libstdc++-v3
-@@ -55930,6 +56445,7 @@ configure-target-libgfortran: maybe-all-
+@@ -55930,6 +56449,7 @@ configure-target-libgfortran: maybe-all-
  configure-target-libobjc: maybe-all-target-libgcc
  configure-target-libgo: maybe-all-target-libgcc
  configure-target-libhsail-rt: maybe-all-target-libgcc
@@ -836,7 +870,7 @@ This implements building of libphobos library in GCC.
  configure-target-libtermcap: maybe-all-target-libgcc
  configure-target-winsup: maybe-all-target-libgcc
  configure-target-libgloss: maybe-all-target-libgcc
-@@ -55973,6 +56489,8 @@ configure-target-libgo: maybe-all-target
+@@ -55973,6 +56493,8 @@ configure-target-libgo: maybe-all-target
  
  configure-target-libhsail-rt: maybe-all-target-newlib maybe-all-target-libgloss
  
@@ -873,7 +907,7 @@ This implements building of libphobos library in GCC.
 +	  -I$$r/prev-$(TARGET_SUBDIR)/libphobos/libdruntime -I$$s/libphobos/libdruntime \
 +	  -L$$r/prev-$(TARGET_SUBDIR)/libphobos/src/.libs"; \
 +	export GDC; \
-+ 	GDC_FOR_BUILD="$$GDC"; export GDC_FOR_BUILD; \
++	GDC_FOR_BUILD="$$GDC"; export GDC_FOR_BUILD; \
  	GNATBIND="$$r/$(HOST_SUBDIR)/prev-gcc/gnatbind"; export GNATBIND; \
  	LDFLAGS="$(POSTSTAGE1_LDFLAGS) $(BOOT_LDFLAGS)"; export LDFLAGS; \
  	HOST_LIBS="$(POSTSTAGE1_LIBS)"; export HOST_LIBS;
@@ -893,7 +927,15 @@ This implements building of libphobos library in GCC.
  LDFLAGS_FOR_BUILD = @LDFLAGS_FOR_BUILD@
  LD_FOR_BUILD = @LD_FOR_BUILD@
  NM_FOR_BUILD = @NM_FOR_BUILD@
-@@ -411,6 +422,7 @@ LIBCFLAGS = $(CFLAGS)
+@@ -402,6 +413,7 @@ STRIP = @STRIP@
+ WINDRES = @WINDRES@
+ WINDMC = @WINDMC@
+ 
++GDC = @GDC@
+ GNATBIND = @GNATBIND@
+ GNATMAKE = @GNATMAKE@
+ 
+@@ -411,6 +423,7 @@ LIBCFLAGS = $(CFLAGS)
  CXXFLAGS = @CXXFLAGS@
  LIBCXXFLAGS = $(CXXFLAGS) -fno-implicit-templates
  GOCFLAGS = $(CFLAGS)
@@ -901,7 +943,7 @@ This implements building of libphobos library in GCC.
  
  CREATE_GCOV = create_gcov
  
-@@ -484,6 +496,7 @@ CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @CXX_
+@@ -484,6 +497,7 @@ CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @CXX_
  RAW_CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @RAW_CXX_FOR_TARGET@
  GFORTRAN_FOR_TARGET=$(STAGE_CC_WRAPPER) @GFORTRAN_FOR_TARGET@
  GOC_FOR_TARGET=$(STAGE_CC_WRAPPER) @GOC_FOR_TARGET@
@@ -909,7 +951,7 @@ This implements building of libphobos library in GCC.
  DLLTOOL_FOR_TARGET=@DLLTOOL_FOR_TARGET@
  LD_FOR_TARGET=@LD_FOR_TARGET@
  
-@@ -508,6 +521,7 @@ LIBCFLAGS_FOR_TARGET = $(CFLAGS_FOR_TARG
+@@ -508,6 +522,7 @@ LIBCFLAGS_FOR_TARGET = $(CFLAGS_FOR_TARG
  LIBCXXFLAGS_FOR_TARGET = $(CXXFLAGS_FOR_TARGET) -fno-implicit-templates
  LDFLAGS_FOR_TARGET = @LDFLAGS_FOR_TARGET@
  GOCFLAGS_FOR_TARGET = -O2 -g
@@ -917,7 +959,7 @@ This implements building of libphobos library in GCC.
  
  FLAGS_FOR_TARGET = @FLAGS_FOR_TARGET@
  SYSROOT_CFLAGS_FOR_TARGET = @SYSROOT_CFLAGS_FOR_TARGET@
-@@ -609,6 +623,7 @@ EXTRA_HOST_FLAGS = \
+@@ -609,6 +624,7 @@ EXTRA_HOST_FLAGS = \
  	'DLLTOOL=$(DLLTOOL)' \
  	'GFORTRAN=$(GFORTRAN)' \
  	'GOC=$(GOC)' \
@@ -925,7 +967,15 @@ This implements building of libphobos library in GCC.
  	'LD=$(LD)' \
  	'LIPO=$(LIPO)' \
  	'NM=$(NM)' \
-@@ -665,6 +680,8 @@ EXTRA_TARGET_FLAGS = \
+@@ -633,6 +649,7 @@ STAGE1_FLAGS_TO_PASS = \
+ POSTSTAGE1_FLAGS_TO_PASS = \
+ 	CC="$${CC}" CC_FOR_BUILD="$${CC_FOR_BUILD}" \
+ 	CXX="$${CXX}" CXX_FOR_BUILD="$${CXX_FOR_BUILD}" \
++	GDC="$${GDC}" GDC_FOR_BUILD="$${GDC_FOR_BUILD}" \
+ 	GNATBIND="$${GNATBIND}" \
+ 	LDFLAGS="$${LDFLAGS}" \
+ 	HOST_LIBS="$${HOST_LIBS}" \
+@@ -665,6 +682,8 @@ EXTRA_TARGET_FLAGS = \
  	'GFORTRAN=$$(GFORTRAN_FOR_TARGET) $$(XGCC_FLAGS_FOR_TARGET) $$(TFLAGS)' \
  	'GOC=$$(GOC_FOR_TARGET) $$(XGCC_FLAGS_FOR_TARGET) $$(TFLAGS)' \
  	'GOCFLAGS=$$(GOCFLAGS_FOR_TARGET)' \

--- a/gcc/d/patches/patch-toplev-ddmd-7.patch
+++ b/gcc/d/patches/patch-toplev-ddmd-7.patch
@@ -27,7 +27,7 @@
  // Not all; these are the ones which don't have special options.
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -1176,13 +1176,17 @@ all-target: maybe-all-target-newlib
+@@ -1180,13 +1180,17 @@ all-target: maybe-all-target-newlib
  @if target-libgcc-no-bootstrap
  all-target: maybe-all-target-libgcc
  @endif target-libgcc-no-bootstrap
@@ -45,7 +45,7 @@
  all-target: maybe-all-target-libtermcap
  all-target: maybe-all-target-winsup
  all-target: maybe-all-target-libgloss
-@@ -1194,7 +1198,9 @@ all-target: maybe-all-target-libada
+@@ -1198,7 +1202,9 @@ all-target: maybe-all-target-libada
  all-target: maybe-all-target-libgomp
  @endif target-libgomp-no-bootstrap
  all-target: maybe-all-target-libitm
@@ -55,7 +55,7 @@
  
  # Do a target for all the subdirectories.  A ``make do-X'' will do a
  # ``make X'' in all subdirectories (because, in general, there is a
-@@ -43871,7 +43877,6 @@ configure-target-libbacktrace: stage_cur
+@@ -43875,7 +43881,6 @@ configure-target-libbacktrace: stage_cur
  @if target-libbacktrace
  maybe-configure-target-libbacktrace: configure-target-libbacktrace
  configure-target-libbacktrace: 
@@ -63,7 +63,7 @@
  	@r=`${PWD_COMMAND}`; export r; \
  	s=`cd $(srcdir); ${PWD_COMMAND}`; export s; \
  	echo "Checking multilib configuration for libbacktrace..."; \
-@@ -43909,6 +43914,367 @@ configure-target-libbacktrace:
+@@ -43913,6 +43918,367 @@ configure-target-libbacktrace:
  
  
  
@@ -431,7 +431,7 @@
  
  
  .PHONY: all-target-libbacktrace maybe-all-target-libbacktrace
-@@ -43920,7 +44286,6 @@ all-target-libbacktrace: stage_current
+@@ -43924,7 +44290,6 @@ all-target-libbacktrace: stage_current
  TARGET-target-libbacktrace=all
  maybe-all-target-libbacktrace: all-target-libbacktrace
  all-target-libbacktrace: configure-target-libbacktrace
@@ -439,7 +439,7 @@
  	@r=`${PWD_COMMAND}`; export r; \
  	s=`cd $(srcdir); ${PWD_COMMAND}`; export s; \
  	$(NORMAL_TARGET_EXPORTS)  \
-@@ -43931,6 +44296,345 @@ all-target-libbacktrace: configure-targe
+@@ -43935,6 +44300,345 @@ all-target-libbacktrace: configure-targe
  
  
  
@@ -785,7 +785,7 @@
  
  
  .PHONY: check-target-libbacktrace maybe-check-target-libbacktrace
-@@ -46619,7 +47323,6 @@ configure-target-libphobos: stage_curren
+@@ -46623,7 +47327,6 @@ configure-target-libphobos: stage_curren
  @if target-libphobos
  maybe-configure-target-libphobos: configure-target-libphobos
  configure-target-libphobos: 
@@ -793,7 +793,7 @@
  	@r=`${PWD_COMMAND}`; export r; \
  	s=`cd $(srcdir); ${PWD_COMMAND}`; export s; \
  	echo "Checking multilib configuration for libphobos..."; \
-@@ -46657,6 +47360,367 @@ configure-target-libphobos:
+@@ -46661,6 +47364,367 @@ configure-target-libphobos:
  
  
  
@@ -1161,7 +1161,7 @@
  
  
  .PHONY: all-target-libphobos maybe-all-target-libphobos
-@@ -46668,7 +47732,6 @@ all-target-libphobos: stage_current
+@@ -46672,7 +47736,6 @@ all-target-libphobos: stage_current
  TARGET-target-libphobos=all
  maybe-all-target-libphobos: all-target-libphobos
  all-target-libphobos: configure-target-libphobos
@@ -1169,7 +1169,7 @@
  	@r=`${PWD_COMMAND}`; export r; \
  	s=`cd $(srcdir); ${PWD_COMMAND}`; export s; \
  	$(NORMAL_TARGET_EXPORTS)  \
-@@ -46679,6 +47742,345 @@ all-target-libphobos: configure-target-l
+@@ -46683,6 +47746,345 @@ all-target-libphobos: configure-target-l
  
  
  
@@ -1515,7 +1515,7 @@
  
  
  .PHONY: check-target-libphobos maybe-check-target-libphobos
-@@ -51817,7 +53219,6 @@ configure-target-libatomic: stage_curren
+@@ -51821,7 +53223,6 @@ configure-target-libatomic: stage_curren
  @if target-libatomic
  maybe-configure-target-libatomic: configure-target-libatomic
  configure-target-libatomic: 
@@ -1523,7 +1523,7 @@
  	@r=`${PWD_COMMAND}`; export r; \
  	s=`cd $(srcdir); ${PWD_COMMAND}`; export s; \
  	echo "Checking multilib configuration for libatomic..."; \
-@@ -51855,6 +53256,367 @@ configure-target-libatomic:
+@@ -51859,6 +53260,367 @@ configure-target-libatomic:
  
  
  
@@ -1891,7 +1891,7 @@
  
  
  .PHONY: all-target-libatomic maybe-all-target-libatomic
-@@ -51866,7 +53628,6 @@ all-target-libatomic: stage_current
+@@ -51870,7 +53632,6 @@ all-target-libatomic: stage_current
  TARGET-target-libatomic=all
  maybe-all-target-libatomic: all-target-libatomic
  all-target-libatomic: configure-target-libatomic
@@ -1899,7 +1899,7 @@
  	@r=`${PWD_COMMAND}`; export r; \
  	s=`cd $(srcdir); ${PWD_COMMAND}`; export s; \
  	$(NORMAL_TARGET_EXPORTS)  \
-@@ -51877,6 +53638,345 @@ all-target-libatomic: configure-target-l
+@@ -51881,6 +53642,345 @@ all-target-libatomic: configure-target-l
  
  
  
@@ -2245,7 +2245,7 @@
  
  
  .PHONY: check-target-libatomic maybe-check-target-libatomic
-@@ -55243,13 +57343,27 @@ configure-stageprofile-target-libgcc: ma
+@@ -55247,13 +57347,27 @@ configure-stageprofile-target-libgcc: ma
  configure-stagefeedback-target-libgcc: maybe-all-stagefeedback-gcc
  configure-stageautoprofile-target-libgcc: maybe-all-stageautoprofile-gcc
  configure-stageautofeedback-target-libgcc: maybe-all-stageautofeedback-gcc
@@ -2275,7 +2275,7 @@
  configure-target-libtermcap: stage_last
  configure-target-winsup: stage_last
  configure-target-libgloss: stage_last
-@@ -55266,7 +57380,14 @@ configure-stagefeedback-target-libgomp:
+@@ -55270,7 +57384,14 @@ configure-stagefeedback-target-libgomp:
  configure-stageautoprofile-target-libgomp: maybe-all-stageautoprofile-gcc
  configure-stageautofeedback-target-libgomp: maybe-all-stageautofeedback-gcc
  configure-target-libitm: stage_last
@@ -2291,7 +2291,7 @@
  @endif gcc-bootstrap
  
  @if gcc-no-bootstrap
-@@ -56313,10 +58434,37 @@ all-target-libgo: maybe-all-target-libba
+@@ -56317,10 +58438,37 @@ all-target-libgo: maybe-all-target-libba
  all-target-libgo: maybe-all-target-libffi
  all-target-libgo: maybe-all-target-libatomic
  configure-target-libphobos: maybe-configure-target-libbacktrace
@@ -2329,7 +2329,7 @@
  configure-target-libstdc++-v3: maybe-configure-target-libgomp
  
  configure-stage1-target-libstdc++-v3: maybe-configure-stage1-target-libgomp
-@@ -56420,6 +58568,22 @@ configure-stageprofile-target-libvtv: ma
+@@ -56424,6 +58572,22 @@ configure-stageprofile-target-libvtv: ma
  configure-stagefeedback-target-libvtv: maybe-all-stagefeedback-target-libgcc
  configure-stageautoprofile-target-libvtv: maybe-all-stageautoprofile-target-libgcc
  configure-stageautofeedback-target-libvtv: maybe-all-stageautofeedback-target-libgcc
@@ -2352,7 +2352,7 @@
  configure-stage1-target-libgomp: maybe-all-stage1-target-libgcc
  configure-stage2-target-libgomp: maybe-all-stage2-target-libgcc
  configure-stage3-target-libgomp: maybe-all-stage3-target-libgcc
-@@ -56428,6 +58592,14 @@ configure-stageprofile-target-libgomp: m
+@@ -56432,6 +58596,14 @@ configure-stageprofile-target-libgomp: m
  configure-stagefeedback-target-libgomp: maybe-all-stagefeedback-target-libgcc
  configure-stageautoprofile-target-libgomp: maybe-all-stageautoprofile-target-libgcc
  configure-stageautofeedback-target-libgomp: maybe-all-stageautofeedback-target-libgcc


### PR DESCRIPTION
The toplev patches are needed to ensure bootstrapping works.