### PR TITLE
fix Issue 303: libgphobos.spec not found linking stage2

### DIFF
--- a/gcc/d/dmd/mtype.d
+++ b/gcc/d/dmd/mtype.d
@@ -3369,10 +3369,10 @@ extern (C++) final class TypeBasic : Type
             EnumDeclaration ed = (cast(TypeEnum)to).sym;
             if (ed.isSpecial())
             {
-                /* Special enums that allow implicit conversions to them
-                 * with a MATCH.convert
-                 */
+                /* Special enums that allow implicit conversions to them.  */
                 tob = to.toBasetype().isTypeBasic();
+                if (tob)
+                    return implicitConvTo(tob);
             }
             else
                 return MATCH.nomatch;

--- a/gcc/d/dmd/root/longdouble.d
+++ b/gcc/d/dmd/root/longdouble.d
@@ -41,6 +41,7 @@ struct longdouble
     }
 
     longdouble opAssign(T)(T r)
+        if (!is (T : longdouble))
     {
         this.set(r);
         return this;

--- a/gcc/d/patches/patch-toplev-9.patch
+++ b/gcc/d/patches/patch-toplev-9.patch
@@ -78,7 +78,7 @@ This implements building of libphobos library in GCC.
  	AR="$(AR)"; export AR; \
  	AS="$(AS)"; export AS; \
  	CC_FOR_BUILD="$(CC_FOR_BUILD)"; export CC_FOR_BUILD; \
-@@ -256,6 +259,14 @@ POSTSTAGE1_HOST_EXPORTS = \
+@@ -256,6 +259,15 @@ POSTSTAGE1_HOST_EXPORTS = \
  	CC_FOR_BUILD="$$CC"; export CC_FOR_BUILD; \
  	$(POSTSTAGE1_CXX_EXPORT) \
  	$(LTO_EXPORTS) \
@@ -87,13 +87,14 @@ This implements building of libphobos library in GCC.
 +	  -B$$r/prev-$(TARGET_SUBDIR)/libphobos/src \
 +	  -I$$r/prev-$(TARGET_SUBDIR)/libphobos/libdruntime -I$$s/libphobos/libdruntime \
 +	  -L$$r/prev-$(TARGET_SUBDIR)/libphobos/src/.libs \
-+	  -L$$r/prev-$(TARGET_SUBDIR)/libphobos/libdruntime/.libs"; \
++	  -L$$r/prev-$(TARGET_SUBDIR)/libphobos/libdruntime/.libs \
++	  -L$$r/prev-$(TARGET_SUBDIR)/libstdc++-v3/src/.libs"; \
 +	export GDC; \
 +	GDC_FOR_BUILD="$$GDC"; export GDC_FOR_BUILD; \
  	GNATBIND="$$r/$(HOST_SUBDIR)/prev-gcc/gnatbind"; export GNATBIND; \
  	LDFLAGS="$(POSTSTAGE1_LDFLAGS) $(BOOT_LDFLAGS)"; export LDFLAGS; \
  	HOST_LIBS="$(POSTSTAGE1_LIBS)"; export HOST_LIBS;
-@@ -278,6 +289,7 @@ BASE_TARGET_EXPORTS = \
+@@ -278,6 +290,7 @@ BASE_TARGET_EXPORTS = \
  	CXXFLAGS="$(CXXFLAGS_FOR_TARGET)"; export CXXFLAGS; \
  	GFORTRAN="$(GFORTRAN_FOR_TARGET) $(XGCC_FLAGS_FOR_TARGET) $$TFLAGS"; export GFORTRAN; \
  	GOC="$(GOC_FOR_TARGET) $(XGCC_FLAGS_FOR_TARGET) $$TFLAGS"; export GOC; \
@@ -101,7 +102,7 @@ This implements building of libphobos library in GCC.
  	DLLTOOL="$(DLLTOOL_FOR_TARGET)"; export DLLTOOL; \
  	LD="$(COMPILER_LD_FOR_TARGET)"; export LD; \
  	LDFLAGS="$(LDFLAGS_FOR_TARGET)"; export LDFLAGS; \
-@@ -342,6 +354,7 @@ CXX_FOR_BUILD = @CXX_FOR_BUILD@
+@@ -342,6 +355,7 @@ CXX_FOR_BUILD = @CXX_FOR_BUILD@
  DLLTOOL_FOR_BUILD = @DLLTOOL_FOR_BUILD@
  GFORTRAN_FOR_BUILD = @GFORTRAN_FOR_BUILD@
  GOC_FOR_BUILD = @GOC_FOR_BUILD@
@@ -109,7 +110,7 @@ This implements building of libphobos library in GCC.
  LDFLAGS_FOR_BUILD = @LDFLAGS_FOR_BUILD@
  LD_FOR_BUILD = @LD_FOR_BUILD@
  NM_FOR_BUILD = @NM_FOR_BUILD@
-@@ -399,6 +412,7 @@ STRIP = @STRIP@
+@@ -399,6 +413,7 @@ STRIP = @STRIP@
  WINDRES = @WINDRES@
  WINDMC = @WINDMC@
  
@@ -117,7 +118,7 @@ This implements building of libphobos library in GCC.
  GNATBIND = @GNATBIND@
  GNATMAKE = @GNATMAKE@
  
-@@ -408,6 +422,7 @@ LIBCFLAGS = $(CFLAGS)
+@@ -408,6 +423,7 @@ LIBCFLAGS = $(CFLAGS)
  CXXFLAGS = @CXXFLAGS@
  LIBCXXFLAGS = $(CXXFLAGS) -fno-implicit-templates
  GOCFLAGS = $(CFLAGS)
@@ -125,7 +126,7 @@ This implements building of libphobos library in GCC.
  
  CREATE_GCOV = create_gcov
  
-@@ -574,6 +589,7 @@ CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @CXX_
+@@ -574,6 +590,7 @@ CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @CXX_
  RAW_CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @RAW_CXX_FOR_TARGET@
  GFORTRAN_FOR_TARGET=$(STAGE_CC_WRAPPER) @GFORTRAN_FOR_TARGET@
  GOC_FOR_TARGET=$(STAGE_CC_WRAPPER) @GOC_FOR_TARGET@
@@ -133,7 +134,7 @@ This implements building of libphobos library in GCC.
  DLLTOOL_FOR_TARGET=@DLLTOOL_FOR_TARGET@
  LD_FOR_TARGET=@LD_FOR_TARGET@
  
-@@ -598,6 +614,7 @@ LIBCFLAGS_FOR_TARGET = $(CFLAGS_FOR_TARG
+@@ -598,6 +615,7 @@ LIBCFLAGS_FOR_TARGET = $(CFLAGS_FOR_TARG
  LIBCXXFLAGS_FOR_TARGET = $(CXXFLAGS_FOR_TARGET) -fno-implicit-templates
  LDFLAGS_FOR_TARGET = @LDFLAGS_FOR_TARGET@
  GOCFLAGS_FOR_TARGET = -O2 -g
@@ -141,7 +142,7 @@ This implements building of libphobos library in GCC.
  
  FLAGS_FOR_TARGET = @FLAGS_FOR_TARGET@
  SYSROOT_CFLAGS_FOR_TARGET = @SYSROOT_CFLAGS_FOR_TARGET@
-@@ -622,7 +639,7 @@ all:
+@@ -622,7 +640,7 @@ all:
  
  # This is the list of directories that may be needed in RPATH_ENVVAR
  # so that programs built for the target machine work.
@@ -150,7 +151,7 @@ This implements building of libphobos library in GCC.
  
  @if target-libstdc++-v3
  TARGET_LIB_PATH_libstdc++-v3 = $$r/$(TARGET_SUBDIR)/libstdc++-v3/src/.libs:
-@@ -644,6 +661,10 @@ TARGET_LIB_PATH_liboffloadmic = $$r/$(TA
+@@ -644,6 +662,10 @@ TARGET_LIB_PATH_liboffloadmic = $$r/$(TA
  TARGET_LIB_PATH_libssp = $$r/$(TARGET_SUBDIR)/libssp/.libs:
  @endif target-libssp
  
@@ -161,7 +162,7 @@ This implements building of libphobos library in GCC.
  @if target-libgomp
  TARGET_LIB_PATH_libgomp = $$r/$(TARGET_SUBDIR)/libgomp/.libs:
  @endif target-libgomp
-@@ -778,6 +799,8 @@ BASE_FLAGS_TO_PASS = \
+@@ -778,6 +800,8 @@ BASE_FLAGS_TO_PASS = \
  	"STAGE1_LANGUAGES=$(STAGE1_LANGUAGES)" \
  	"GNATBIND=$(GNATBIND)" \
  	"GNATMAKE=$(GNATMAKE)" \
@@ -170,7 +171,7 @@ This implements building of libphobos library in GCC.
  	"AR_FOR_TARGET=$(AR_FOR_TARGET)" \
  	"AS_FOR_TARGET=$(AS_FOR_TARGET)" \
  	"CC_FOR_TARGET=$(CC_FOR_TARGET)" \
-@@ -789,6 +812,8 @@ BASE_FLAGS_TO_PASS = \
+@@ -789,6 +813,8 @@ BASE_FLAGS_TO_PASS = \
  	"GFORTRAN_FOR_TARGET=$(GFORTRAN_FOR_TARGET)" \
  	"GOC_FOR_TARGET=$(GOC_FOR_TARGET)" \
  	"GOCFLAGS_FOR_TARGET=$(GOCFLAGS_FOR_TARGET)" \
@@ -179,7 +180,7 @@ This implements building of libphobos library in GCC.
  	"LD_FOR_TARGET=$(LD_FOR_TARGET)" \
  	"LIPO_FOR_TARGET=$(LIPO_FOR_TARGET)" \
  	"LDFLAGS_FOR_TARGET=$(LDFLAGS_FOR_TARGET)" \
-@@ -851,6 +876,7 @@ EXTRA_HOST_FLAGS = \
+@@ -851,6 +877,7 @@ EXTRA_HOST_FLAGS = \
  	'DLLTOOL=$(DLLTOOL)' \
  	'GFORTRAN=$(GFORTRAN)' \
  	'GOC=$(GOC)' \
@@ -187,7 +188,7 @@ This implements building of libphobos library in GCC.
  	'LD=$(LD)' \
  	'LIPO=$(LIPO)' \
  	'NM=$(NM)' \
-@@ -875,6 +901,7 @@ STAGE1_FLAGS_TO_PASS = \
+@@ -875,6 +902,7 @@ STAGE1_FLAGS_TO_PASS = \
  POSTSTAGE1_FLAGS_TO_PASS = \
  	CC="$${CC}" CC_FOR_BUILD="$${CC_FOR_BUILD}" \
  	CXX="$${CXX}" CXX_FOR_BUILD="$${CXX_FOR_BUILD}" \
@@ -195,7 +196,7 @@ This implements building of libphobos library in GCC.
  	GNATBIND="$${GNATBIND}" \
  	LDFLAGS="$${LDFLAGS}" \
  	HOST_LIBS="$${HOST_LIBS}" \
-@@ -907,6 +934,8 @@ EXTRA_TARGET_FLAGS = \
+@@ -907,6 +935,8 @@ EXTRA_TARGET_FLAGS = \
  	'GFORTRAN=$$(GFORTRAN_FOR_TARGET) $$(XGCC_FLAGS_FOR_TARGET) $$(TFLAGS)' \
  	'GOC=$$(GOC_FOR_TARGET) $$(XGCC_FLAGS_FOR_TARGET) $$(TFLAGS)' \
  	'GOCFLAGS=$$(GOCFLAGS_FOR_TARGET)' \
@@ -204,7 +205,7 @@ This implements building of libphobos library in GCC.
  	'LD=$(COMPILER_LD_FOR_TARGET)' \
  	'LDFLAGS=$$(LDFLAGS_FOR_TARGET)' \
  	'LIBCFLAGS=$$(LIBCFLAGS_FOR_TARGET)' \
-@@ -1008,6 +1037,7 @@ configure-target:  \
+@@ -1008,6 +1038,7 @@ configure-target:  \
      maybe-configure-target-libobjc \
      maybe-configure-target-libgo \
      maybe-configure-target-libhsail-rt \
@@ -212,7 +213,7 @@ This implements building of libphobos library in GCC.
      maybe-configure-target-libtermcap \
      maybe-configure-target-winsup \
      maybe-configure-target-libgloss \
-@@ -1170,6 +1200,7 @@ all-target: maybe-all-target-libgfortran
+@@ -1170,6 +1201,7 @@ all-target: maybe-all-target-libgfortran
  all-target: maybe-all-target-libobjc
  all-target: maybe-all-target-libgo
  all-target: maybe-all-target-libhsail-rt
@@ -220,7 +221,7 @@ This implements building of libphobos library in GCC.
  all-target: maybe-all-target-libtermcap
  all-target: maybe-all-target-winsup
  all-target: maybe-all-target-libgloss
-@@ -1261,6 +1292,7 @@ info-target: maybe-info-target-libgfortr
+@@ -1261,6 +1293,7 @@ info-target: maybe-info-target-libgfortr
  info-target: maybe-info-target-libobjc
  info-target: maybe-info-target-libgo
  info-target: maybe-info-target-libhsail-rt
@@ -228,7 +229,7 @@ This implements building of libphobos library in GCC.
  info-target: maybe-info-target-libtermcap
  info-target: maybe-info-target-winsup
  info-target: maybe-info-target-libgloss
-@@ -1345,6 +1377,7 @@ dvi-target: maybe-dvi-target-libgfortran
+@@ -1345,6 +1378,7 @@ dvi-target: maybe-dvi-target-libgfortran
  dvi-target: maybe-dvi-target-libobjc
  dvi-target: maybe-dvi-target-libgo
  dvi-target: maybe-dvi-target-libhsail-rt
@@ -236,7 +237,7 @@ This implements building of libphobos library in GCC.
  dvi-target: maybe-dvi-target-libtermcap
  dvi-target: maybe-dvi-target-winsup
  dvi-target: maybe-dvi-target-libgloss
-@@ -1429,6 +1462,7 @@ pdf-target: maybe-pdf-target-libgfortran
+@@ -1429,6 +1463,7 @@ pdf-target: maybe-pdf-target-libgfortran
  pdf-target: maybe-pdf-target-libobjc
  pdf-target: maybe-pdf-target-libgo
  pdf-target: maybe-pdf-target-libhsail-rt
@@ -244,7 +245,7 @@ This implements building of libphobos library in GCC.
  pdf-target: maybe-pdf-target-libtermcap
  pdf-target: maybe-pdf-target-winsup
  pdf-target: maybe-pdf-target-libgloss
-@@ -1513,6 +1547,7 @@ html-target: maybe-html-target-libgfortr
+@@ -1513,6 +1548,7 @@ html-target: maybe-html-target-libgfortr
  html-target: maybe-html-target-libobjc
  html-target: maybe-html-target-libgo
  html-target: maybe-html-target-libhsail-rt
@@ -252,7 +253,7 @@ This implements building of libphobos library in GCC.
  html-target: maybe-html-target-libtermcap
  html-target: maybe-html-target-winsup
  html-target: maybe-html-target-libgloss
-@@ -1597,6 +1632,7 @@ TAGS-target: maybe-TAGS-target-libgfortr
+@@ -1597,6 +1633,7 @@ TAGS-target: maybe-TAGS-target-libgfortr
  TAGS-target: maybe-TAGS-target-libobjc
  TAGS-target: maybe-TAGS-target-libgo
  TAGS-target: maybe-TAGS-target-libhsail-rt
@@ -260,7 +261,7 @@ This implements building of libphobos library in GCC.
  TAGS-target: maybe-TAGS-target-libtermcap
  TAGS-target: maybe-TAGS-target-winsup
  TAGS-target: maybe-TAGS-target-libgloss
-@@ -1681,6 +1717,7 @@ install-info-target: maybe-install-info-
+@@ -1681,6 +1718,7 @@ install-info-target: maybe-install-info-
  install-info-target: maybe-install-info-target-libobjc
  install-info-target: maybe-install-info-target-libgo
  install-info-target: maybe-install-info-target-libhsail-rt
@@ -268,7 +269,7 @@ This implements building of libphobos library in GCC.
  install-info-target: maybe-install-info-target-libtermcap
  install-info-target: maybe-install-info-target-winsup
  install-info-target: maybe-install-info-target-libgloss
-@@ -1765,6 +1802,7 @@ install-pdf-target: maybe-install-pdf-ta
+@@ -1765,6 +1803,7 @@ install-pdf-target: maybe-install-pdf-ta
  install-pdf-target: maybe-install-pdf-target-libobjc
  install-pdf-target: maybe-install-pdf-target-libgo
  install-pdf-target: maybe-install-pdf-target-libhsail-rt
@@ -276,7 +277,7 @@ This implements building of libphobos library in GCC.
  install-pdf-target: maybe-install-pdf-target-libtermcap
  install-pdf-target: maybe-install-pdf-target-winsup
  install-pdf-target: maybe-install-pdf-target-libgloss
-@@ -1849,6 +1887,7 @@ install-html-target: maybe-install-html-
+@@ -1849,6 +1888,7 @@ install-html-target: maybe-install-html-
  install-html-target: maybe-install-html-target-libobjc
  install-html-target: maybe-install-html-target-libgo
  install-html-target: maybe-install-html-target-libhsail-rt
@@ -284,7 +285,7 @@ This implements building of libphobos library in GCC.
  install-html-target: maybe-install-html-target-libtermcap
  install-html-target: maybe-install-html-target-winsup
  install-html-target: maybe-install-html-target-libgloss
-@@ -1933,6 +1972,7 @@ installcheck-target: maybe-installcheck-
+@@ -1933,6 +1973,7 @@ installcheck-target: maybe-installcheck-
  installcheck-target: maybe-installcheck-target-libobjc
  installcheck-target: maybe-installcheck-target-libgo
  installcheck-target: maybe-installcheck-target-libhsail-rt
@@ -292,7 +293,7 @@ This implements building of libphobos library in GCC.
  installcheck-target: maybe-installcheck-target-libtermcap
  installcheck-target: maybe-installcheck-target-winsup
  installcheck-target: maybe-installcheck-target-libgloss
-@@ -2017,6 +2057,7 @@ mostlyclean-target: maybe-mostlyclean-ta
+@@ -2017,6 +2058,7 @@ mostlyclean-target: maybe-mostlyclean-ta
  mostlyclean-target: maybe-mostlyclean-target-libobjc
  mostlyclean-target: maybe-mostlyclean-target-libgo
  mostlyclean-target: maybe-mostlyclean-target-libhsail-rt
@@ -300,7 +301,7 @@ This implements building of libphobos library in GCC.
  mostlyclean-target: maybe-mostlyclean-target-libtermcap
  mostlyclean-target: maybe-mostlyclean-target-winsup
  mostlyclean-target: maybe-mostlyclean-target-libgloss
-@@ -2101,6 +2142,7 @@ clean-target: maybe-clean-target-libgfor
+@@ -2101,6 +2143,7 @@ clean-target: maybe-clean-target-libgfor
  clean-target: maybe-clean-target-libobjc
  clean-target: maybe-clean-target-libgo
  clean-target: maybe-clean-target-libhsail-rt
@@ -308,7 +309,7 @@ This implements building of libphobos library in GCC.
  clean-target: maybe-clean-target-libtermcap
  clean-target: maybe-clean-target-winsup
  clean-target: maybe-clean-target-libgloss
-@@ -2185,6 +2227,7 @@ distclean-target: maybe-distclean-target
+@@ -2185,6 +2228,7 @@ distclean-target: maybe-distclean-target
  distclean-target: maybe-distclean-target-libobjc
  distclean-target: maybe-distclean-target-libgo
  distclean-target: maybe-distclean-target-libhsail-rt
@@ -316,7 +317,7 @@ This implements building of libphobos library in GCC.
  distclean-target: maybe-distclean-target-libtermcap
  distclean-target: maybe-distclean-target-winsup
  distclean-target: maybe-distclean-target-libgloss
-@@ -2269,6 +2312,7 @@ maintainer-clean-target: maybe-maintaine
+@@ -2269,6 +2313,7 @@ maintainer-clean-target: maybe-maintaine
  maintainer-clean-target: maybe-maintainer-clean-target-libobjc
  maintainer-clean-target: maybe-maintainer-clean-target-libgo
  maintainer-clean-target: maybe-maintainer-clean-target-libhsail-rt
@@ -324,7 +325,7 @@ This implements building of libphobos library in GCC.
  maintainer-clean-target: maybe-maintainer-clean-target-libtermcap
  maintainer-clean-target: maybe-maintainer-clean-target-winsup
  maintainer-clean-target: maybe-maintainer-clean-target-libgloss
-@@ -2409,6 +2453,7 @@ check-target:  \
+@@ -2409,6 +2454,7 @@ check-target:  \
      maybe-check-target-libobjc \
      maybe-check-target-libgo \
      maybe-check-target-libhsail-rt \
@@ -332,7 +333,7 @@ This implements building of libphobos library in GCC.
      maybe-check-target-libtermcap \
      maybe-check-target-winsup \
      maybe-check-target-libgloss \
-@@ -2589,6 +2634,7 @@ install-target:  \
+@@ -2589,6 +2635,7 @@ install-target:  \
      maybe-install-target-libobjc \
      maybe-install-target-libgo \
      maybe-install-target-libhsail-rt \
@@ -340,7 +341,7 @@ This implements building of libphobos library in GCC.
      maybe-install-target-libtermcap \
      maybe-install-target-winsup \
      maybe-install-target-libgloss \
-@@ -2693,6 +2739,7 @@ install-strip-target:  \
+@@ -2693,6 +2740,7 @@ install-strip-target:  \
      maybe-install-strip-target-libobjc \
      maybe-install-strip-target-libgo \
      maybe-install-strip-target-libhsail-rt \
@@ -348,7 +349,7 @@ This implements building of libphobos library in GCC.
      maybe-install-strip-target-libtermcap \
      maybe-install-strip-target-winsup \
      maybe-install-strip-target-libgloss \
-@@ -46944,6 +46991,464 @@ maintainer-clean-target-libhsail-rt:
+@@ -46944,6 +46992,464 @@ maintainer-clean-target-libhsail-rt:
  
  
  
@@ -813,7 +814,7 @@ This implements building of libphobos library in GCC.
  .PHONY: configure-target-libtermcap maybe-configure-target-libtermcap
  maybe-configure-target-libtermcap:
  @if gcc-bootstrap
-@@ -52329,6 +52834,14 @@ check-gcc-brig:
+@@ -52329,6 +52835,14 @@ check-gcc-brig:
  	(cd gcc && $(MAKE) $(GCC_FLAGS_TO_PASS) check-brig);
  check-brig: check-gcc-brig check-target-libhsail-rt
  
@@ -828,7 +829,7 @@ This implements building of libphobos library in GCC.
  
  # The gcc part of install-no-fixedincludes, which relies on an intimate
  # knowledge of how a number of gcc internal targets (inter)operate.  Delegate.
-@@ -55521,6 +56034,7 @@ configure-target-libgfortran: stage_last
+@@ -55521,6 +56035,7 @@ configure-target-libgfortran: stage_last
  configure-target-libobjc: stage_last
  configure-target-libgo: stage_last
  configure-target-libhsail-rt: stage_last
@@ -836,7 +837,7 @@ This implements building of libphobos library in GCC.
  configure-target-libtermcap: stage_last
  configure-target-winsup: stage_last
  configure-target-libgloss: stage_last
-@@ -55555,6 +56069,7 @@ configure-target-libgfortran: maybe-all-
+@@ -55555,6 +56070,7 @@ configure-target-libgfortran: maybe-all-
  configure-target-libobjc: maybe-all-gcc
  configure-target-libgo: maybe-all-gcc
  configure-target-libhsail-rt: maybe-all-gcc
@@ -844,7 +845,7 @@ This implements building of libphobos library in GCC.
  configure-target-libtermcap: maybe-all-gcc
  configure-target-winsup: maybe-all-gcc
  configure-target-libgloss: maybe-all-gcc
-@@ -56550,6 +57065,11 @@ configure-target-libgo: maybe-configure-
+@@ -56550,6 +57066,11 @@ configure-target-libgo: maybe-configure-
  all-target-libgo: maybe-all-target-libbacktrace
  all-target-libgo: maybe-all-target-libffi
  all-target-libgo: maybe-all-target-libatomic
@@ -856,7 +857,7 @@ This implements building of libphobos library in GCC.
  configure-target-libstdc++-v3: maybe-configure-target-libgomp
  configure-stage1-target-libstdc++-v3: maybe-configure-stage1-target-libgomp
  configure-stage2-target-libstdc++-v3: maybe-configure-stage2-target-libgomp
-@@ -56593,6 +57113,7 @@ all-stageautofeedback-target-libstdc++-v
+@@ -56593,6 +57114,7 @@ all-stageautofeedback-target-libstdc++-v
  install-target-libgo: maybe-install-target-libatomic
  install-target-libgfortran: maybe-install-target-libquadmath
  install-target-libgfortran: maybe-install-target-libgcc
@@ -864,7 +865,7 @@ This implements building of libphobos library in GCC.
  install-target-libsanitizer: maybe-install-target-libstdc++-v3
  install-target-libsanitizer: maybe-install-target-libgcc
  install-target-libvtv: maybe-install-target-libstdc++-v3
-@@ -56717,6 +57238,7 @@ configure-target-libgfortran: maybe-all-
+@@ -56717,6 +57239,7 @@ configure-target-libgfortran: maybe-all-
  configure-target-libobjc: maybe-all-target-libgcc
  configure-target-libgo: maybe-all-target-libgcc
  configure-target-libhsail-rt: maybe-all-target-libgcc
@@ -872,7 +873,7 @@ This implements building of libphobos library in GCC.
  configure-target-libtermcap: maybe-all-target-libgcc
  configure-target-winsup: maybe-all-target-libgcc
  configure-target-libgloss: maybe-all-target-libgcc
-@@ -56755,6 +57277,8 @@ configure-target-libgo: maybe-all-target
+@@ -56755,6 +57278,8 @@ configure-target-libgo: maybe-all-target
  
  configure-target-libhsail-rt: maybe-all-target-newlib maybe-all-target-libgloss
  
@@ -900,7 +901,7 @@ This implements building of libphobos library in GCC.
  	AR="$(AR)"; export AR; \
  	AS="$(AS)"; export AS; \
  	CC_FOR_BUILD="$(CC_FOR_BUILD)"; export CC_FOR_BUILD; \
-@@ -259,6 +262,14 @@ POSTSTAGE1_HOST_EXPORTS = \
+@@ -259,6 +262,15 @@ POSTSTAGE1_HOST_EXPORTS = \
  	CC_FOR_BUILD="$$CC"; export CC_FOR_BUILD; \
  	$(POSTSTAGE1_CXX_EXPORT) \
  	$(LTO_EXPORTS) \
@@ -909,13 +910,14 @@ This implements building of libphobos library in GCC.
 +	  -B$$r/prev-$(TARGET_SUBDIR)/libphobos/src \
 +	  -I$$r/prev-$(TARGET_SUBDIR)/libphobos/libdruntime -I$$s/libphobos/libdruntime \
 +	  -L$$r/prev-$(TARGET_SUBDIR)/libphobos/src/.libs \
-+	  -L$$r/prev-$(TARGET_SUBDIR)/libphobos/libdruntime/.libs"; \
++	  -L$$r/prev-$(TARGET_SUBDIR)/libphobos/libdruntime/.libs \
++	  -L$$r/prev-$(TARGET_SUBDIR)/libstdc++-v3/src/.libs"; \
 +	export GDC; \
 +	GDC_FOR_BUILD="$$GDC"; export GDC_FOR_BUILD; \
  	GNATBIND="$$r/$(HOST_SUBDIR)/prev-gcc/gnatbind"; export GNATBIND; \
  	LDFLAGS="$(POSTSTAGE1_LDFLAGS) $(BOOT_LDFLAGS)"; export LDFLAGS; \
  	HOST_LIBS="$(POSTSTAGE1_LIBS)"; export HOST_LIBS;
-@@ -281,6 +292,7 @@ BASE_TARGET_EXPORTS = \
+@@ -281,6 +293,7 @@ BASE_TARGET_EXPORTS = \
  	CXXFLAGS="$(CXXFLAGS_FOR_TARGET)"; export CXXFLAGS; \
  	GFORTRAN="$(GFORTRAN_FOR_TARGET) $(XGCC_FLAGS_FOR_TARGET) $$TFLAGS"; export GFORTRAN; \
  	GOC="$(GOC_FOR_TARGET) $(XGCC_FLAGS_FOR_TARGET) $$TFLAGS"; export GOC; \
@@ -923,7 +925,7 @@ This implements building of libphobos library in GCC.
  	DLLTOOL="$(DLLTOOL_FOR_TARGET)"; export DLLTOOL; \
  	LD="$(COMPILER_LD_FOR_TARGET)"; export LD; \
  	LDFLAGS="$(LDFLAGS_FOR_TARGET)"; export LDFLAGS; \
-@@ -345,6 +357,7 @@ CXX_FOR_BUILD = @CXX_FOR_BUILD@
+@@ -345,6 +358,7 @@ CXX_FOR_BUILD = @CXX_FOR_BUILD@
  DLLTOOL_FOR_BUILD = @DLLTOOL_FOR_BUILD@
  GFORTRAN_FOR_BUILD = @GFORTRAN_FOR_BUILD@
  GOC_FOR_BUILD = @GOC_FOR_BUILD@
@@ -931,7 +933,7 @@ This implements building of libphobos library in GCC.
  LDFLAGS_FOR_BUILD = @LDFLAGS_FOR_BUILD@
  LD_FOR_BUILD = @LD_FOR_BUILD@
  NM_FOR_BUILD = @NM_FOR_BUILD@
-@@ -402,6 +415,7 @@ STRIP = @STRIP@
+@@ -402,6 +416,7 @@ STRIP = @STRIP@
  WINDRES = @WINDRES@
  WINDMC = @WINDMC@
  
@@ -939,7 +941,7 @@ This implements building of libphobos library in GCC.
  GNATBIND = @GNATBIND@
  GNATMAKE = @GNATMAKE@
  
-@@ -411,6 +425,7 @@ LIBCFLAGS = $(CFLAGS)
+@@ -411,6 +426,7 @@ LIBCFLAGS = $(CFLAGS)
  CXXFLAGS = @CXXFLAGS@
  LIBCXXFLAGS = $(CXXFLAGS) -fno-implicit-templates
  GOCFLAGS = $(CFLAGS)
@@ -947,7 +949,7 @@ This implements building of libphobos library in GCC.
  
  CREATE_GCOV = create_gcov
  
-@@ -497,6 +512,7 @@ CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @CXX_
+@@ -497,6 +513,7 @@ CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @CXX_
  RAW_CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @RAW_CXX_FOR_TARGET@
  GFORTRAN_FOR_TARGET=$(STAGE_CC_WRAPPER) @GFORTRAN_FOR_TARGET@
  GOC_FOR_TARGET=$(STAGE_CC_WRAPPER) @GOC_FOR_TARGET@
@@ -955,7 +957,7 @@ This implements building of libphobos library in GCC.
  DLLTOOL_FOR_TARGET=@DLLTOOL_FOR_TARGET@
  LD_FOR_TARGET=@LD_FOR_TARGET@
  
-@@ -521,6 +537,7 @@ LIBCFLAGS_FOR_TARGET = $(CFLAGS_FOR_TARG
+@@ -521,6 +538,7 @@ LIBCFLAGS_FOR_TARGET = $(CFLAGS_FOR_TARG
  LIBCXXFLAGS_FOR_TARGET = $(CXXFLAGS_FOR_TARGET) -fno-implicit-templates
  LDFLAGS_FOR_TARGET = @LDFLAGS_FOR_TARGET@
  GOCFLAGS_FOR_TARGET = -O2 -g
@@ -963,7 +965,7 @@ This implements building of libphobos library in GCC.
  
  FLAGS_FOR_TARGET = @FLAGS_FOR_TARGET@
  SYSROOT_CFLAGS_FOR_TARGET = @SYSROOT_CFLAGS_FOR_TARGET@
-@@ -622,6 +639,7 @@ EXTRA_HOST_FLAGS = \
+@@ -622,6 +640,7 @@ EXTRA_HOST_FLAGS = \
  	'DLLTOOL=$(DLLTOOL)' \
  	'GFORTRAN=$(GFORTRAN)' \
  	'GOC=$(GOC)' \
@@ -971,7 +973,7 @@ This implements building of libphobos library in GCC.
  	'LD=$(LD)' \
  	'LIPO=$(LIPO)' \
  	'NM=$(NM)' \
-@@ -646,6 +664,7 @@ STAGE1_FLAGS_TO_PASS = \
+@@ -646,6 +665,7 @@ STAGE1_FLAGS_TO_PASS = \
  POSTSTAGE1_FLAGS_TO_PASS = \
  	CC="$${CC}" CC_FOR_BUILD="$${CC_FOR_BUILD}" \
  	CXX="$${CXX}" CXX_FOR_BUILD="$${CXX_FOR_BUILD}" \
@@ -979,7 +981,7 @@ This implements building of libphobos library in GCC.
  	GNATBIND="$${GNATBIND}" \
  	LDFLAGS="$${LDFLAGS}" \
  	HOST_LIBS="$${HOST_LIBS}" \
-@@ -678,6 +697,8 @@ EXTRA_TARGET_FLAGS = \
+@@ -678,6 +698,8 @@ EXTRA_TARGET_FLAGS = \
  	'GFORTRAN=$$(GFORTRAN_FOR_TARGET) $$(XGCC_FLAGS_FOR_TARGET) $$(TFLAGS)' \
  	'GOC=$$(GOC_FOR_TARGET) $$(XGCC_FLAGS_FOR_TARGET) $$(TFLAGS)' \
  	'GOCFLAGS=$$(GOCFLAGS_FOR_TARGET)' \

--- a/gcc/d/patches/patch-toplev-9.patch
+++ b/gcc/d/patches/patch-toplev-9.patch
@@ -78,20 +78,22 @@ This implements building of libphobos library in GCC.
  	AR="$(AR)"; export AR; \
  	AS="$(AS)"; export AS; \
  	CC_FOR_BUILD="$(CC_FOR_BUILD)"; export CC_FOR_BUILD; \
-@@ -256,6 +259,12 @@ POSTSTAGE1_HOST_EXPORTS = \
+@@ -256,6 +259,14 @@ POSTSTAGE1_HOST_EXPORTS = \
  	CC_FOR_BUILD="$$CC"; export CC_FOR_BUILD; \
  	$(POSTSTAGE1_CXX_EXPORT) \
  	$(LTO_EXPORTS) \
 +	GDC="$$r/$(HOST_SUBDIR)/prev-gcc/gdc$(exeext) -B$$r/$(HOST_SUBDIR)/prev-gcc/ \
-+	  -B$(build_tooldir)/bin/ $(GDC_FLAGS_FOR_TARGET) \
++	  -B$(build_tooldir)/bin/ $(GDCFLAGS_FOR_TARGET) \
++	  -B$$r/prev-$(TARGET_SUBDIR)/libphobos/src \
 +	  -I$$r/prev-$(TARGET_SUBDIR)/libphobos/libdruntime -I$$s/libphobos/libdruntime \
-+	  -L$$r/prev-$(TARGET_SUBDIR)/libphobos/src/.libs"; \
++	  -L$$r/prev-$(TARGET_SUBDIR)/libphobos/src/.libs \
++	  -L$$r/prev-$(TARGET_SUBDIR)/libphobos/libdruntime/.libs"; \
 +	export GDC; \
 +	GDC_FOR_BUILD="$$GDC"; export GDC_FOR_BUILD; \
  	GNATBIND="$$r/$(HOST_SUBDIR)/prev-gcc/gnatbind"; export GNATBIND; \
  	LDFLAGS="$(POSTSTAGE1_LDFLAGS) $(BOOT_LDFLAGS)"; export LDFLAGS; \
  	HOST_LIBS="$(POSTSTAGE1_LIBS)"; export HOST_LIBS;
-@@ -278,6 +287,7 @@ BASE_TARGET_EXPORTS = \
+@@ -278,6 +289,7 @@ BASE_TARGET_EXPORTS = \
  	CXXFLAGS="$(CXXFLAGS_FOR_TARGET)"; export CXXFLAGS; \
  	GFORTRAN="$(GFORTRAN_FOR_TARGET) $(XGCC_FLAGS_FOR_TARGET) $$TFLAGS"; export GFORTRAN; \
  	GOC="$(GOC_FOR_TARGET) $(XGCC_FLAGS_FOR_TARGET) $$TFLAGS"; export GOC; \
@@ -99,7 +101,7 @@ This implements building of libphobos library in GCC.
  	DLLTOOL="$(DLLTOOL_FOR_TARGET)"; export DLLTOOL; \
  	LD="$(COMPILER_LD_FOR_TARGET)"; export LD; \
  	LDFLAGS="$(LDFLAGS_FOR_TARGET)"; export LDFLAGS; \
-@@ -342,6 +352,7 @@ CXX_FOR_BUILD = @CXX_FOR_BUILD@
+@@ -342,6 +354,7 @@ CXX_FOR_BUILD = @CXX_FOR_BUILD@
  DLLTOOL_FOR_BUILD = @DLLTOOL_FOR_BUILD@
  GFORTRAN_FOR_BUILD = @GFORTRAN_FOR_BUILD@
  GOC_FOR_BUILD = @GOC_FOR_BUILD@
@@ -107,7 +109,7 @@ This implements building of libphobos library in GCC.
  LDFLAGS_FOR_BUILD = @LDFLAGS_FOR_BUILD@
  LD_FOR_BUILD = @LD_FOR_BUILD@
  NM_FOR_BUILD = @NM_FOR_BUILD@
-@@ -399,6 +410,7 @@ STRIP = @STRIP@
+@@ -399,6 +412,7 @@ STRIP = @STRIP@
  WINDRES = @WINDRES@
  WINDMC = @WINDMC@
  
@@ -115,7 +117,7 @@ This implements building of libphobos library in GCC.
  GNATBIND = @GNATBIND@
  GNATMAKE = @GNATMAKE@
  
-@@ -408,6 +420,7 @@ LIBCFLAGS = $(CFLAGS)
+@@ -408,6 +422,7 @@ LIBCFLAGS = $(CFLAGS)
  CXXFLAGS = @CXXFLAGS@
  LIBCXXFLAGS = $(CXXFLAGS) -fno-implicit-templates
  GOCFLAGS = $(CFLAGS)
@@ -123,7 +125,7 @@ This implements building of libphobos library in GCC.
  
  CREATE_GCOV = create_gcov
  
-@@ -574,6 +587,7 @@ CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @CXX_
+@@ -574,6 +589,7 @@ CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @CXX_
  RAW_CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @RAW_CXX_FOR_TARGET@
  GFORTRAN_FOR_TARGET=$(STAGE_CC_WRAPPER) @GFORTRAN_FOR_TARGET@
  GOC_FOR_TARGET=$(STAGE_CC_WRAPPER) @GOC_FOR_TARGET@
@@ -131,7 +133,7 @@ This implements building of libphobos library in GCC.
  DLLTOOL_FOR_TARGET=@DLLTOOL_FOR_TARGET@
  LD_FOR_TARGET=@LD_FOR_TARGET@
  
-@@ -598,6 +612,7 @@ LIBCFLAGS_FOR_TARGET = $(CFLAGS_FOR_TARG
+@@ -598,6 +614,7 @@ LIBCFLAGS_FOR_TARGET = $(CFLAGS_FOR_TARG
  LIBCXXFLAGS_FOR_TARGET = $(CXXFLAGS_FOR_TARGET) -fno-implicit-templates
  LDFLAGS_FOR_TARGET = @LDFLAGS_FOR_TARGET@
  GOCFLAGS_FOR_TARGET = -O2 -g
@@ -139,7 +141,7 @@ This implements building of libphobos library in GCC.
  
  FLAGS_FOR_TARGET = @FLAGS_FOR_TARGET@
  SYSROOT_CFLAGS_FOR_TARGET = @SYSROOT_CFLAGS_FOR_TARGET@
-@@ -622,7 +637,7 @@ all:
+@@ -622,7 +639,7 @@ all:
  
  # This is the list of directories that may be needed in RPATH_ENVVAR
  # so that programs built for the target machine work.
@@ -148,7 +150,7 @@ This implements building of libphobos library in GCC.
  
  @if target-libstdc++-v3
  TARGET_LIB_PATH_libstdc++-v3 = $$r/$(TARGET_SUBDIR)/libstdc++-v3/src/.libs:
-@@ -644,6 +659,10 @@ TARGET_LIB_PATH_liboffloadmic = $$r/$(TA
+@@ -644,6 +661,10 @@ TARGET_LIB_PATH_liboffloadmic = $$r/$(TA
  TARGET_LIB_PATH_libssp = $$r/$(TARGET_SUBDIR)/libssp/.libs:
  @endif target-libssp
  
@@ -159,7 +161,7 @@ This implements building of libphobos library in GCC.
  @if target-libgomp
  TARGET_LIB_PATH_libgomp = $$r/$(TARGET_SUBDIR)/libgomp/.libs:
  @endif target-libgomp
-@@ -778,6 +797,8 @@ BASE_FLAGS_TO_PASS = \
+@@ -778,6 +799,8 @@ BASE_FLAGS_TO_PASS = \
  	"STAGE1_LANGUAGES=$(STAGE1_LANGUAGES)" \
  	"GNATBIND=$(GNATBIND)" \
  	"GNATMAKE=$(GNATMAKE)" \
@@ -168,7 +170,7 @@ This implements building of libphobos library in GCC.
  	"AR_FOR_TARGET=$(AR_FOR_TARGET)" \
  	"AS_FOR_TARGET=$(AS_FOR_TARGET)" \
  	"CC_FOR_TARGET=$(CC_FOR_TARGET)" \
-@@ -789,6 +810,8 @@ BASE_FLAGS_TO_PASS = \
+@@ -789,6 +812,8 @@ BASE_FLAGS_TO_PASS = \
  	"GFORTRAN_FOR_TARGET=$(GFORTRAN_FOR_TARGET)" \
  	"GOC_FOR_TARGET=$(GOC_FOR_TARGET)" \
  	"GOCFLAGS_FOR_TARGET=$(GOCFLAGS_FOR_TARGET)" \
@@ -177,7 +179,7 @@ This implements building of libphobos library in GCC.
  	"LD_FOR_TARGET=$(LD_FOR_TARGET)" \
  	"LIPO_FOR_TARGET=$(LIPO_FOR_TARGET)" \
  	"LDFLAGS_FOR_TARGET=$(LDFLAGS_FOR_TARGET)" \
-@@ -851,6 +874,7 @@ EXTRA_HOST_FLAGS = \
+@@ -851,6 +876,7 @@ EXTRA_HOST_FLAGS = \
  	'DLLTOOL=$(DLLTOOL)' \
  	'GFORTRAN=$(GFORTRAN)' \
  	'GOC=$(GOC)' \
@@ -185,7 +187,7 @@ This implements building of libphobos library in GCC.
  	'LD=$(LD)' \
  	'LIPO=$(LIPO)' \
  	'NM=$(NM)' \
-@@ -875,6 +899,7 @@ STAGE1_FLAGS_TO_PASS = \
+@@ -875,6 +901,7 @@ STAGE1_FLAGS_TO_PASS = \
  POSTSTAGE1_FLAGS_TO_PASS = \
  	CC="$${CC}" CC_FOR_BUILD="$${CC_FOR_BUILD}" \
  	CXX="$${CXX}" CXX_FOR_BUILD="$${CXX_FOR_BUILD}" \
@@ -193,7 +195,7 @@ This implements building of libphobos library in GCC.
  	GNATBIND="$${GNATBIND}" \
  	LDFLAGS="$${LDFLAGS}" \
  	HOST_LIBS="$${HOST_LIBS}" \
-@@ -907,6 +932,8 @@ EXTRA_TARGET_FLAGS = \
+@@ -907,6 +934,8 @@ EXTRA_TARGET_FLAGS = \
  	'GFORTRAN=$$(GFORTRAN_FOR_TARGET) $$(XGCC_FLAGS_FOR_TARGET) $$(TFLAGS)' \
  	'GOC=$$(GOC_FOR_TARGET) $$(XGCC_FLAGS_FOR_TARGET) $$(TFLAGS)' \
  	'GOCFLAGS=$$(GOCFLAGS_FOR_TARGET)' \
@@ -202,7 +204,7 @@ This implements building of libphobos library in GCC.
  	'LD=$(COMPILER_LD_FOR_TARGET)' \
  	'LDFLAGS=$$(LDFLAGS_FOR_TARGET)' \
  	'LIBCFLAGS=$$(LIBCFLAGS_FOR_TARGET)' \
-@@ -1008,6 +1035,7 @@ configure-target:  \
+@@ -1008,6 +1037,7 @@ configure-target:  \
      maybe-configure-target-libobjc \
      maybe-configure-target-libgo \
      maybe-configure-target-libhsail-rt \
@@ -210,7 +212,7 @@ This implements building of libphobos library in GCC.
      maybe-configure-target-libtermcap \
      maybe-configure-target-winsup \
      maybe-configure-target-libgloss \
-@@ -1170,6 +1198,7 @@ all-target: maybe-all-target-libgfortran
+@@ -1170,6 +1200,7 @@ all-target: maybe-all-target-libgfortran
  all-target: maybe-all-target-libobjc
  all-target: maybe-all-target-libgo
  all-target: maybe-all-target-libhsail-rt
@@ -218,7 +220,7 @@ This implements building of libphobos library in GCC.
  all-target: maybe-all-target-libtermcap
  all-target: maybe-all-target-winsup
  all-target: maybe-all-target-libgloss
-@@ -1261,6 +1290,7 @@ info-target: maybe-info-target-libgfortr
+@@ -1261,6 +1292,7 @@ info-target: maybe-info-target-libgfortr
  info-target: maybe-info-target-libobjc
  info-target: maybe-info-target-libgo
  info-target: maybe-info-target-libhsail-rt
@@ -226,7 +228,7 @@ This implements building of libphobos library in GCC.
  info-target: maybe-info-target-libtermcap
  info-target: maybe-info-target-winsup
  info-target: maybe-info-target-libgloss
-@@ -1345,6 +1375,7 @@ dvi-target: maybe-dvi-target-libgfortran
+@@ -1345,6 +1377,7 @@ dvi-target: maybe-dvi-target-libgfortran
  dvi-target: maybe-dvi-target-libobjc
  dvi-target: maybe-dvi-target-libgo
  dvi-target: maybe-dvi-target-libhsail-rt
@@ -234,7 +236,7 @@ This implements building of libphobos library in GCC.
  dvi-target: maybe-dvi-target-libtermcap
  dvi-target: maybe-dvi-target-winsup
  dvi-target: maybe-dvi-target-libgloss
-@@ -1429,6 +1460,7 @@ pdf-target: maybe-pdf-target-libgfortran
+@@ -1429,6 +1462,7 @@ pdf-target: maybe-pdf-target-libgfortran
  pdf-target: maybe-pdf-target-libobjc
  pdf-target: maybe-pdf-target-libgo
  pdf-target: maybe-pdf-target-libhsail-rt
@@ -242,7 +244,7 @@ This implements building of libphobos library in GCC.
  pdf-target: maybe-pdf-target-libtermcap
  pdf-target: maybe-pdf-target-winsup
  pdf-target: maybe-pdf-target-libgloss
-@@ -1513,6 +1545,7 @@ html-target: maybe-html-target-libgfortr
+@@ -1513,6 +1547,7 @@ html-target: maybe-html-target-libgfortr
  html-target: maybe-html-target-libobjc
  html-target: maybe-html-target-libgo
  html-target: maybe-html-target-libhsail-rt
@@ -250,7 +252,7 @@ This implements building of libphobos library in GCC.
  html-target: maybe-html-target-libtermcap
  html-target: maybe-html-target-winsup
  html-target: maybe-html-target-libgloss
-@@ -1597,6 +1630,7 @@ TAGS-target: maybe-TAGS-target-libgfortr
+@@ -1597,6 +1632,7 @@ TAGS-target: maybe-TAGS-target-libgfortr
  TAGS-target: maybe-TAGS-target-libobjc
  TAGS-target: maybe-TAGS-target-libgo
  TAGS-target: maybe-TAGS-target-libhsail-rt
@@ -258,7 +260,7 @@ This implements building of libphobos library in GCC.
  TAGS-target: maybe-TAGS-target-libtermcap
  TAGS-target: maybe-TAGS-target-winsup
  TAGS-target: maybe-TAGS-target-libgloss
-@@ -1681,6 +1715,7 @@ install-info-target: maybe-install-info-
+@@ -1681,6 +1717,7 @@ install-info-target: maybe-install-info-
  install-info-target: maybe-install-info-target-libobjc
  install-info-target: maybe-install-info-target-libgo
  install-info-target: maybe-install-info-target-libhsail-rt
@@ -266,7 +268,7 @@ This implements building of libphobos library in GCC.
  install-info-target: maybe-install-info-target-libtermcap
  install-info-target: maybe-install-info-target-winsup
  install-info-target: maybe-install-info-target-libgloss
-@@ -1765,6 +1800,7 @@ install-pdf-target: maybe-install-pdf-ta
+@@ -1765,6 +1802,7 @@ install-pdf-target: maybe-install-pdf-ta
  install-pdf-target: maybe-install-pdf-target-libobjc
  install-pdf-target: maybe-install-pdf-target-libgo
  install-pdf-target: maybe-install-pdf-target-libhsail-rt
@@ -274,7 +276,7 @@ This implements building of libphobos library in GCC.
  install-pdf-target: maybe-install-pdf-target-libtermcap
  install-pdf-target: maybe-install-pdf-target-winsup
  install-pdf-target: maybe-install-pdf-target-libgloss
-@@ -1849,6 +1885,7 @@ install-html-target: maybe-install-html-
+@@ -1849,6 +1887,7 @@ install-html-target: maybe-install-html-
  install-html-target: maybe-install-html-target-libobjc
  install-html-target: maybe-install-html-target-libgo
  install-html-target: maybe-install-html-target-libhsail-rt
@@ -282,7 +284,7 @@ This implements building of libphobos library in GCC.
  install-html-target: maybe-install-html-target-libtermcap
  install-html-target: maybe-install-html-target-winsup
  install-html-target: maybe-install-html-target-libgloss
-@@ -1933,6 +1970,7 @@ installcheck-target: maybe-installcheck-
+@@ -1933,6 +1972,7 @@ installcheck-target: maybe-installcheck-
  installcheck-target: maybe-installcheck-target-libobjc
  installcheck-target: maybe-installcheck-target-libgo
  installcheck-target: maybe-installcheck-target-libhsail-rt
@@ -290,7 +292,7 @@ This implements building of libphobos library in GCC.
  installcheck-target: maybe-installcheck-target-libtermcap
  installcheck-target: maybe-installcheck-target-winsup
  installcheck-target: maybe-installcheck-target-libgloss
-@@ -2017,6 +2055,7 @@ mostlyclean-target: maybe-mostlyclean-ta
+@@ -2017,6 +2057,7 @@ mostlyclean-target: maybe-mostlyclean-ta
  mostlyclean-target: maybe-mostlyclean-target-libobjc
  mostlyclean-target: maybe-mostlyclean-target-libgo
  mostlyclean-target: maybe-mostlyclean-target-libhsail-rt
@@ -298,7 +300,7 @@ This implements building of libphobos library in GCC.
  mostlyclean-target: maybe-mostlyclean-target-libtermcap
  mostlyclean-target: maybe-mostlyclean-target-winsup
  mostlyclean-target: maybe-mostlyclean-target-libgloss
-@@ -2101,6 +2140,7 @@ clean-target: maybe-clean-target-libgfor
+@@ -2101,6 +2142,7 @@ clean-target: maybe-clean-target-libgfor
  clean-target: maybe-clean-target-libobjc
  clean-target: maybe-clean-target-libgo
  clean-target: maybe-clean-target-libhsail-rt
@@ -306,7 +308,7 @@ This implements building of libphobos library in GCC.
  clean-target: maybe-clean-target-libtermcap
  clean-target: maybe-clean-target-winsup
  clean-target: maybe-clean-target-libgloss
-@@ -2185,6 +2225,7 @@ distclean-target: maybe-distclean-target
+@@ -2185,6 +2227,7 @@ distclean-target: maybe-distclean-target
  distclean-target: maybe-distclean-target-libobjc
  distclean-target: maybe-distclean-target-libgo
  distclean-target: maybe-distclean-target-libhsail-rt
@@ -314,7 +316,7 @@ This implements building of libphobos library in GCC.
  distclean-target: maybe-distclean-target-libtermcap
  distclean-target: maybe-distclean-target-winsup
  distclean-target: maybe-distclean-target-libgloss
-@@ -2269,6 +2310,7 @@ maintainer-clean-target: maybe-maintaine
+@@ -2269,6 +2312,7 @@ maintainer-clean-target: maybe-maintaine
  maintainer-clean-target: maybe-maintainer-clean-target-libobjc
  maintainer-clean-target: maybe-maintainer-clean-target-libgo
  maintainer-clean-target: maybe-maintainer-clean-target-libhsail-rt
@@ -322,7 +324,7 @@ This implements building of libphobos library in GCC.
  maintainer-clean-target: maybe-maintainer-clean-target-libtermcap
  maintainer-clean-target: maybe-maintainer-clean-target-winsup
  maintainer-clean-target: maybe-maintainer-clean-target-libgloss
-@@ -2409,6 +2451,7 @@ check-target:  \
+@@ -2409,6 +2453,7 @@ check-target:  \
      maybe-check-target-libobjc \
      maybe-check-target-libgo \
      maybe-check-target-libhsail-rt \
@@ -330,7 +332,7 @@ This implements building of libphobos library in GCC.
      maybe-check-target-libtermcap \
      maybe-check-target-winsup \
      maybe-check-target-libgloss \
-@@ -2589,6 +2632,7 @@ install-target:  \
+@@ -2589,6 +2634,7 @@ install-target:  \
      maybe-install-target-libobjc \
      maybe-install-target-libgo \
      maybe-install-target-libhsail-rt \
@@ -338,7 +340,7 @@ This implements building of libphobos library in GCC.
      maybe-install-target-libtermcap \
      maybe-install-target-winsup \
      maybe-install-target-libgloss \
-@@ -2693,6 +2737,7 @@ install-strip-target:  \
+@@ -2693,6 +2739,7 @@ install-strip-target:  \
      maybe-install-strip-target-libobjc \
      maybe-install-strip-target-libgo \
      maybe-install-strip-target-libhsail-rt \
@@ -346,7 +348,7 @@ This implements building of libphobos library in GCC.
      maybe-install-strip-target-libtermcap \
      maybe-install-strip-target-winsup \
      maybe-install-strip-target-libgloss \
-@@ -46944,6 +46989,464 @@ maintainer-clean-target-libhsail-rt:
+@@ -46944,6 +46991,464 @@ maintainer-clean-target-libhsail-rt:
  
  
  
@@ -811,7 +813,7 @@ This implements building of libphobos library in GCC.
  .PHONY: configure-target-libtermcap maybe-configure-target-libtermcap
  maybe-configure-target-libtermcap:
  @if gcc-bootstrap
-@@ -52329,6 +52832,14 @@ check-gcc-brig:
+@@ -52329,6 +52834,14 @@ check-gcc-brig:
  	(cd gcc && $(MAKE) $(GCC_FLAGS_TO_PASS) check-brig);
  check-brig: check-gcc-brig check-target-libhsail-rt
  
@@ -826,7 +828,7 @@ This implements building of libphobos library in GCC.
  
  # The gcc part of install-no-fixedincludes, which relies on an intimate
  # knowledge of how a number of gcc internal targets (inter)operate.  Delegate.
-@@ -55521,6 +56032,7 @@ configure-target-libgfortran: stage_last
+@@ -55521,6 +56034,7 @@ configure-target-libgfortran: stage_last
  configure-target-libobjc: stage_last
  configure-target-libgo: stage_last
  configure-target-libhsail-rt: stage_last
@@ -834,7 +836,7 @@ This implements building of libphobos library in GCC.
  configure-target-libtermcap: stage_last
  configure-target-winsup: stage_last
  configure-target-libgloss: stage_last
-@@ -55555,6 +56067,7 @@ configure-target-libgfortran: maybe-all-
+@@ -55555,6 +56069,7 @@ configure-target-libgfortran: maybe-all-
  configure-target-libobjc: maybe-all-gcc
  configure-target-libgo: maybe-all-gcc
  configure-target-libhsail-rt: maybe-all-gcc
@@ -842,7 +844,7 @@ This implements building of libphobos library in GCC.
  configure-target-libtermcap: maybe-all-gcc
  configure-target-winsup: maybe-all-gcc
  configure-target-libgloss: maybe-all-gcc
-@@ -56550,6 +57063,11 @@ configure-target-libgo: maybe-configure-
+@@ -56550,6 +57065,11 @@ configure-target-libgo: maybe-configure-
  all-target-libgo: maybe-all-target-libbacktrace
  all-target-libgo: maybe-all-target-libffi
  all-target-libgo: maybe-all-target-libatomic
@@ -854,7 +856,7 @@ This implements building of libphobos library in GCC.
  configure-target-libstdc++-v3: maybe-configure-target-libgomp
  configure-stage1-target-libstdc++-v3: maybe-configure-stage1-target-libgomp
  configure-stage2-target-libstdc++-v3: maybe-configure-stage2-target-libgomp
-@@ -56593,6 +57111,7 @@ all-stageautofeedback-target-libstdc++-v
+@@ -56593,6 +57113,7 @@ all-stageautofeedback-target-libstdc++-v
  install-target-libgo: maybe-install-target-libatomic
  install-target-libgfortran: maybe-install-target-libquadmath
  install-target-libgfortran: maybe-install-target-libgcc
@@ -862,7 +864,7 @@ This implements building of libphobos library in GCC.
  install-target-libsanitizer: maybe-install-target-libstdc++-v3
  install-target-libsanitizer: maybe-install-target-libgcc
  install-target-libvtv: maybe-install-target-libstdc++-v3
-@@ -56717,6 +57236,7 @@ configure-target-libgfortran: maybe-all-
+@@ -56717,6 +57238,7 @@ configure-target-libgfortran: maybe-all-
  configure-target-libobjc: maybe-all-target-libgcc
  configure-target-libgo: maybe-all-target-libgcc
  configure-target-libhsail-rt: maybe-all-target-libgcc
@@ -870,7 +872,7 @@ This implements building of libphobos library in GCC.
  configure-target-libtermcap: maybe-all-target-libgcc
  configure-target-winsup: maybe-all-target-libgcc
  configure-target-libgloss: maybe-all-target-libgcc
-@@ -56755,6 +57275,8 @@ configure-target-libgo: maybe-all-target
+@@ -56755,6 +57277,8 @@ configure-target-libgo: maybe-all-target
  
  configure-target-libhsail-rt: maybe-all-target-newlib maybe-all-target-libgloss
  
@@ -898,20 +900,22 @@ This implements building of libphobos library in GCC.
  	AR="$(AR)"; export AR; \
  	AS="$(AS)"; export AS; \
  	CC_FOR_BUILD="$(CC_FOR_BUILD)"; export CC_FOR_BUILD; \
-@@ -259,6 +262,12 @@ POSTSTAGE1_HOST_EXPORTS = \
+@@ -259,6 +262,14 @@ POSTSTAGE1_HOST_EXPORTS = \
  	CC_FOR_BUILD="$$CC"; export CC_FOR_BUILD; \
  	$(POSTSTAGE1_CXX_EXPORT) \
  	$(LTO_EXPORTS) \
 +	GDC="$$r/$(HOST_SUBDIR)/prev-gcc/gdc$(exeext) -B$$r/$(HOST_SUBDIR)/prev-gcc/ \
-+	  -B$(build_tooldir)/bin/ $(GDC_FLAGS_FOR_TARGET) \
++	  -B$(build_tooldir)/bin/ $(GDCFLAGS_FOR_TARGET) \
++	  -B$$r/prev-$(TARGET_SUBDIR)/libphobos/src \
 +	  -I$$r/prev-$(TARGET_SUBDIR)/libphobos/libdruntime -I$$s/libphobos/libdruntime \
-+	  -L$$r/prev-$(TARGET_SUBDIR)/libphobos/src/.libs"; \
++	  -L$$r/prev-$(TARGET_SUBDIR)/libphobos/src/.libs \
++	  -L$$r/prev-$(TARGET_SUBDIR)/libphobos/libdruntime/.libs"; \
 +	export GDC; \
 +	GDC_FOR_BUILD="$$GDC"; export GDC_FOR_BUILD; \
  	GNATBIND="$$r/$(HOST_SUBDIR)/prev-gcc/gnatbind"; export GNATBIND; \
  	LDFLAGS="$(POSTSTAGE1_LDFLAGS) $(BOOT_LDFLAGS)"; export LDFLAGS; \
  	HOST_LIBS="$(POSTSTAGE1_LIBS)"; export HOST_LIBS;
-@@ -281,6 +290,7 @@ BASE_TARGET_EXPORTS = \
+@@ -281,6 +292,7 @@ BASE_TARGET_EXPORTS = \
  	CXXFLAGS="$(CXXFLAGS_FOR_TARGET)"; export CXXFLAGS; \
  	GFORTRAN="$(GFORTRAN_FOR_TARGET) $(XGCC_FLAGS_FOR_TARGET) $$TFLAGS"; export GFORTRAN; \
  	GOC="$(GOC_FOR_TARGET) $(XGCC_FLAGS_FOR_TARGET) $$TFLAGS"; export GOC; \
@@ -919,7 +923,7 @@ This implements building of libphobos library in GCC.
  	DLLTOOL="$(DLLTOOL_FOR_TARGET)"; export DLLTOOL; \
  	LD="$(COMPILER_LD_FOR_TARGET)"; export LD; \
  	LDFLAGS="$(LDFLAGS_FOR_TARGET)"; export LDFLAGS; \
-@@ -345,6 +355,7 @@ CXX_FOR_BUILD = @CXX_FOR_BUILD@
+@@ -345,6 +357,7 @@ CXX_FOR_BUILD = @CXX_FOR_BUILD@
  DLLTOOL_FOR_BUILD = @DLLTOOL_FOR_BUILD@
  GFORTRAN_FOR_BUILD = @GFORTRAN_FOR_BUILD@
  GOC_FOR_BUILD = @GOC_FOR_BUILD@
@@ -927,7 +931,7 @@ This implements building of libphobos library in GCC.
  LDFLAGS_FOR_BUILD = @LDFLAGS_FOR_BUILD@
  LD_FOR_BUILD = @LD_FOR_BUILD@
  NM_FOR_BUILD = @NM_FOR_BUILD@
-@@ -402,6 +413,7 @@ STRIP = @STRIP@
+@@ -402,6 +415,7 @@ STRIP = @STRIP@
  WINDRES = @WINDRES@
  WINDMC = @WINDMC@
  
@@ -935,7 +939,7 @@ This implements building of libphobos library in GCC.
  GNATBIND = @GNATBIND@
  GNATMAKE = @GNATMAKE@
  
-@@ -411,6 +423,7 @@ LIBCFLAGS = $(CFLAGS)
+@@ -411,6 +425,7 @@ LIBCFLAGS = $(CFLAGS)
  CXXFLAGS = @CXXFLAGS@
  LIBCXXFLAGS = $(CXXFLAGS) -fno-implicit-templates
  GOCFLAGS = $(CFLAGS)
@@ -943,7 +947,7 @@ This implements building of libphobos library in GCC.
  
  CREATE_GCOV = create_gcov
  
-@@ -497,6 +510,7 @@ CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @CXX_
+@@ -497,6 +512,7 @@ CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @CXX_
  RAW_CXX_FOR_TARGET=$(STAGE_CC_WRAPPER) @RAW_CXX_FOR_TARGET@
  GFORTRAN_FOR_TARGET=$(STAGE_CC_WRAPPER) @GFORTRAN_FOR_TARGET@
  GOC_FOR_TARGET=$(STAGE_CC_WRAPPER) @GOC_FOR_TARGET@
@@ -951,7 +955,7 @@ This implements building of libphobos library in GCC.
  DLLTOOL_FOR_TARGET=@DLLTOOL_FOR_TARGET@
  LD_FOR_TARGET=@LD_FOR_TARGET@
  
-@@ -521,6 +535,7 @@ LIBCFLAGS_FOR_TARGET = $(CFLAGS_FOR_TARG
+@@ -521,6 +537,7 @@ LIBCFLAGS_FOR_TARGET = $(CFLAGS_FOR_TARG
  LIBCXXFLAGS_FOR_TARGET = $(CXXFLAGS_FOR_TARGET) -fno-implicit-templates
  LDFLAGS_FOR_TARGET = @LDFLAGS_FOR_TARGET@
  GOCFLAGS_FOR_TARGET = -O2 -g
@@ -959,7 +963,7 @@ This implements building of libphobos library in GCC.
  
  FLAGS_FOR_TARGET = @FLAGS_FOR_TARGET@
  SYSROOT_CFLAGS_FOR_TARGET = @SYSROOT_CFLAGS_FOR_TARGET@
-@@ -622,6 +637,7 @@ EXTRA_HOST_FLAGS = \
+@@ -622,6 +639,7 @@ EXTRA_HOST_FLAGS = \
  	'DLLTOOL=$(DLLTOOL)' \
  	'GFORTRAN=$(GFORTRAN)' \
  	'GOC=$(GOC)' \
@@ -967,7 +971,7 @@ This implements building of libphobos library in GCC.
  	'LD=$(LD)' \
  	'LIPO=$(LIPO)' \
  	'NM=$(NM)' \
-@@ -646,6 +662,7 @@ STAGE1_FLAGS_TO_PASS = \
+@@ -646,6 +664,7 @@ STAGE1_FLAGS_TO_PASS = \
  POSTSTAGE1_FLAGS_TO_PASS = \
  	CC="$${CC}" CC_FOR_BUILD="$${CC_FOR_BUILD}" \
  	CXX="$${CXX}" CXX_FOR_BUILD="$${CXX_FOR_BUILD}" \
@@ -975,7 +979,7 @@ This implements building of libphobos library in GCC.
  	GNATBIND="$${GNATBIND}" \
  	LDFLAGS="$${LDFLAGS}" \
  	HOST_LIBS="$${HOST_LIBS}" \
-@@ -678,6 +695,8 @@ EXTRA_TARGET_FLAGS = \
+@@ -678,6 +697,8 @@ EXTRA_TARGET_FLAGS = \
  	'GFORTRAN=$$(GFORTRAN_FOR_TARGET) $$(XGCC_FLAGS_FOR_TARGET) $$(TFLAGS)' \
  	'GOC=$$(GOC_FOR_TARGET) $$(XGCC_FLAGS_FOR_TARGET) $$(TFLAGS)' \
  	'GOCFLAGS=$$(GOCFLAGS_FOR_TARGET)' \

--- a/gcc/d/patches/patch-toplev-ddmd-9.patch
+++ b/gcc/d/patches/patch-toplev-ddmd-9.patch
@@ -30,7 +30,7 @@ This implements building of self hosted D compiler in GCC.
  // Not all; these are the ones which don't have special options.
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -1194,13 +1194,17 @@ all-target: maybe-all-target-newlib
+@@ -1195,13 +1195,17 @@ all-target: maybe-all-target-newlib
  @if target-libgcc-no-bootstrap
  all-target: maybe-all-target-libgcc
  @endif target-libgcc-no-bootstrap
@@ -48,7 +48,7 @@ This implements building of self hosted D compiler in GCC.
  all-target: maybe-all-target-libtermcap
  all-target: maybe-all-target-winsup
  all-target: maybe-all-target-libgloss
-@@ -1212,7 +1216,9 @@ all-target: maybe-all-target-libada
+@@ -1213,7 +1217,9 @@ all-target: maybe-all-target-libada
  all-target: maybe-all-target-libgomp
  @endif target-libgomp-no-bootstrap
  all-target: maybe-all-target-libitm
@@ -58,7 +58,7 @@ This implements building of self hosted D compiler in GCC.
  
  # Do a target for all the subdirectories.  A ``make do-X'' will do a
  # ``make X'' in all subdirectories (because, in general, there is a
-@@ -44251,7 +44257,6 @@ configure-target-libbacktrace: stage_cur
+@@ -44252,7 +44258,6 @@ configure-target-libbacktrace: stage_cur
  @if target-libbacktrace
  maybe-configure-target-libbacktrace: configure-target-libbacktrace
  configure-target-libbacktrace: 
@@ -66,7 +66,7 @@ This implements building of self hosted D compiler in GCC.
  	@r=`${PWD_COMMAND}`; export r; \
  	s=`cd $(srcdir); ${PWD_COMMAND}`; export s; \
  	echo "Checking multilib configuration for libbacktrace..."; \
-@@ -44289,6 +44294,412 @@ configure-target-libbacktrace:
+@@ -44290,6 +44295,412 @@ configure-target-libbacktrace:
  
  
  
@@ -479,7 +479,7 @@ This implements building of self hosted D compiler in GCC.
  
  
  .PHONY: all-target-libbacktrace maybe-all-target-libbacktrace
-@@ -44300,7 +44711,6 @@ all-target-libbacktrace: stage_current
+@@ -44301,7 +44712,6 @@ all-target-libbacktrace: stage_current
  TARGET-target-libbacktrace=all
  maybe-all-target-libbacktrace: all-target-libbacktrace
  all-target-libbacktrace: configure-target-libbacktrace
@@ -487,7 +487,7 @@ This implements building of self hosted D compiler in GCC.
  	@r=`${PWD_COMMAND}`; export r; \
  	s=`cd $(srcdir); ${PWD_COMMAND}`; export s; \
  	$(NORMAL_TARGET_EXPORTS)  \
-@@ -44311,6 +44721,387 @@ all-target-libbacktrace: configure-targe
+@@ -44312,6 +44722,387 @@ all-target-libbacktrace: configure-targe
  
  
  
@@ -875,7 +875,7 @@ This implements building of self hosted D compiler in GCC.
  
  
  .PHONY: check-target-libbacktrace maybe-check-target-libbacktrace
-@@ -46999,7 +47790,6 @@ configure-target-libphobos: stage_curren
+@@ -47000,7 +47791,6 @@ configure-target-libphobos: stage_curren
  @if target-libphobos
  maybe-configure-target-libphobos: configure-target-libphobos
  configure-target-libphobos: 
@@ -883,7 +883,7 @@ This implements building of self hosted D compiler in GCC.
  	@r=`${PWD_COMMAND}`; export r; \
  	s=`cd $(srcdir); ${PWD_COMMAND}`; export s; \
  	echo "Checking multilib configuration for libphobos..."; \
-@@ -47037,6 +47827,412 @@ configure-target-libphobos:
+@@ -47038,6 +47828,412 @@ configure-target-libphobos:
  
  
  
@@ -1296,7 +1296,7 @@ This implements building of self hosted D compiler in GCC.
  
  
  .PHONY: all-target-libphobos maybe-all-target-libphobos
-@@ -47048,7 +48244,6 @@ all-target-libphobos: stage_current
+@@ -47049,7 +48245,6 @@ all-target-libphobos: stage_current
  TARGET-target-libphobos=all
  maybe-all-target-libphobos: all-target-libphobos
  all-target-libphobos: configure-target-libphobos
@@ -1304,7 +1304,7 @@ This implements building of self hosted D compiler in GCC.
  	@r=`${PWD_COMMAND}`; export r; \
  	s=`cd $(srcdir); ${PWD_COMMAND}`; export s; \
  	$(NORMAL_TARGET_EXPORTS)  \
-@@ -47059,6 +48254,387 @@ all-target-libphobos: configure-target-l
+@@ -47060,6 +48255,387 @@ all-target-libphobos: configure-target-l
  
  
  
@@ -1692,7 +1692,7 @@ This implements building of self hosted D compiler in GCC.
  
  
  .PHONY: check-target-libphobos maybe-check-target-libphobos
-@@ -52284,7 +53860,6 @@ configure-target-libatomic: stage_curren
+@@ -52285,7 +53861,6 @@ configure-target-libatomic: stage_curren
  @if target-libatomic
  maybe-configure-target-libatomic: configure-target-libatomic
  configure-target-libatomic: 
@@ -1700,7 +1700,7 @@ This implements building of self hosted D compiler in GCC.
  	@r=`${PWD_COMMAND}`; export r; \
  	s=`cd $(srcdir); ${PWD_COMMAND}`; export s; \
  	echo "Checking multilib configuration for libatomic..."; \
-@@ -52322,6 +53897,412 @@ configure-target-libatomic:
+@@ -52323,6 +53898,412 @@ configure-target-libatomic:
  
  
  
@@ -2113,7 +2113,7 @@ This implements building of self hosted D compiler in GCC.
  
  
  .PHONY: all-target-libatomic maybe-all-target-libatomic
-@@ -52333,7 +54314,6 @@ all-target-libatomic: stage_current
+@@ -52334,7 +54315,6 @@ all-target-libatomic: stage_current
  TARGET-target-libatomic=all
  maybe-all-target-libatomic: all-target-libatomic
  all-target-libatomic: configure-target-libatomic
@@ -2121,7 +2121,7 @@ This implements building of self hosted D compiler in GCC.
  	@r=`${PWD_COMMAND}`; export r; \
  	s=`cd $(srcdir); ${PWD_COMMAND}`; export s; \
  	$(NORMAL_TARGET_EXPORTS)  \
-@@ -52344,6 +54324,387 @@ all-target-libatomic: configure-target-l
+@@ -52345,6 +54325,387 @@ all-target-libatomic: configure-target-l
  
  
  
@@ -2509,7 +2509,7 @@ This implements building of self hosted D compiler in GCC.
  
  
  .PHONY: check-target-libatomic maybe-check-target-libatomic
-@@ -56028,13 +58389,29 @@ configure-stagetrain-target-libgcc: mayb
+@@ -56029,13 +58390,29 @@ configure-stagetrain-target-libgcc: mayb
  configure-stagefeedback-target-libgcc: maybe-all-stagefeedback-gcc
  configure-stageautoprofile-target-libgcc: maybe-all-stageautoprofile-gcc
  configure-stageautofeedback-target-libgcc: maybe-all-stageautofeedback-gcc
@@ -2541,7 +2541,7 @@ This implements building of self hosted D compiler in GCC.
  configure-target-libtermcap: stage_last
  configure-target-winsup: stage_last
  configure-target-libgloss: stage_last
-@@ -56052,7 +58429,15 @@ configure-stagefeedback-target-libgomp:
+@@ -56053,7 +58430,15 @@ configure-stagefeedback-target-libgomp:
  configure-stageautoprofile-target-libgomp: maybe-all-stageautoprofile-gcc
  configure-stageautofeedback-target-libgomp: maybe-all-stageautofeedback-gcc
  configure-target-libitm: stage_last
@@ -2558,7 +2558,7 @@ This implements building of self hosted D compiler in GCC.
  @endif gcc-bootstrap
  
  @if gcc-no-bootstrap
-@@ -57062,14 +59447,39 @@ all-m4: maybe-all-build-texinfo
+@@ -57063,14 +59448,39 @@ all-m4: maybe-all-build-texinfo
  configure-target-fastjar: maybe-configure-target-zlib
  all-target-fastjar: maybe-all-target-zlib
  configure-target-libgo: maybe-configure-target-libffi
@@ -2600,7 +2600,7 @@ This implements building of self hosted D compiler in GCC.
  configure-target-libstdc++-v3: maybe-configure-target-libgomp
  configure-stage1-target-libstdc++-v3: maybe-configure-stage1-target-libgomp
  configure-stage2-target-libstdc++-v3: maybe-configure-stage2-target-libgomp
-@@ -57126,7 +59536,6 @@ install-target-libstdc++-v3: maybe-insta
+@@ -57127,7 +59537,6 @@ install-target-libstdc++-v3: maybe-insta
  all-target-libgloss: maybe-all-target-newlib
  all-target-winsup: maybe-all-target-libtermcap
  configure-target-libgfortran: maybe-all-target-libquadmath
@@ -2608,7 +2608,7 @@ This implements building of self hosted D compiler in GCC.
  
  
  @if gcc-bootstrap
-@@ -57175,10 +59584,13 @@ all-bison: maybe-all-intl
+@@ -57176,10 +59585,13 @@ all-bison: maybe-all-intl
  all-flex: maybe-all-intl
  all-m4: maybe-all-intl
  configure-target-libgo: maybe-all-target-libstdc++-v3
@@ -2622,7 +2622,7 @@ This implements building of self hosted D compiler in GCC.
  @endunless gcc-bootstrap
  
  # Dependencies for target modules on other target modules are
-@@ -57214,6 +59626,24 @@ configure-stagetrain-target-libvtv: mayb
+@@ -57215,6 +59627,24 @@ configure-stagetrain-target-libvtv: mayb
  configure-stagefeedback-target-libvtv: maybe-all-stagefeedback-target-libgcc
  configure-stageautoprofile-target-libvtv: maybe-all-stageautoprofile-target-libgcc
  configure-stageautofeedback-target-libvtv: maybe-all-stageautofeedback-target-libgcc
@@ -2647,7 +2647,7 @@ This implements building of self hosted D compiler in GCC.
  configure-stage1-target-libgomp: maybe-all-stage1-target-libgcc
  configure-stage2-target-libgomp: maybe-all-stage2-target-libgcc
  configure-stage3-target-libgomp: maybe-all-stage3-target-libgcc
-@@ -57223,6 +59653,15 @@ configure-stagetrain-target-libgomp: may
+@@ -57224,6 +59654,15 @@ configure-stagetrain-target-libgomp: may
  configure-stagefeedback-target-libgomp: maybe-all-stagefeedback-target-libgcc
  configure-stageautoprofile-target-libgomp: maybe-all-stageautoprofile-target-libgcc
  configure-stageautofeedback-target-libgomp: maybe-all-stageautofeedback-target-libgcc

--- a/gcc/d/patches/patch-toplev-ddmd-9.patch
+++ b/gcc/d/patches/patch-toplev-ddmd-9.patch
@@ -30,7 +30,7 @@ This implements building of self hosted D compiler in GCC.
  // Not all; these are the ones which don't have special options.
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -1192,13 +1192,17 @@ all-target: maybe-all-target-newlib
+@@ -1194,13 +1194,17 @@ all-target: maybe-all-target-newlib
  @if target-libgcc-no-bootstrap
  all-target: maybe-all-target-libgcc
  @endif target-libgcc-no-bootstrap
@@ -48,7 +48,7 @@ This implements building of self hosted D compiler in GCC.
  all-target: maybe-all-target-libtermcap
  all-target: maybe-all-target-winsup
  all-target: maybe-all-target-libgloss
-@@ -1210,7 +1214,9 @@ all-target: maybe-all-target-libada
+@@ -1212,7 +1216,9 @@ all-target: maybe-all-target-libada
  all-target: maybe-all-target-libgomp
  @endif target-libgomp-no-bootstrap
  all-target: maybe-all-target-libitm
@@ -58,7 +58,7 @@ This implements building of self hosted D compiler in GCC.
  
  # Do a target for all the subdirectories.  A ``make do-X'' will do a
  # ``make X'' in all subdirectories (because, in general, there is a
-@@ -44249,7 +44255,6 @@ configure-target-libbacktrace: stage_cur
+@@ -44251,7 +44257,6 @@ configure-target-libbacktrace: stage_cur
  @if target-libbacktrace
  maybe-configure-target-libbacktrace: configure-target-libbacktrace
  configure-target-libbacktrace: 
@@ -66,7 +66,7 @@ This implements building of self hosted D compiler in GCC.
  	@r=`${PWD_COMMAND}`; export r; \
  	s=`cd $(srcdir); ${PWD_COMMAND}`; export s; \
  	echo "Checking multilib configuration for libbacktrace..."; \
-@@ -44287,6 +44292,412 @@ configure-target-libbacktrace:
+@@ -44289,6 +44294,412 @@ configure-target-libbacktrace:
  
  
  
@@ -479,7 +479,7 @@ This implements building of self hosted D compiler in GCC.
  
  
  .PHONY: all-target-libbacktrace maybe-all-target-libbacktrace
-@@ -44298,7 +44709,6 @@ all-target-libbacktrace: stage_current
+@@ -44300,7 +44711,6 @@ all-target-libbacktrace: stage_current
  TARGET-target-libbacktrace=all
  maybe-all-target-libbacktrace: all-target-libbacktrace
  all-target-libbacktrace: configure-target-libbacktrace
@@ -487,7 +487,7 @@ This implements building of self hosted D compiler in GCC.
  	@r=`${PWD_COMMAND}`; export r; \
  	s=`cd $(srcdir); ${PWD_COMMAND}`; export s; \
  	$(NORMAL_TARGET_EXPORTS)  \
-@@ -44309,6 +44719,387 @@ all-target-libbacktrace: configure-targe
+@@ -44311,6 +44721,387 @@ all-target-libbacktrace: configure-targe
  
  
  
@@ -875,7 +875,7 @@ This implements building of self hosted D compiler in GCC.
  
  
  .PHONY: check-target-libbacktrace maybe-check-target-libbacktrace
-@@ -46997,7 +47788,6 @@ configure-target-libphobos: stage_curren
+@@ -46999,7 +47790,6 @@ configure-target-libphobos: stage_curren
  @if target-libphobos
  maybe-configure-target-libphobos: configure-target-libphobos
  configure-target-libphobos: 
@@ -883,7 +883,7 @@ This implements building of self hosted D compiler in GCC.
  	@r=`${PWD_COMMAND}`; export r; \
  	s=`cd $(srcdir); ${PWD_COMMAND}`; export s; \
  	echo "Checking multilib configuration for libphobos..."; \
-@@ -47035,6 +47825,412 @@ configure-target-libphobos:
+@@ -47037,6 +47827,412 @@ configure-target-libphobos:
  
  
  
@@ -1296,7 +1296,7 @@ This implements building of self hosted D compiler in GCC.
  
  
  .PHONY: all-target-libphobos maybe-all-target-libphobos
-@@ -47046,7 +48242,6 @@ all-target-libphobos: stage_current
+@@ -47048,7 +48244,6 @@ all-target-libphobos: stage_current
  TARGET-target-libphobos=all
  maybe-all-target-libphobos: all-target-libphobos
  all-target-libphobos: configure-target-libphobos
@@ -1304,7 +1304,7 @@ This implements building of self hosted D compiler in GCC.
  	@r=`${PWD_COMMAND}`; export r; \
  	s=`cd $(srcdir); ${PWD_COMMAND}`; export s; \
  	$(NORMAL_TARGET_EXPORTS)  \
-@@ -47057,6 +48252,387 @@ all-target-libphobos: configure-target-l
+@@ -47059,6 +48254,387 @@ all-target-libphobos: configure-target-l
  
  
  
@@ -1692,7 +1692,7 @@ This implements building of self hosted D compiler in GCC.
  
  
  .PHONY: check-target-libphobos maybe-check-target-libphobos
-@@ -52282,7 +53858,6 @@ configure-target-libatomic: stage_curren
+@@ -52284,7 +53860,6 @@ configure-target-libatomic: stage_curren
  @if target-libatomic
  maybe-configure-target-libatomic: configure-target-libatomic
  configure-target-libatomic: 
@@ -1700,7 +1700,7 @@ This implements building of self hosted D compiler in GCC.
  	@r=`${PWD_COMMAND}`; export r; \
  	s=`cd $(srcdir); ${PWD_COMMAND}`; export s; \
  	echo "Checking multilib configuration for libatomic..."; \
-@@ -52320,6 +53895,412 @@ configure-target-libatomic:
+@@ -52322,6 +53897,412 @@ configure-target-libatomic:
  
  
  
@@ -2113,7 +2113,7 @@ This implements building of self hosted D compiler in GCC.
  
  
  .PHONY: all-target-libatomic maybe-all-target-libatomic
-@@ -52331,7 +54312,6 @@ all-target-libatomic: stage_current
+@@ -52333,7 +54314,6 @@ all-target-libatomic: stage_current
  TARGET-target-libatomic=all
  maybe-all-target-libatomic: all-target-libatomic
  all-target-libatomic: configure-target-libatomic
@@ -2121,7 +2121,7 @@ This implements building of self hosted D compiler in GCC.
  	@r=`${PWD_COMMAND}`; export r; \
  	s=`cd $(srcdir); ${PWD_COMMAND}`; export s; \
  	$(NORMAL_TARGET_EXPORTS)  \
-@@ -52342,6 +54322,387 @@ all-target-libatomic: configure-target-l
+@@ -52344,6 +54324,387 @@ all-target-libatomic: configure-target-l
  
  
  
@@ -2509,7 +2509,7 @@ This implements building of self hosted D compiler in GCC.
  
  
  .PHONY: check-target-libatomic maybe-check-target-libatomic
-@@ -56026,13 +58387,29 @@ configure-stagetrain-target-libgcc: mayb
+@@ -56028,13 +58389,29 @@ configure-stagetrain-target-libgcc: mayb
  configure-stagefeedback-target-libgcc: maybe-all-stagefeedback-gcc
  configure-stageautoprofile-target-libgcc: maybe-all-stageautoprofile-gcc
  configure-stageautofeedback-target-libgcc: maybe-all-stageautofeedback-gcc
@@ -2541,7 +2541,7 @@ This implements building of self hosted D compiler in GCC.
  configure-target-libtermcap: stage_last
  configure-target-winsup: stage_last
  configure-target-libgloss: stage_last
-@@ -56050,7 +58427,15 @@ configure-stagefeedback-target-libgomp:
+@@ -56052,7 +58429,15 @@ configure-stagefeedback-target-libgomp:
  configure-stageautoprofile-target-libgomp: maybe-all-stageautoprofile-gcc
  configure-stageautofeedback-target-libgomp: maybe-all-stageautofeedback-gcc
  configure-target-libitm: stage_last
@@ -2558,11 +2558,14 @@ This implements building of self hosted D compiler in GCC.
  @endif gcc-bootstrap
  
  @if gcc-no-bootstrap
-@@ -57064,10 +59449,40 @@ all-target-libgo: maybe-all-target-libba
+@@ -57062,14 +59447,39 @@ all-m4: maybe-all-build-texinfo
+ configure-target-fastjar: maybe-configure-target-zlib
+ all-target-fastjar: maybe-all-target-zlib
+ configure-target-libgo: maybe-configure-target-libffi
+-all-target-libgo: maybe-all-target-libbacktrace
  all-target-libgo: maybe-all-target-libffi
- all-target-libgo: maybe-all-target-libatomic
+-all-target-libgo: maybe-all-target-libatomic
  configure-target-libphobos: maybe-configure-target-libbacktrace
-+
 +configure-stage1-target-libphobos: maybe-configure-stage1-target-libbacktrace
 +configure-stage2-target-libphobos: maybe-configure-stage2-target-libbacktrace
 +configure-stage3-target-libphobos: maybe-configure-stage3-target-libbacktrace
@@ -2574,7 +2577,6 @@ This implements building of self hosted D compiler in GCC.
 +configure-stageautofeedback-target-libphobos: maybe-configure-stageautofeedback-target-libbacktrace
  configure-target-libphobos: maybe-configure-target-zlib
  all-target-libphobos: maybe-all-target-libbacktrace
-+
 +all-stage1-target-libphobos: maybe-all-stage1-target-libbacktrace
 +all-stage2-target-libphobos: maybe-all-stage2-target-libbacktrace
 +all-stage3-target-libphobos: maybe-all-stage3-target-libbacktrace
@@ -2586,7 +2588,6 @@ This implements building of self hosted D compiler in GCC.
 +all-stageautofeedback-target-libphobos: maybe-all-stageautofeedback-target-libbacktrace
  all-target-libphobos: maybe-all-target-zlib
  all-target-libphobos: maybe-all-target-libatomic
-+
 +all-stage1-target-libphobos: maybe-all-stage1-target-libatomic
 +all-stage2-target-libphobos: maybe-all-stage2-target-libatomic
 +all-stage3-target-libphobos: maybe-all-stage3-target-libatomic
@@ -2599,7 +2600,29 @@ This implements building of self hosted D compiler in GCC.
  configure-target-libstdc++-v3: maybe-configure-target-libgomp
  configure-stage1-target-libstdc++-v3: maybe-configure-stage1-target-libgomp
  configure-stage2-target-libstdc++-v3: maybe-configure-stage2-target-libgomp
-@@ -57212,6 +59627,24 @@ configure-stagetrain-target-libvtv: mayb
+@@ -57126,7 +59536,6 @@ install-target-libstdc++-v3: maybe-insta
+ all-target-libgloss: maybe-all-target-newlib
+ all-target-winsup: maybe-all-target-libtermcap
+ configure-target-libgfortran: maybe-all-target-libquadmath
+-configure-target-libgfortran: maybe-all-target-libbacktrace
+ 
+ 
+ @if gcc-bootstrap
+@@ -57175,10 +59584,13 @@ all-bison: maybe-all-intl
+ all-flex: maybe-all-intl
+ all-m4: maybe-all-intl
+ configure-target-libgo: maybe-all-target-libstdc++-v3
++all-target-libgo: maybe-all-target-libbacktrace
++all-target-libgo: maybe-all-target-libatomic
+ configure-target-liboffloadmic: maybe-configure-target-libgomp
+ all-target-liboffloadmic: maybe-all-target-libgomp
+ configure-target-newlib: maybe-all-binutils
+ configure-target-newlib: maybe-all-ld
++configure-target-libgfortran: maybe-all-target-libbacktrace
+ @endunless gcc-bootstrap
+ 
+ # Dependencies for target modules on other target modules are
+@@ -57214,6 +59626,24 @@ configure-stagetrain-target-libvtv: mayb
  configure-stagefeedback-target-libvtv: maybe-all-stagefeedback-target-libgcc
  configure-stageautoprofile-target-libvtv: maybe-all-stageautoprofile-target-libgcc
  configure-stageautofeedback-target-libvtv: maybe-all-stageautofeedback-target-libgcc
@@ -2624,7 +2647,7 @@ This implements building of self hosted D compiler in GCC.
  configure-stage1-target-libgomp: maybe-all-stage1-target-libgcc
  configure-stage2-target-libgomp: maybe-all-stage2-target-libgcc
  configure-stage3-target-libgomp: maybe-all-stage3-target-libgcc
-@@ -57221,6 +59654,15 @@ configure-stagetrain-target-libgomp: may
+@@ -57223,6 +59653,15 @@ configure-stagetrain-target-libgomp: may
  configure-stagefeedback-target-libgomp: maybe-all-stagefeedback-target-libgcc
  configure-stageautoprofile-target-libgomp: maybe-all-stageautoprofile-target-libgcc
  configure-stageautofeedback-target-libgomp: maybe-all-stageautofeedback-target-libgcc


### PR DESCRIPTION
1. Error libgphobos.spec not found.
```
gdc: error: libgphobos.spec: No such file or directory
```
Link command was missing -B option to `prev-target/libphobos/src` in `POSTSTAGE1_HOST_EXPORTS`, and so it was using the host installed copy if found.  The error occurs if libgphobos.spec is not found on the host either.

Bug fix: https://bugzilla.gdcproject.org/show_bug.cgi?id=303

---

2. Error undefined references to recently added druntime symbols.
```
d: d/dmodule.o:(.data.rel.ro._D3dmd5parse__T6ParserTS3dmd10astcodegen10ASTCodegenZQBm6__vtblZ[_D3dmd5parse__T6ParserTS3dmd10astcodegen10ASTCodegenZQBm6__vtblZ]+0x18): undefined reference to `_D6object6Object5opCmpMFCQqZi'
ld: d/dmodule.o:(.data.rel.ro._D3dmd5parse__T6ParserTS3dmd10astcodegen10ASTCodegenZQBm6__vtblZ[_D3dmd5parse__T6ParserTS3dmd10astcodegen10ASTCodegenZQBm6__vtblZ]+0x20): undefined reference to `_D6object6Object8opEqualsMFCQtZb'
ld: d/filename.o: in function `FileName::searchPath(Array<char const*>*, char const*, bool)':
gcc/d/dmd/root/filename.d:611: undefined reference to `_D4core3sys5posixQk4stat7S_ISDIRFNbNikZb'
ld: gcc/d/dmd/root/filename.d:611: undefined reference to `_D4core3sys5posixQk4stat7S_ISDIRFNbNikZb'
ld: d/filename.o: in function `FileName::exists(char const*)':
gcc/d/dmd/root/filename.d:611: undefined reference to `_D4core3sys5posixQk4stat7S_ISDIRFNbNikZb'
ld: d/filename.o: in function `FileName::safeSearchPath(Array<char const*>*, char const*)':
gcc/d/dmd/root/filename.d:611: undefined reference to `_D4core3sys5posixQk4stat7S_ISDIRFNbNikZb'
ld: d/filename.o: in function `FileName::ensurePathExists(char const*) [clone .localalias.0]':
gcc/d/dmd/root/filename.d:611: undefined reference to `_D4core3sys5posixQk4stat7S_ISDIRFNbNikZb'
```
Link command was missing -L option to `prev-target/libphobos/libdruntime/.libs` in `POSTSTAGE1_HOST_EXPORTS`, and so it was linking against the host installed copy of libgdruntime, which is a different version to the one being built.

---

3. Stage 2 fails to build after merging #704 (if I understand write) due to changes to `__c_long` definition.
```
gcc/d/dmd/root/longdouble.d:30:5: note: ‘dmd.root.longdouble.longdouble.__ctor(T)(T r)’
     this(T)(T r)
     ^
gcc/d/dmd/dcast.d:381:52: error: cannot cast expression ‘cast(long)value’ of type ‘long’ to ‘longdouble’
                 const f = cast(T) cast(sinteger_t) value;
                                                    ^
gcc/d/dmd/dcast.d:459:22: error: template instance ‘dmd.dcast.implicitConvTo.ImplicitConvTo.visit.isLosslesslyConvertibleToFP!(longdouble)’ error instantiating
                 if (!isLosslesslyConvertibleToFP!real_t)
                      ^
```
See: https://github.com/dlang/dmd/pull/8632
Bug fix: https://bugzilla.gdcproject.org/show_bug.cgi?id=301

---

4. Fix gagged warning discovered when debugging [3].
```
gcc/d/dmd/root/longdouble.d:28:1: anachronism: ‘dmd.root.longdouble.longdouble.opAssign’ called with argument types ‘(longdouble)’ matches both:
   gcc/d/dmd/root/longdouble.d:36:16:     ‘dmd.root.longdouble.longdouble.opAssign!(longdouble).opAssign(longdouble r)’
and:
   gcc/d/dmd/root/longdouble.d:43:16:     ‘dmd.root.longdouble.longdouble.opAssign!(longdouble).opAssign(longdouble r)’
28 | struct longdouble
   | ^
```

---

5. Error cannot find libstdc++
```
ld: cannot find -lstdc++
collect2: error: ld returned 1 exit status
make[3]: *** [../../gcc/d/Make-lang.in:191: cc1d] Error 1
```
Link command was missing -L option to `prev-target/libstdc++-v3/src/.libs` in `POSTSTAGE1_HOST_EXPORTS`, and so it was using the host installed copy if found.  The error occurs if libstdc++ is not found on the host.