### PR TITLE
Add support for RISC-V architecture

### DIFF
--- a/gcc/d/patches/patch-targetdm-9.patch
+++ b/gcc/d/patches/patch-targetdm-9.patch
@@ -31,6 +31,8 @@ The following CPU versions are implemented:
 * PPC64
 ** PPC_HardFloat
 ** PPC_SoftFloat
+* RISCV32
+* RISCV64
 * S390
 * S390X (deprecated)
 * SystemZ
@@ -267,7 +269,15 @@ The following OS versions are implemented:
  	extra_headers="loongson.h msa.h"
  	extra_objs="frame-header-opt.o"
  	extra_options="${extra_options} g.opt fused-madd.opt mips/mips-tables.opt"
-@@ -505,6 +522,7 @@ sparc*-*-*)
+@@ -496,6 +513,7 @@ powerpc*-*-*)
+ riscv*)
+ 	cpu_type=riscv
+ 	extra_objs="riscv-builtins.o riscv-c.o"
++	d_target_objs="riscv-d.o"
+ 	;;
+ rs6000*-*-*)
+ 	extra_options="${extra_options} g.opt fused-madd.opt rs6000/rs6000-tables.opt"
+@@ -505,6 +523,7 @@ sparc*-*-*)
  	cpu_type=sparc
  	c_target_objs="sparc-c.o"
  	cxx_target_objs="sparc-c.o"
@@ -275,7 +285,7 @@ The following OS versions are implemented:
  	extra_headers="visintrin.h"
  	;;
  spu*-*-*)
-@@ -512,6 +530,7 @@ spu*-*-*)
+@@ -512,6 +531,7 @@ spu*-*-*)
  	;;
  s390*-*-*)
  	cpu_type=s390
@@ -283,7 +293,7 @@ The following OS versions are implemented:
  	extra_options="${extra_options} fused-madd.opt"
  	extra_headers="s390intrin.h htmintrin.h htmxlintrin.h vecintrin.h"
  	;;
-@@ -541,10 +560,13 @@ tilepro*-*-*)
+@@ -541,10 +561,13 @@ tilepro*-*-*)
  esac
  
  tm_file=${cpu_type}/${cpu_type}.h
@@ -297,7 +307,7 @@ The following OS versions are implemented:
  extra_modes=
  if test -f ${srcdir}/config/${cpu_type}/${cpu_type}-modes.def
  then
-@@ -814,8 +836,10 @@ case ${target} in
+@@ -814,8 +837,10 @@ case ${target} in
    esac
    c_target_objs="${c_target_objs} glibc-c.o"
    cxx_target_objs="${cxx_target_objs} glibc-c.o"
@@ -308,7 +318,7 @@ The following OS versions are implemented:
    ;;
  *-*-netbsd*)
    tm_p_file="${tm_p_file} netbsd-protos.h"
-@@ -3231,6 +3255,10 @@ if [ "$common_out_file" = "" ]; then
+@@ -3231,6 +3256,10 @@ if [ "$common_out_file" = "" ]; then
    fi
  fi
  
@@ -319,7 +329,7 @@ The following OS versions are implemented:
  # Support for --with-cpu and related options (and a few unrelated options,
  # too).
  case ${with_cpu} in
-@@ -4845,6 +4873,7 @@ case ${target} in
+@@ -4845,6 +4874,7 @@ case ${target} in
  		out_file="${cpu_type}/${cpu_type}.c"
  		c_target_objs="${c_target_objs} ${cpu_type}-c.o"
  		cxx_target_objs="${cxx_target_objs} ${cpu_type}-c.o"
@@ -329,7 +339,7 @@ The following OS versions are implemented:
  
 --- /dev/null
 +++ b/gcc/config/aarch64/aarch64-d.c
-@@ -0,0 +1,31 @@
+@@ -0,0 +1,32 @@
 +/* Subroutines for the D front end on the AArch64 architecture.
 +   Copyright (C) 2017 Free Software Foundation, Inc.
 +
@@ -360,6 +370,7 @@ The following OS versions are implemented:
 +{
 +  d_add_builtin_version ("AArch64");
 +  d_add_builtin_version ("D_HardFloat");
++  d_add_builtin_version ("D_DoubleFloat");
 +}
 --- a/gcc/config/aarch64/aarch64-linux.h
 +++ b/gcc/config/aarch64/aarch64-linux.h
@@ -411,7 +422,7 @@ The following OS versions are implemented:
  cortex-a57-fma-steering.o: $(srcdir)/config/aarch64/cortex-a57-fma-steering.c \
 --- /dev/null
 +++ b/gcc/config/alpha/alpha-d.c
-@@ -0,0 +1,41 @@
+@@ -0,0 +1,42 @@
 +/* Subroutines for the D front end on the Alpha architecture.
 +   Copyright (C) 2017 Free Software Foundation, Inc.
 +
@@ -450,6 +461,7 @@ The following OS versions are implemented:
 +  else
 +    {
 +      d_add_builtin_version ("D_HardFloat");
++      d_add_builtin_version ("D_DoubleFloat");
 +      d_add_builtin_version ("Alpha_HardFloat");
 +    }
 +}
@@ -509,7 +521,7 @@ The following OS versions are implemented:
  PASSES_EXTRA += $(srcdir)/config/alpha/alpha-passes.def
 --- /dev/null
 +++ b/gcc/config/arm/arm-d.c
-@@ -0,0 +1,53 @@
+@@ -0,0 +1,56 @@
 +/* Subroutines for the D front end on the ARM architecture.
 +   Copyright (C) 2017 Free Software Foundation, Inc.
 +
@@ -561,7 +573,10 @@ The following OS versions are implemented:
 +  if (TARGET_SOFT_FLOAT)
 +    d_add_builtin_version ("D_SoftFloat");
 +  else if (TARGET_HARD_FLOAT)
-+    d_add_builtin_version ("D_HardFloat");
++    {
++      d_add_builtin_version ("D_HardFloat");
++      d_add_builtin_version ("D_DoubleFloat");
++    }
 +}
 --- a/gcc/config/arm/arm-protos.h
 +++ b/gcc/config/arm/arm-protos.h
@@ -721,7 +736,7 @@ The following OS versions are implemented:
 +    } while (0)
 --- /dev/null
 +++ b/gcc/config/i386/i386-d.c
-@@ -0,0 +1,44 @@
+@@ -0,0 +1,47 @@
 +/* Subroutines for the D front end on the x86 architecture.
 +   Copyright (C) 2017 Free Software Foundation, Inc.
 +
@@ -762,7 +777,10 @@ The following OS versions are implemented:
 +    d_add_builtin_version ("X86");
 +
 +  if (TARGET_80387)
-+    d_add_builtin_version ("D_HardFloat");
++    {
++      d_add_builtin_version ("D_HardFloat");
++      d_add_builtin_version ("D_DoubleFloat");
++    }
 +  else
 +    d_add_builtin_version ("D_SoftFloat");
 +}
@@ -898,7 +916,7 @@ The following OS versions are implemented:
    LINUX_OR_ANDROID_LD (GNU_USER_TARGET_LINK_SPEC,			\
 --- /dev/null
 +++ b/gcc/config/mips/mips-d.c
-@@ -0,0 +1,56 @@
+@@ -0,0 +1,59 @@
 +/* Subroutines for the D front end on the MIPS architecture.
 +   Copyright (C) 2017 Free Software Foundation, Inc.
 +
@@ -954,6 +972,9 @@ The following OS versions are implemented:
 +      d_add_builtin_version ("MIPS_SoftFloat");
 +      d_add_builtin_version ("D_SoftFloat");
 +    }
++
++  if (TARGET_DOUBLE_FLOAT)
++    d_add_builtin_version ("D_DoubleFloat");
 +}
 --- a/gcc/config/mips/mips-protos.h
 +++ b/gcc/config/mips/mips-protos.h
@@ -1033,7 +1054,7 @@ The following OS versions are implemented:
  
 --- /dev/null
 +++ b/gcc/config/powerpcspe/powerpcspe-d.c
-@@ -0,0 +1,45 @@
+@@ -0,0 +1,48 @@
 +/* Subroutines for the D front end on the PowerPC architecture.
 +   Copyright (C) 2017 Free Software Foundation, Inc.
 +
@@ -1078,6 +1099,9 @@ The following OS versions are implemented:
 +      d_add_builtin_version ("PPC_SoftFloat");
 +      d_add_builtin_version ("D_SoftFloat");
 +    }
++
++  if (TARGET_DOUBLE_FLOAT)
++    d_add_builtin_version ("D_DoubleFloat");
 +}
 --- a/gcc/config/powerpcspe/powerpcspe-protos.h
 +++ b/gcc/config/powerpcspe/powerpcspe-protos.h
@@ -1116,6 +1140,85 @@ The following OS versions are implemented:
  $(srcdir)/config/powerpcspe/powerpcspe-tables.opt: $(srcdir)/config/powerpcspe/genopt.sh \
    $(srcdir)/config/powerpcspe/powerpcspe-cpus.def
  	$(SHELL) $(srcdir)/config/powerpcspe/genopt.sh $(srcdir)/config/powerpcspe > \
+--- /dev/null
++++ b/gcc/config/riscv/riscv-d.c
+@@ -0,0 +1,42 @@
++/* Subroutines for the D front end on the RISC-V architecture.
++   Copyright (C) 2017 Free Software Foundation, Inc.
++
++GCC is free software; you can redistribute it and/or modify
++it under the terms of the GNU General Public License as published by
++the Free Software Foundation; either version 3, or (at your option)
++any later version.
++
++GCC is distributed in the hope that it will be useful,
++but WITHOUT ANY WARRANTY; without even the implied warranty of
++MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++GNU General Public License for more details.
++
++You should have received a copy of the GNU General Public License
++along with GCC; see the file COPYING3.  If not see
++<http://www.gnu.org/licenses/>.  */
++
++#include "config.h"
++#include "system.h"
++#include "coretypes.h"
++#include "target.h"
++#include "d/d-target.h"
++#include "d/d-target-def.h"
++
++/* Implement TARGET_D_CPU_VERSIONS for RISC-V targets.  */
++
++void
++riscv_d_target_versions (void)
++{
++  if (TARGET_64BIT)
++    d_add_builtin_version ("RISCV64");
++  else
++    d_add_builtin_version ("RISCV32");
++
++  if (TARGET_HARD_FLOAT)
++    d_add_builtin_version ("D_HardFloat");
++  else
++    d_add_builtin_version ("D_SoftFloat");
++
++  if (TARGET_DOUBLE_FLOAT)
++    d_add_builtin_version ("D_DoubleFloat");
++}
+--- a/gcc/config/riscv/riscv-protos.h
++++ b/gcc/config/riscv/riscv-protos.h
+@@ -75,6 +75,9 @@ extern bool riscv_expand_block_move (rtx
+ /* Routines implemented in riscv-c.c.  */
+ void riscv_cpu_cpp_builtins (cpp_reader *);
+ 
++/* Routines implemented in riscv-d.c  */
++extern void riscv_d_target_versions (void);
++
+ /* Routines implemented in riscv-builtins.c.  */
+ extern void riscv_atomic_assign_expand_fenv (tree *, tree *, tree *);
+ extern rtx riscv_expand_builtin (tree, rtx, rtx, machine_mode, int);
+--- a/gcc/config/riscv/riscv.h
++++ b/gcc/config/riscv/riscv.h
+@@ -27,6 +27,9 @@ along with GCC; see the file COPYING3.
+ /* Target CPU builtins.  */
+ #define TARGET_CPU_CPP_BUILTINS() riscv_cpu_cpp_builtins (pfile)
+ 
++/* Target CPU versions for D.  */
++#define TARGET_D_CPU_VERSIONS riscv_d_target_versions
++
+ /* Default target_flags if no switches are specified  */
+ 
+ #ifndef TARGET_DEFAULT
+--- a/gcc/config/riscv/t-riscv
++++ b/gcc/config/riscv/t-riscv
+@@ -9,3 +9,7 @@ riscv-c.o: $(srcdir)/config/riscv/riscv-
+     coretypes.h $(TM_H) $(TREE_H) output.h $(C_COMMON_H) $(TARGET_H)
+ 	$(COMPILER) -c $(ALL_COMPILERFLAGS) $(ALL_CPPFLAGS) $(INCLUDES) \
+ 		$(srcdir)/config/riscv/riscv-c.c
++
++riscv-d.o: $(srcdir)/config/riscv/riscv-d.c
++	$(COMPILE) $<
++	$(POSTCOMPILE)
 --- a/gcc/config/rs6000/linux.h
 +++ b/gcc/config/rs6000/linux.h
 @@ -57,6 +57,19 @@
@@ -1162,7 +1265,7 @@ The following OS versions are implemented:
  
 --- /dev/null
 +++ b/gcc/config/rs6000/rs6000-d.c
-@@ -0,0 +1,45 @@
+@@ -0,0 +1,46 @@
 +/* Subroutines for the D front end on the PowerPC architecture.
 +   Copyright (C) 2017 Free Software Foundation, Inc.
 +
@@ -1201,6 +1304,7 @@ The following OS versions are implemented:
 +    {
 +      d_add_builtin_version ("PPC_HardFloat");
 +      d_add_builtin_version ("D_HardFloat");
++      d_add_builtin_version ("D_DoubleFloat");
 +    }
 +  else if (TARGET_SOFT_FLOAT)
 +    {
@@ -1247,7 +1351,7 @@ The following OS versions are implemented:
  	$(SHELL) $(srcdir)/config/rs6000/genopt.sh $(srcdir)/config/rs6000 > \
 --- /dev/null
 +++ b/gcc/config/s390/s390-d.c
-@@ -0,0 +1,41 @@
+@@ -0,0 +1,44 @@
 +/* Subroutines for the D front end on the IBM S/390 and zSeries architectures.
 +   Copyright (C) 2017 Free Software Foundation, Inc.
 +
@@ -1287,7 +1391,10 @@ The following OS versions are implemented:
 +  if (TARGET_SOFT_FLOAT)
 +    d_add_builtin_version ("D_SoftFloat");
 +  else if (TARGET_HARD_FLOAT)
-+    d_add_builtin_version ("D_HardFloat");
++    {
++      d_add_builtin_version ("D_HardFloat");
++      d_add_builtin_version ("D_DoubleFloat");
++    }
 +}
 --- a/gcc/config/s390/s390-protos.h
 +++ b/gcc/config/s390/s390-protos.h
@@ -1325,7 +1432,7 @@ The following OS versions are implemented:
 +	$(POSTCOMPILE)
 --- /dev/null
 +++ b/gcc/config/sparc/sparc-d.c
-@@ -0,0 +1,48 @@
+@@ -0,0 +1,49 @@
 +/* Subroutines for the D front end on the SPARC architecture.
 +   Copyright (C) 2017 Free Software Foundation, Inc.
 +
@@ -1366,6 +1473,7 @@ The following OS versions are implemented:
 +  if (TARGET_FPU)
 +    {
 +      d_add_builtin_version ("D_HardFloat");
++      d_add_builtin_version ("D_DoubleFloat");
 +      d_add_builtin_version ("SPARC_HardFloat");
 +    }
 +  else

--- a/gcc/d/patches/patch-targetdm-untested-9.patch
+++ b/gcc/d/patches/patch-targetdm-untested-9.patch
@@ -11,8 +11,6 @@ The following CPU versions are implemented:
 * IA64
 * NVPTX
 * NVPTX64
-* RISCV32
-* RISCV64
 * SH
 
 The following OS versions are implemented:
@@ -71,14 +69,6 @@ These official OS versions are not implemented:
  	;;
  powerpc*-*-*spe*)
  	cpu_type=powerpcspe
-@@ -499,6 +504,7 @@ powerpc*-*-*)
- riscv*)
- 	cpu_type=riscv
- 	extra_objs="riscv-builtins.o riscv-c.o"
-+	d_target_objs="riscv-d.o"
- 	;;
- rs6000*-*-*)
- 	extra_options="${extra_options} g.opt fused-madd.opt rs6000/rs6000-tables.opt"
 @@ -685,8 +691,10 @@ case ${target} in
    extra_options="${extra_options} darwin.opt"
    c_target_objs="${c_target_objs} darwin-c.o"
@@ -823,82 +813,6 @@ These official OS versions are not implemented:
 +++ b/gcc/config/pa/t-pa
 @@ -0,0 +1,3 @@
 +pa-d.o: $(srcdir)/config/pa/pa-d.c
-+	$(COMPILE) $<
-+	$(POSTCOMPILE)
---- /dev/null
-+++ b/gcc/config/riscv/riscv-d.c
-@@ -0,0 +1,39 @@
-+/* Subroutines for the D front end on the RISC-V architecture.
-+   Copyright (C) 2017 Free Software Foundation, Inc.
-+
-+GCC is free software; you can redistribute it and/or modify
-+it under the terms of the GNU General Public License as published by
-+the Free Software Foundation; either version 3, or (at your option)
-+any later version.
-+
-+GCC is distributed in the hope that it will be useful,
-+but WITHOUT ANY WARRANTY; without even the implied warranty of
-+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+GNU General Public License for more details.
-+
-+You should have received a copy of the GNU General Public License
-+along with GCC; see the file COPYING3.  If not see
-+<http://www.gnu.org/licenses/>.  */
-+
-+#include "config.h"
-+#include "system.h"
-+#include "coretypes.h"
-+#include "target.h"
-+#include "d/d-target.h"
-+#include "d/d-target-def.h"
-+
-+/* Implement TARGET_D_CPU_VERSIONS for RISC-V targets.  */
-+
-+void
-+riscv_d_target_versions (void)
-+{
-+  if (TARGET_64BIT)
-+    d_add_builtin_version ("RISCV64");
-+  else
-+    d_add_builtin_version ("RISCV32");
-+
-+  if (TARGET_HARDFLOAT)
-+    d_add_builtin_version ("D_HardFloat");
-+  else
-+    d_add_builtin_version ("D_SoftFloat");
-+}
---- a/gcc/config/riscv/riscv-protos.h
-+++ b/gcc/config/riscv/riscv-protos.h
-@@ -74,6 +74,9 @@ extern bool riscv_expand_block_move (rtx
- /* Routines implemented in riscv-c.c.  */
- void riscv_cpu_cpp_builtins (cpp_reader *);
- 
-+/* Routines implemented in riscv-d.c  */
-+extern void riscv_d_target_versions (void);
-+
- /* Routines implemented in riscv-builtins.c.  */
- extern void riscv_atomic_assign_expand_fenv (tree *, tree *, tree *);
- extern rtx riscv_expand_builtin (tree, rtx, rtx, machine_mode, int);
---- a/gcc/config/riscv/riscv.h
-+++ b/gcc/config/riscv/riscv.h
-@@ -27,6 +27,9 @@ along with GCC; see the file COPYING3.
- /* Target CPU builtins.  */
- #define TARGET_CPU_CPP_BUILTINS() riscv_cpu_cpp_builtins (pfile)
- 
-+/* Target CPU versions for D.  */
-+#define TARGET_D_CPU_VERSIONS riscv_d_target_versions
-+
- /* Default target_flags if no switches are specified  */
- 
- #ifndef TARGET_DEFAULT
---- a/gcc/config/riscv/t-riscv
-+++ b/gcc/config/riscv/t-riscv
-@@ -9,3 +9,7 @@ riscv-c.o: $(srcdir)/config/riscv/riscv-
-     coretypes.h $(TM_H) $(TREE_H) output.h $(C_COMMON_H) $(TARGET_H)
- 	$(COMPILER) -c $(ALL_COMPILERFLAGS) $(ALL_CPPFLAGS) $(INCLUDES) \
- 		$(srcdir)/config/riscv/riscv-c.c
-+
-+riscv-d.o: $(srcdir)/config/riscv/riscv-d.c
 +	$(COMPILE) $<
 +	$(POSTCOMPILE)
 --- /dev/null

--- a/libphobos/libdruntime/core/atomic.d
+++ b/libphobos/libdruntime/core/atomic.d
@@ -1458,7 +1458,7 @@ else version( GNU )
 
     private bool casImpl(T,V1,V2)( shared(T)* here, V1 ifThis, V2 writeThis ) pure nothrow @nogc @trusted
     {
-        static assert(GNU_Have_Atomics, "cas() not supported on this architecture");
+        static assert(GNU_Have_Atomics || GNU_Have_LibAtomic, "cas() not supported on this architecture");
         bool res = void;
 
         static if (T.sizeof == byte.sizeof)
@@ -1511,7 +1511,7 @@ else version( GNU )
     {
         static assert(ms != MemoryOrder.rel, "Invalid MemoryOrder for atomicLoad");
         static assert(__traits(isPOD, T), "argument to atomicLoad() must be POD");
-        static assert(GNU_Have_Atomics, "atomicLoad() not supported on this architecture");
+        static assert(GNU_Have_Atomics || GNU_Have_LibAtomic, "atomicLoad() not supported on this architecture");
 
         static if (T.sizeof == ubyte.sizeof)
         {
@@ -1549,7 +1549,7 @@ else version( GNU )
     {
         static assert(ms != MemoryOrder.acq, "Invalid MemoryOrder for atomicStore");
         static assert(__traits(isPOD, T), "argument to atomicLoad() must be POD");
-        static assert(GNU_Have_Atomics, "atomicStore() not supported on this architecture");
+        static assert(GNU_Have_Atomics || GNU_Have_LibAtomic, "atomicStore() not supported on this architecture");
 
         static if (T.sizeof == ubyte.sizeof)
         {

--- a/libphobos/libdruntime/core/internal/convert.d
+++ b/libphobos/libdruntime/core/internal/convert.d
@@ -58,13 +58,31 @@ const(ubyte)[] toUbyte(T)(const ref T val) if(is(Unqual!T == float) || is(Unqual
         size_t off_bytes = 0;
         size_t off_bits  = 0;
 
-        for(; off_bytes < FloatTraits!T.MANTISSA/8; ++off_bytes)
+        // Quadruples won't fit in one ulong, so check for that.
+        enum mantissaMax = FloatTraits!T.MANTISSA < ulong.sizeof*8 ?
+                           FloatTraits!T.MANTISSA : ulong.sizeof*8;
+
+        for(; off_bytes < mantissaMax/8; ++off_bytes)
         {
             buff[off_bytes] = cast(ubyte)mantissa;
             mantissa >>= 8;
         }
-        off_bits = FloatTraits!T.MANTISSA%8;
-        buff[off_bytes] = cast(ubyte)mantissa;
+        static if (floatFormat!T == FloatFormat.Quadruple)
+        {
+            ulong mantissa2 = parsed.mantissa2;
+            off_bytes--; // go back one, since mantissa only stored data in 56
+                         // bits, ie 7 bytes
+            for(; off_bytes < FloatTraits!T.MANTISSA/8; ++off_bytes)
+            {
+                buff[off_bytes] = cast(ubyte)mantissa2;
+                mantissa2 >>= 8;
+            }
+        }
+        else
+        {
+            off_bits = FloatTraits!T.MANTISSA%8;
+            buff[off_bytes] = cast(ubyte)mantissa;
+        }
 
         for(size_t i=0; i<FloatTraits!T.EXPONENT/8; ++i)
         {
@@ -106,8 +124,8 @@ private Float parse(bool is_denormalized = false, T)(T x) if(is(Unqual!T == iflo
 private Float parse(bool is_denormalized = false, T:real)(T x_) if(floatFormat!T != FloatFormat.Real80)
 {
     Unqual!T x = x_;
-    assert(floatFormat!T != FloatFormat.DoubleDouble && floatFormat!T != FloatFormat.Quadruple,
-           "doubledouble and quadruple float formats are not supported in CTFE");
+    static assert(floatFormat!T != FloatFormat.DoubleDouble,
+           "doubledouble float format not supported in CTFE");
     if(x is cast(T)0.0) return FloatTraits!T.ZERO;
     if(x is cast(T)-0.0) return FloatTraits!T.NZERO;
     if(x is T.nan) return FloatTraits!T.NAN;
@@ -126,7 +144,12 @@ private Float parse(bool is_denormalized = false, T:real)(T x_) if(floatFormat!T
         if(is_denormalized)
             return Float(0, 0, sign);
         else
-            return Float(denormalizedMantissa(x), 0, sign);
+        {
+            static if (floatFormat!T == FloatFormat.Quadruple)
+                return floatDenormalizedMantissa(x, sign);
+            else
+                return floatDenormalizedMantissa(x, sign);
+        }
     }
 
     x2 /= binPow2(e);
@@ -134,9 +157,30 @@ private Float parse(bool is_denormalized = false, T:real)(T x_) if(floatFormat!T
     static if(!is_denormalized)
         x2 -= 1.0;
 
-    x2 *=  2UL<<(FloatTraits!T.MANTISSA);
-    ulong mant = shiftrRound(cast(ulong)x2);
-    return Float(mant, exp, sign);
+    static if (floatFormat!T == FloatFormat.Quadruple)
+    {
+        // Store the 112-bit mantissa in two ulongs, specifically the lower 56
+        // bits of each, with the most significant bits in mantissa2. There's
+        // an edge case exposed by the labeled test below, where only a subnormal
+        // with the highest bit set being the 57th bit will "overflow" to the
+        // 57th bit in mantissa2 with the following logic, but that special case
+        // is handled by an additional check in floatDenormalizedMantissa for
+        // Quadruples below.
+
+        x2 *=  2UL<<(FloatTraits!T.MANTISSA - (ulong.sizeof - 1)*8 - 1);
+        ulong mant2 = cast(ulong) x2;
+        x2 -= mant2;
+
+        x2 *=  2UL<<((ulong.sizeof - 1)*8 - 1);
+        ulong mant = cast(ulong) x2;
+        return Float(mant, exp, sign, mant2);
+    }
+    else
+    {
+        x2 *=  2UL<<(FloatTraits!T.MANTISSA);
+        ulong mant = shiftrRound(cast(ulong)x2);
+        return Float(mant, exp, sign);
+    }
 }
 
 @safe pure nothrow @nogc
@@ -174,7 +218,7 @@ private Float parse(bool _ = false, T:real)(T x_) if(floatFormat!T == FloatForma
     uint exp = cast(uint)(e + EXPONENT_MED);
     if(!exp)
     {
-        return Float(denormalizedMantissa(x), 0, sign);
+        return floatDenormalizedMantissa(x, sign);
     }
     int pow = (FloatTraits!T.MANTISSA-1-e);
     x *=  binPow2((pow / EXPONENT_MED)*EXPONENT_MED); //To avoid overflow in 2.0L ^^ pow
@@ -188,6 +232,7 @@ private struct Float
     ulong mantissa;
     uint exponent;
     uint sign;
+    ulong mantissa2;
 }
 
 private template FloatTraits(T) if(floatFormat!T == FloatFormat.Float)
@@ -238,14 +283,14 @@ private template FloatTraits(T) if(floatFormat!T == FloatFormat.DoubleDouble) //
     enum NINF     = Float(0, 0x7ff, 1);
 }
 
-private template FloatTraits(T) if(floatFormat!T == FloatFormat.Quadruple) //Unsupported in CTFE
+private template FloatTraits(T) if(floatFormat!T == FloatFormat.Quadruple)
 {
     enum EXPONENT = 15;
     enum MANTISSA = 112;
     enum ZERO     = Float(0, 0, 0);
     enum NZERO    = Float(0, 0, 1);
-    enum NAN      = Float(-1, 0x7fff, 0);
-    enum NNAN     = Float(-1, 0x7fff, 1);
+    enum NAN      = Float(0, 0x7fff, 0, 0x80000000000000UL);
+    enum NNAN     = Float(0, 0x7fff, 1, 0x80000000000000UL);
     enum INF      = Float(0, 0x7fff, 0);
     enum NINF     = Float(0, 0x7fff, 1);
 }
@@ -314,21 +359,51 @@ private uint binLog2(T)(const T x)
 }
 
 @safe pure nothrow @nogc
-private ulong denormalizedMantissa(T)(T x) if(floatFormat!T == FloatFormat.Real80)
+private Float floatDenormalizedMantissa(T)(T x, uint sign)
+    if(floatFormat!T == FloatFormat.Real80)
 {
     x *= 2.0L^^FloatTraits!T.MANTISSA;
     auto fl = parse(x);
     uint pow = FloatTraits!T.MANTISSA - fl.exponent + 1;
-    return fl.mantissa >> pow;
+    return Float(fl.mantissa >> pow, 0, sign);
 }
 
 @safe pure nothrow @nogc
-private ulong denormalizedMantissa(T)(T x) if(floatFormat!T != FloatFormat.Real80)
+private Float floatDenormalizedMantissa(T)(T x, uint sign)
+    if(floatFormat!T == FloatFormat.Float || floatFormat!T == FloatFormat.Double)
 {
     x *= 2.0L^^FloatTraits!T.MANTISSA;
     auto fl = parse!true(x);
     ulong mant = fl.mantissa >> (FloatTraits!T.MANTISSA - fl.exponent);
-    return shiftrRound(mant);
+    return Float(shiftrRound(mant), 0, sign);
+}
+
+@safe pure nothrow @nogc
+private Float floatDenormalizedMantissa(T)(T x, uint sign)
+    if(floatFormat!T == FloatFormat.Quadruple)
+{
+    x *= 2.0L^^FloatTraits!T.MANTISSA;
+    auto fl = parse!true(x);
+    uint offset = FloatTraits!T.MANTISSA - fl.exponent + 1;
+    enum mantissaSize = (ulong.sizeof - 1) * 8;
+
+    if (offset < mantissaSize)
+    {   // Create a new mantissa ulong with the trailing mantissa2 bits that
+        // need to be shifted into mantissa, by shifting the needed bits left,
+        // zeroing out the first byte, and then ORing it with mantissa shifted
+        // right by offset.
+
+        ulong shiftedMantissa = ((fl.mantissa2 << (mantissaSize - offset)) &
+                                 0x00FFFFFFFFFFFFFFUL) | fl.mantissa >> offset;
+        return Float(shiftedMantissa, 0, sign, fl.mantissa2 >> offset);
+    }
+    else if (offset > mantissaSize)
+        return Float(fl.mantissa2 >> offset - mantissaSize , 0, sign, 0);
+    else
+        // Handle special case mentioned in parse() above by zeroing out the
+        // 57'th bit of mantissa2, "shifting" it into mantissa, and setting the
+        // first bit of mantissa2.
+        return Float(fl.mantissa2 & 0x00FFFFFFFFFFFFFFUL , 0, sign, 1);
 }
 
 version(unittest)
@@ -426,6 +501,8 @@ version(unittest)
 
         testNumberConvert!("real.min_normal/2");
         testNumberConvert!("real.min_normal/2UL^^63");
+        // check subnormal storage edge case for Quadruple
+        testNumberConvert!("real.min_normal/2UL^^56");
         testNumberConvert!("real.min_normal/19");
         testNumberConvert!("real.min_normal/17");
 

--- a/libphobos/libdruntime/core/stdc/fenv.d
+++ b/libphobos/libdruntime/core/stdc/fenv.d
@@ -32,6 +32,10 @@ version (PPC)
     version = PPC_Any;
 else version (PPC64)
     version = PPC_Any;
+version (RISCV32)
+    version = RISCV_Any;
+version (RISCV64)
+    version = RISCV_Any;
 
 version( MinGW )
     version = GNUFP;
@@ -128,6 +132,12 @@ version( GNUFP )
     else version (PPC_Any)
     {
         alias fenv_t = double;
+        alias fexcept_t = uint;
+    }
+    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/riscv/bits/fenv.h
+    else version (RISCV_Any)
+    {
+        alias fenv_t = uint;
         alias fexcept_t = uint;
     }
     // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/sparc/fpu/bits/fenv.h
@@ -649,6 +659,28 @@ else
             FE_TOWARDZERO   = 1, ///
             FE_UPWARD       = 2, ///
             FE_DOWNWARD     = 3, ///
+        }
+    }
+    else version (RISCV_Any)
+    {
+        // Define bits representing exceptions in the FPSR status word.
+        enum
+        {
+            FE_INEXACT      = 0x01, ///
+            FE_UNDERFLOW    = 0x02, ///
+            FE_OVERFLOW     = 0x04, ///
+            FE_DIVBYZERO    = 0x08, ///
+            FE_INVALID      = 0x10, ///
+            FE_ALL_EXCEPT   = 0x1f, ///
+        }
+
+        // Define bits representing rounding modes in the FPCR Rmode field.
+        enum
+        {
+            FE_TONEAREST    = 0x0, ///
+            FE_TOWARDZERO   = 0x1, ///
+            FE_DOWNWARD     = 0x2, ///
+            FE_UPWARD       = 0x3, ///
         }
     }
     else version(SPARC64)

--- a/libphobos/libdruntime/core/stdc/math.d
+++ b/libphobos/libdruntime/core/stdc/math.d
@@ -174,6 +174,20 @@ else version (CRuntime_Glibc)
         ///
         enum int FP_ILOGBNAN      = int.max;
     }
+    else version (RISCV32)
+    {
+        ///
+        enum int FP_ILOGB0        = -int.max;
+        ///
+        enum int FP_ILOGBNAN      = int.max;
+    }
+    else version (RISCV64)
+    {
+        ///
+        enum int FP_ILOGB0        = -int.max;
+        ///
+        enum int FP_ILOGBNAN      = int.max;
+    }
     else version (SPARC64)
     {
         ///

--- a/libphobos/libdruntime/core/sys/linux/dlfcn.d
+++ b/libphobos/libdruntime/core/sys/linux/dlfcn.d
@@ -206,6 +206,54 @@ else version (AArch64)
         void _dl_mcount_wrapper_check(void* __selfpc);
     }
 }
+else version (RISCV32)
+{
+    // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/dlfcn.h
+    // enum RTLD_LAZY = 0x0001; // POSIX
+    // enum RTLD_NOW = 0x0002; // POSIX
+    enum RTLD_BINDING_MASK = 0x3;
+    enum RTLD_NOLOAD = 0x00004;
+    enum RTLD_DEEPBIND = 0x00008;
+
+    // enum RTLD_GLOBAL = 0x00100; // POSIX
+    // enum RTLD_LOCAL = 0; // POSIX
+    enum RTLD_NODELETE = 0x01000;
+
+    static if (__USE_GNU)
+    {
+        RT DL_CALL_FCT(RT, Args...)(RT function(Args) fctp, auto ref Args args)
+        {
+            _dl_mcount_wrapper_check(cast(void*)fctp);
+            return fctp(args);
+        }
+
+        void _dl_mcount_wrapper_check(void* __selfpc);
+    }
+}
+else version (RISCV64)
+{
+    // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/dlfcn.h
+    // enum RTLD_LAZY = 0x0001; // POSIX
+    // enum RTLD_NOW = 0x0002; // POSIX
+    enum RTLD_BINDING_MASK = 0x3;
+    enum RTLD_NOLOAD = 0x00004;
+    enum RTLD_DEEPBIND = 0x00008;
+
+    // enum RTLD_GLOBAL = 0x00100; // POSIX
+    // enum RTLD_LOCAL = 0; // POSIX
+    enum RTLD_NODELETE = 0x01000;
+
+    static if (__USE_GNU)
+    {
+        RT DL_CALL_FCT(RT, Args...)(RT function(Args) fctp, auto ref Args args)
+        {
+            _dl_mcount_wrapper_check(cast(void*)fctp);
+            return fctp(args);
+        }
+
+        void _dl_mcount_wrapper_check(void* __selfpc);
+    }
+}
 else version (SPARC64)
 {
     // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/dlfcn.h

--- a/libphobos/libdruntime/core/sys/linux/epoll.d
+++ b/libphobos/libdruntime/core/sys/linux/epoll.d
@@ -112,6 +112,22 @@ else version (MIPS64)
         epoll_data_t data;
     }
 }
+else version (RISCV32)
+{
+    struct epoll_event
+    {
+        uint events;
+        epoll_data_t data;
+    }
+}
+else version (RISCV64)
+{
+    struct epoll_event
+    {
+        uint events;
+        epoll_data_t data;
+    }
+}
 else version (SPARC64)
 {
     struct epoll_event

--- a/libphobos/libdruntime/core/sys/linux/link.d
+++ b/libphobos/libdruntime/core/sys/linux/link.d
@@ -63,6 +63,18 @@ else version (AArch64)
     alias __WORDSIZE __ELF_NATIVE_CLASS;
     alias uint32_t Elf_Symndx;
 }
+else version (RISCV32)
+{
+    // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/elfclass.h
+    alias __WORDSIZE __ELF_NATIVE_CLASS;
+    alias uint32_t Elf_Symndx;
+}
+else version (RISCV64)
+{
+    // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/elfclass.h
+    alias __WORDSIZE __ELF_NATIVE_CLASS;
+    alias uint32_t Elf_Symndx;
+}
 else version (SPARC64)
 {
     // http://sourceware.org/git/?p=glibc.git;a=blob;f=bits/elfclass.h

--- a/libphobos/libdruntime/core/sys/linux/sys/eventfd.d
+++ b/libphobos/libdruntime/core/sys/linux/sys/eventfd.d
@@ -75,6 +75,18 @@ else version (AArch64)
     enum EFD_CLOEXEC = 0x80000; // octal!2000000
     enum EFD_NONBLOCK = 0x800; // octal!4000
 }
+else version (RISCV32)
+{
+    enum EFD_SEMAPHORE = 1;
+    enum EFD_CLOEXEC = 0x80000; // octal!2000000
+    enum EFD_NONBLOCK = 0x800; // octal!4000
+}
+else version (RISCV64)
+{
+    enum EFD_SEMAPHORE = 1;
+    enum EFD_CLOEXEC = 0x80000; // octal!2000000
+    enum EFD_NONBLOCK = 0x800; // octal!4000
+}
 else version (SPARC64)
 {
     enum EFD_SEMAPHORE = 1;

--- a/libphobos/libdruntime/core/sys/linux/sys/inotify.d
+++ b/libphobos/libdruntime/core/sys/linux/sys/inotify.d
@@ -93,6 +93,16 @@ else version (AArch64)
     enum IN_CLOEXEC = 0x80000; // octal!2000000
     enum IN_NONBLOCK = 0x800; // octal!4000
 }
+else version (RISCV32)
+{
+    enum IN_CLOEXEC = 0x80000; // octal!2000000
+    enum IN_NONBLOCK = 0x800; // octal!4000
+}
+else version (RISCV64)
+{
+    enum IN_CLOEXEC = 0x80000; // octal!2000000
+    enum IN_NONBLOCK = 0x800; // octal!4000
+}
 else version (SPARC64)
 {
     enum IN_CLOEXEC = 0x80000; // octal!2000000

--- a/libphobos/libdruntime/core/sys/linux/sys/mman.d
+++ b/libphobos/libdruntime/core/sys/linux/sys/mman.d
@@ -63,6 +63,56 @@ else version (PPC64)
     //     MCL_FUTURE = 0x4000,
     // }
 }
+// https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/riscv/bits/mman.h
+else version (RISCV32)
+{
+    static if (__USE_MISC) enum
+    {
+        MAP_GROWSDOWN = 0x00100,
+        MAP_DENYWRITE = 0x00800,
+        MAP_EXECUTABLE = 0x01000,
+        MAP_LOCKED = 0x02000,
+        MAP_NORESERVE = 0x04000,
+        MAP_POPULATE = 0x08000,
+        MAP_NONBLOCK = 0x10000,
+        MAP_STACK = 0x20000,
+        MAP_HUGETLB = 0x40000,
+        MAP_SYNC = 0x80000,
+        MAP_FIXED_NOREPLACE = 0x100000,
+    }
+
+    // in core.sys.posix.sys.mman
+    // enum
+    // {
+    //     MCL_CURRENT = 0x2000,
+    //     MCL_FUTURE = 0x4000,
+    // }
+}
+// https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/riscv/bits/mman.h
+else version (RISCV64)
+{
+    static if (__USE_MISC) enum
+    {
+        MAP_GROWSDOWN = 0x00100,
+        MAP_DENYWRITE = 0x00800,
+        MAP_EXECUTABLE = 0x01000,
+        MAP_LOCKED = 0x02000,
+        MAP_NORESERVE = 0x04000,
+        MAP_POPULATE = 0x08000,
+        MAP_NONBLOCK = 0x10000,
+        MAP_STACK = 0x20000,
+        MAP_HUGETLB = 0x40000,
+        MAP_SYNC = 0x80000,
+        MAP_FIXED_NOREPLACE = 0x100000,
+    }
+
+    // in core.sys.posix.sys.mman
+    // enum
+    // {
+    //     MCL_CURRENT = 0x2000,
+    //     MCL_FUTURE = 0x4000,
+    // }
+}
 // http://sourceware.org/git/?p=glibc.git;a=blob;hb=51e945a8f950a6695754b11c1e6fba8bb750e100;f=sysdeps/unix/sysv/linux/s390/bits/mman.h
 else version (S390)
 {

--- a/libphobos/libdruntime/core/sys/posix/dlfcn.d
+++ b/libphobos/libdruntime/core/sys/posix/dlfcn.d
@@ -103,6 +103,20 @@ version( CRuntime_Glibc )
         enum RTLD_GLOBAL    = 0x00100;
         enum RTLD_LOCAL     = 0;
     }
+    else version (RISCV32)
+    {
+        enum RTLD_LAZY      = 0x00001;
+        enum RTLD_NOW       = 0x00002;
+        enum RTLD_GLOBAL    = 0x00100;
+        enum RTLD_LOCAL     = 0;
+    }
+    else version (RISCV64)
+    {
+        enum RTLD_LAZY      = 0x00001;
+        enum RTLD_NOW       = 0x00002;
+        enum RTLD_GLOBAL    = 0x00100;
+        enum RTLD_LOCAL     = 0;
+    }
     else version (SPARC64)
     {
         enum RTLD_LAZY      = 0x00001;

--- a/libphobos/libdruntime/core/sys/posix/fcntl.d
+++ b/libphobos/libdruntime/core/sys/posix/fcntl.d
@@ -230,6 +230,32 @@ version( CRuntime_Glibc )
         enum O_DSYNC        = 0x1000;   // octal   010000
         enum O_RSYNC        = O_SYNC;
     }
+    else version (RISCV32)
+    {
+        enum O_CREAT        = 0x40;     // octal     0100
+        enum O_EXCL         = 0x80;     // octal     0200
+        enum O_NOCTTY       = 0x100;    // octal     0400
+        enum O_TRUNC        = 0x200;    // octal    01000
+
+        enum O_APPEND       = 0x400;    // octal    02000
+        enum O_NONBLOCK     = 0x800;    // octal    04000
+        enum O_SYNC         = 0x101000; // octal 04010000
+        enum O_DSYNC        = 0x1000;   // octal   010000
+        enum O_RSYNC        = O_SYNC;
+    }
+    else version (RISCV64)
+    {
+        enum O_CREAT        = 0x40;     // octal     0100
+        enum O_EXCL         = 0x80;     // octal     0200
+        enum O_NOCTTY       = 0x100;    // octal     0400
+        enum O_TRUNC        = 0x200;    // octal    01000
+
+        enum O_APPEND       = 0x400;    // octal    02000
+        enum O_NONBLOCK     = 0x800;    // octal    04000
+        enum O_SYNC         = 0x101000; // octal 04010000
+        enum O_DSYNC        = 0x1000;   // octal   010000
+        enum O_RSYNC        = O_SYNC;
+    }
     else version (SPARC64)
     {
         enum O_CREAT        = 0x200;

--- a/libphobos/libdruntime/core/sys/posix/setjmp.d
+++ b/libphobos/libdruntime/core/sys/posix/setjmp.d
@@ -125,6 +125,30 @@ version( CRuntime_Glibc )
                 double[6] __fpregs;
         }
     }
+    else version (RISCV32)
+    {
+        struct __riscv_jmp_buf
+        {
+            c_long __pc;
+            c_long[12] __regs;
+            c_long __sp;
+            version (D_DoubleFloat)
+                double[12] __fpregs;
+        }
+        alias __jmp_buf = __riscv_jmp_buf[1];
+    }
+    else version (RISCV64)
+    {
+        struct __riscv_jmp_buf
+        {
+            c_long __pc;
+            c_long[12] __regs;
+            c_long __sp;
+            version (D_DoubleFloat)
+                double[12] __fpregs;
+        }
+        alias __jmp_buf = __riscv_jmp_buf[1];
+    }
     else version (SystemZ)
     {
         struct __s390_jmp_buf

--- a/libphobos/libdruntime/core/sys/posix/signal.d
+++ b/libphobos/libdruntime/core/sys/posix/signal.d
@@ -411,6 +411,54 @@ version( linux )
         enum SIGUSR2    = 12;
         enum SIGURG     = 23;
     }
+    else version (RISCV32)
+    {
+        //SIGABRT (defined in core.stdc.signal)
+        enum SIGALRM    = 14;
+        enum SIGBUS     = 7;
+        enum SIGCHLD    = 17;
+        enum SIGCONT    = 18;
+        //SIGFPE (defined in core.stdc.signal)
+        enum SIGHUP     = 1;
+        //SIGILL (defined in core.stdc.signal)
+        //SIGINT (defined in core.stdc.signal)
+        enum SIGKILL    = 9;
+        enum SIGPIPE    = 13;
+        enum SIGQUIT    = 3;
+        //SIGSEGV (defined in core.stdc.signal)
+        enum SIGSTOP    = 19;
+        //SIGTERM (defined in core.stdc.signal)
+        enum SIGTSTP    = 20;
+        enum SIGTTIN    = 21;
+        enum SIGTTOU    = 22;
+        enum SIGUSR1    = 10;
+        enum SIGUSR2    = 12;
+        enum SIGURG     = 23;
+    }
+    else version (RISCV64)
+    {
+        //SIGABRT (defined in core.stdc.signal)
+        enum SIGALRM    = 14;
+        enum SIGBUS     = 7;
+        enum SIGCHLD    = 17;
+        enum SIGCONT    = 18;
+        //SIGFPE (defined in core.stdc.signal)
+        enum SIGHUP     = 1;
+        //SIGILL (defined in core.stdc.signal)
+        //SIGINT (defined in core.stdc.signal)
+        enum SIGKILL    = 9;
+        enum SIGPIPE    = 13;
+        enum SIGQUIT    = 3;
+        //SIGSEGV (defined in core.stdc.signal)
+        enum SIGSTOP    = 19;
+        //SIGTERM (defined in core.stdc.signal)
+        enum SIGTSTP    = 20;
+        enum SIGTTIN    = 21;
+        enum SIGTTOU    = 22;
+        enum SIGUSR1    = 10;
+        enum SIGUSR2    = 12;
+        enum SIGURG     = 23;
+    }
     else version (SPARC64)
     {
         //SIGABRT (defined in core.stdc.signal)
@@ -2133,6 +2181,26 @@ version( CRuntime_Glibc )
         enum SIGXFSZ    = 25;
     }
     else version (AArch64)
+    {
+        enum SIGPOLL    = 29;
+        enum SIGPROF    = 27;
+        enum SIGSYS     = 31;
+        enum SIGTRAP    = 5;
+        enum SIGVTALRM  = 26;
+        enum SIGXCPU    = 24;
+        enum SIGXFSZ    = 25;
+    }
+    else version (RISCV32)
+    {
+        enum SIGPOLL    = 29;
+        enum SIGPROF    = 27;
+        enum SIGSYS     = 31;
+        enum SIGTRAP    = 5;
+        enum SIGVTALRM  = 26;
+        enum SIGXCPU    = 24;
+        enum SIGXFSZ    = 25;
+    }
+    else version (RISCV64)
     {
         enum SIGPOLL    = 29;
         enum SIGPROF    = 27;

--- a/libphobos/libdruntime/core/sys/posix/sys/mman.d
+++ b/libphobos/libdruntime/core/sys/posix/sys/mman.d
@@ -363,6 +363,10 @@ version( CRuntime_Glibc )
         enum MS_INVALIDATE = 2;
         enum MS_SYNC = 4;
     }
+    else version (RISCV32)
+        private enum DEFAULTS = true;
+    else version (RISCV64)
+        private enum DEFAULTS = true;
     else version (SPARC)
         private enum DEFAULTS = true;
     else version (SPARC64)

--- a/libphobos/libdruntime/core/sys/posix/sys/msg.d
+++ b/libphobos/libdruntime/core/sys/posix/sys/msg.d
@@ -180,6 +180,48 @@ else version (PPC64)
         c_ulong   __glibc_reserved5;
     }
 }
+else version (RISCV32)
+{
+    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/generic/bits/msq.h
+    alias c_ulong msgqnum_t;
+    alias c_ulong msglen_t;
+
+    struct msqid_ds
+    {
+        ipc_perm msg_perm;
+        time_t          msg_stime;
+        time_t          msg_rtime;
+        time_t          msg_ctime;
+        c_ulong         __msg_cbytes;
+        msgqnum_t       msg_qnum;
+        msglen_t        msg_qbytes;
+        pid_t           msg_lspid;
+        pid_t           msg_lrpid;
+        c_ulong __glibc_reserved4;
+        c_ulong __glibc_reserved5;
+    }
+}
+else version (RISCV64)
+{
+    // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/generic/bits/msq.h
+    alias c_ulong msgqnum_t;
+    alias c_ulong msglen_t;
+
+    struct msqid_ds
+    {
+        ipc_perm msg_perm;
+        time_t          msg_stime;
+        time_t          msg_rtime;
+        time_t          msg_ctime;
+        c_ulong         __msg_cbytes;
+        msgqnum_t       msg_qnum;
+        msglen_t        msg_qbytes;
+        pid_t           msg_lspid;
+        pid_t           msg_lrpid;
+        c_ulong __glibc_reserved4;
+        c_ulong __glibc_reserved5;
+    }
+}
 else version (S390)
 {
     // https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/s390/bits/msq.h

--- a/libphobos/libdruntime/core/sys/posix/sys/socket.d
+++ b/libphobos/libdruntime/core/sys/posix/sys/socket.d
@@ -516,6 +516,74 @@ version( CRuntime_Glibc )
             SO_TYPE         = 3
         }
     }
+    else version (RISCV32)
+    {
+        enum
+        {
+            SOCK_DGRAM      = 2,
+            SOCK_SEQPACKET  = 5,
+            SOCK_STREAM     = 1
+        }
+
+        enum
+        {
+            SOL_SOCKET      = 1
+        }
+
+        enum
+        {
+            SO_ACCEPTCONN   = 30,
+            SO_BROADCAST    = 6,
+            SO_DEBUG        = 1,
+            SO_DONTROUTE    = 5,
+            SO_ERROR        = 4,
+            SO_KEEPALIVE    = 9,
+            SO_LINGER       = 13,
+            SO_OOBINLINE    = 10,
+            SO_RCVBUF       = 8,
+            SO_RCVLOWAT     = 18,
+            SO_RCVTIMEO     = 20,
+            SO_REUSEADDR    = 2,
+            SO_SNDBUF       = 7,
+            SO_SNDLOWAT     = 19,
+            SO_SNDTIMEO     = 21,
+            SO_TYPE         = 3
+        }
+    }
+    else version (RISCV64)
+    {
+        enum
+        {
+            SOCK_DGRAM      = 2,
+            SOCK_SEQPACKET  = 5,
+            SOCK_STREAM     = 1
+        }
+
+        enum
+        {
+            SOL_SOCKET      = 1
+        }
+
+        enum
+        {
+            SO_ACCEPTCONN   = 30,
+            SO_BROADCAST    = 6,
+            SO_DEBUG        = 1,
+            SO_DONTROUTE    = 5,
+            SO_ERROR        = 4,
+            SO_KEEPALIVE    = 9,
+            SO_LINGER       = 13,
+            SO_OOBINLINE    = 10,
+            SO_RCVBUF       = 8,
+            SO_RCVLOWAT     = 18,
+            SO_RCVTIMEO     = 20,
+            SO_REUSEADDR    = 2,
+            SO_SNDBUF       = 7,
+            SO_SNDLOWAT     = 19,
+            SO_SNDTIMEO     = 21,
+            SO_TYPE         = 3
+        }
+    }
     else version (SPARC64)
     {
         enum

--- a/libphobos/libdruntime/core/sys/posix/sys/stat.d
+++ b/libphobos/libdruntime/core/sys/posix/sys/stat.d
@@ -353,6 +353,54 @@ version( CRuntime_Glibc )
             c_ulong     __unused6;
         }
     }
+    else version (RISCV32)
+    {
+        struct stat_t
+        {
+            dev_t       st_dev;
+            ino_t       st_ino;
+            mode_t      st_mode;
+            nlink_t     st_nlink;
+            uid_t       st_uid;
+            gid_t       st_gid;
+            dev_t       st_rdev;
+            dev_t       __pad1;
+            off_t       st_size;
+            blksize_t   st_blksize;
+            int         __pad2;
+            time_t      st_atime;
+            c_ulong     st_atime_nsec;
+            time_t      st_mtime;
+            c_ulong     st_mtime_nsec;
+            time_t      st_ctime;
+            c_ulong     st_ctime_nsec;
+            int[2]      __reserved;
+        }
+    }
+    else version (RISCV64)
+    {
+        struct stat_t
+        {
+            dev_t       st_dev;
+            ino_t       st_ino;
+            mode_t      st_mode;
+            nlink_t     st_nlink;
+            uid_t       st_uid;
+            gid_t       st_gid;
+            dev_t       st_rdev;
+            dev_t       __pad1;
+            off_t       st_size;
+            blksize_t   st_blksize;
+            int         __pad2;
+            time_t      st_atime;
+            c_ulong     st_atime_nsec;
+            time_t      st_mtime;
+            c_ulong     st_mtime_nsec;
+            time_t      st_ctime;
+            c_ulong     st_ctime_nsec;
+            int[2]      __reserved;
+        }
+    }
     else version (ARM)
     {
         private

--- a/libphobos/libdruntime/core/sys/posix/ucontext.d
+++ b/libphobos/libdruntime/core/sys/posix/ucontext.d
@@ -542,6 +542,104 @@ version( CRuntime_Glibc )
             mcontext_t  uc_mcontext;
         }
     }
+    else version (RISCV32)
+    {
+        private
+        {
+            alias c_ulong[32] __riscv_mc_gp_state;
+
+            struct __riscv_mc_f_ext_state
+            {
+                uint[32] __f;
+                uint __fcsr;
+            }
+
+            struct __riscv_mc_d_ext_state
+            {
+                ulong[32] __f;
+                uint __fcsr;
+            }
+
+            struct __riscv_mc_q_ext_state
+            {
+                align(16) ulong[64] __f;
+                uint __fcsr;
+                uint[3] __reserved;
+            }
+
+            union __riscv_mc_fp_state
+            {
+                __riscv_mc_f_ext_state __f;
+                __riscv_mc_d_ext_state __d;
+                __riscv_mc_q_ext_state __q;
+            }
+        }
+
+        struct mcontext_t
+        {
+            __riscv_mc_gp_state __gregs;
+            __riscv_mc_fp_state __fpregs;
+        }
+
+        struct ucontext_t
+        {
+            c_ulong     __uc_flags;
+            ucontext_t* uc_link;
+            stack_t     uc_stack;
+            sigset_t    uc_sigmask;
+            char[1024 / 8 - sigset_t.sizeof] __reserved;
+            mcontext_t  uc_mcontext;
+        }
+    }
+    else version (RISCV64)
+    {
+        private
+        {
+            alias c_ulong[32] __riscv_mc_gp_state;
+
+            struct __riscv_mc_f_ext_state
+            {
+                uint[32] __f;
+                uint __fcsr;
+            }
+
+            struct __riscv_mc_d_ext_state
+            {
+                ulong[32] __f;
+                uint __fcsr;
+            }
+
+            struct __riscv_mc_q_ext_state
+            {
+                align(16) ulong[64] __f;
+                uint __fcsr;
+                uint[3] __reserved;
+            }
+
+            union __riscv_mc_fp_state
+            {
+                __riscv_mc_f_ext_state __f;
+                __riscv_mc_d_ext_state __d;
+                __riscv_mc_q_ext_state __q;
+            }
+        }
+
+        struct mcontext_t
+        {
+            __riscv_mc_gp_state __gregs;
+            __riscv_mc_fp_state __fpregs;
+        }
+
+        struct ucontext_t
+        {
+            c_ulong     __uc_flags;
+            ucontext_t* uc_link;
+            stack_t     uc_stack;
+            sigset_t    uc_sigmask;
+            char[1024 / 8 - sigset_t.sizeof] __reserved;
+            mcontext_t  uc_mcontext;
+        }
+    }
     else version (SPARC64)
     {
         enum MC_NGREG = 19;

--- a/libphobos/libdruntime/gcc/backtrace.d
+++ b/libphobos/libdruntime/gcc/backtrace.d
@@ -261,8 +261,12 @@ static if (BACKTRACE_SUPPORTED && !BACKTRACE_USES_MALLOC)
                         msg = formatLine(sym.symbol, buffer);
                         int ret = dg(i, msg);
 
-                        if (!ret && sym.symbol.funcName && strcmp(sym.symbol.funcName, "_Dmain") == 0)
+                        if (!ret && sym.symbol.funcName &&
+                            (strcmp(sym.symbol.funcName, "_Dmain") == 0 ||
+                             strcmp(sym.symbol.funcName, "_d_run_main") == 0))
+                        {
                             return 1;
+                        }
                         return ret;
                     }
                 }

--- a/libphobos/libdruntime/rt/sections_elf_shared.d
+++ b/libphobos/libdruntime/rt/sections_elf_shared.d
@@ -904,6 +904,7 @@ extern(C) void* __tls_get_addr(tls_index* ti) nothrow @nogc;
  * each TLS block. This is at least true for PowerPC and Mips platforms.
  * See: https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/powerpc/dl-tls.h;h=f7cf6f96ebfb505abfd2f02be0ad0e833107c0cd;hb=HEAD#l34
  *      https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/mips/dl-tls.h;h=93a6dc050cb144b9f68b96fb3199c60f5b1fcd18;hb=HEAD#l32
+ *      https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/riscv/dl-tls.h;h=ab2d860314de94c18812bc894ff6b3f55368f20f;hb=HEAD#l32
  */
 version(X86)
     enum TLS_DTV_OFFSET = 0x0;
@@ -913,6 +914,10 @@ else version(ARM)
     enum TLS_DTV_OFFSET = 0x0;
 else version(AArch64)
     enum TLS_DTV_OFFSET = 0x0;
+else version(RISCV32)
+    enum TLS_DTV_OFFSET = 0x800;
+else version(RISCV64)
+    enum TLS_DTV_OFFSET = 0x800;
 else version(SPARC)
     enum TLS_DTV_OFFSET = 0x0;
 else version(SPARC64)

--- a/libphobos/src/std/experimental/allocator/building_blocks/region.d
+++ b/libphobos/src/std/experimental/allocator/building_blocks/region.d
@@ -514,6 +514,7 @@ struct InSituRegion(size_t size, size_t minAlign = platformAlignment)
     else version (PPC64) enum growDownwards = Yes.growDownwards;
     else version (MIPS32) enum growDownwards = Yes.growDownwards;
     else version (MIPS64) enum growDownwards = Yes.growDownwards;
+    else version (RISCV64) enum growDownwards = Yes.growDownwards;
     else version (SPARC) enum growDownwards = Yes.growDownwards;
     else version (SystemZ) enum growDownwards = Yes.growDownwards;
     else static assert(0, "Dunno how the stack grows on this architecture.");

--- a/libphobos/src/std/math.d
+++ b/libphobos/src/std/math.d
@@ -148,6 +148,8 @@ version(DigitalMars)
 
 version (X86)       version = X86_Any;
 version (X86_64)    version = X86_Any;
+version (RISCV32)   version = RISCV_Any;
+version (RISCV64)   version = RISCV_Any;
 version (PPC)       version = PPC_Any;
 version (PPC64)     version = PPC_Any;
 version (MIPS32)    version = MIPS_Any;
@@ -6116,6 +6118,21 @@ nothrow @nogc:
                                  | inexactException,
         }
     }
+    else version (RISCV_Any)
+    {
+        enum : ExceptionMask
+        {
+            inexactException      = 0x01,
+            divByZeroException    = 0x08,
+            overflowException     = 0x04,
+            underflowException    = 0x02,
+            invalidException      = 0x10,
+            severeExceptions   = overflowException | divByZeroException
+                                 | invalidException,
+            allExceptions      = severeExceptions | underflowException
+                                 | inexactException,
+        }
+    }
     else version (SPARC64)
     {
         enum : ExceptionMask
@@ -6255,6 +6272,10 @@ private:
         alias ControlState = uint;
     }
     else version(MIPS_Any)
+    {
+        alias ControlState = uint;
+    }
+    else version (RISCV_Any)
     {
         alias ControlState = uint;
     }


### PR DESCRIPTION
- Moves riscv patches out of untested.
- Fix backtrace when uncaught exception occurs outside of `_Dmain`.
- Quick hack to fix libatomic (RISC-V supports atomics, but not for all sizes), should probably have more fine-grained versions for each size.
- Add support for 128-bit floating point in core.internal.convert.

The C bindings really need a good squashing, something to the effect of:
```
version (Foo)
  version = GENERIC;
else version (Bar)
  version = GENERIC;
else version (Baz)
{
  /* Do something different.  */
}
else
  static assert(0, "unsupported");

version (GENERIC)
{
  /* Default implementation.  */
}
```