### PR TITLE
gdc.texi: Remove front and back-cover texts

### DIFF
--- a/gcc/d/gdc.texi
+++ b/gcc/d/gdc.texi
@@ -21,8 +21,7 @@ Copyright @copyright{} @value{copyrights-d} Free Software Foundation, Inc.
 Permission is granted to copy, distribute and/or modify this document
 under the terms of the GNU Free Documentation License, Version 1.3 or
 any later version published by the Free Software Foundation; with no
-Invariant Sections, the Front-Cover Texts being (a) (see below), and
-with the Back-Cover Texts being (b) (see below).
+Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.
 A copy of the license is included in the
 @c man end
 section entitled ``GNU Free Documentation License''.
@@ -31,19 +30,6 @@ section entitled ``GNU Free Documentation License''.
 man page gfdl(7).
 @c man end
 @end ignore
-
-@c man begin COPYRIGHT
-
-(a) The FSF's Front-Cover Text is:
-
-     A GNU Manual
-
-(b) The FSF's Back-Cover Text is:
-
-     You have freedom to copy and modify this GNU Manual, like GNU
-     software.  Copies published by the Free Software Foundation raise
-     funds for GNU development.
-@c man end
 @end copying
 
 @ifinfo


### PR DESCRIPTION
This was removed once before in 61a9aff8.  Seems to have been reverted when rebasing the docs using another front-end as a template.