### PR TITLE
Cherry-pick: Support COMPILED_IMPORTS in testsuite, remove fix-up for…

### DIFF
--- a/gcc/testsuite/gdc.test/compilable/b6395.d
+++ b/gcc/testsuite/gdc.test/compilable/b6395.d
@@ -1,5 +1,5 @@
-// REQUIRED_ARGS: -c -Icompilable/extra-files
-// EXTRA_SOURCES: extra-files/c6395.d
+// REQUIRED_ARGS: -Icompilable/extra-files
+// EXTRA_FILES: extra-files/c6395.d
 
 // 6395
 

--- a/gcc/testsuite/gdc.test/compilable/ddoc9369.d
+++ b/gcc/testsuite/gdc.test/compilable/ddoc9369.d
@@ -1,5 +1,5 @@
 // PERMUTE_ARGS:
-// EXTRA_SOURCES: /extra-files/ddoc9369.ddoc
+// EXTRA_SOURCES: extra-files/ddoc9369.ddoc
 // REQUIRED_ARGS: -D -Dd${RESULTS_DIR}/compilable -o-
 // POST_SCRIPT: compilable/extra-files/ddocAny-postscript.sh 9369
 

--- a/gcc/testsuite/gdc.test/compilable/json.d
+++ b/gcc/testsuite/gdc.test/compilable/json.d
@@ -1,7 +1,7 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -o- -X -Xf${RESULTS_DIR}/compilable/json.out
 // POST_SCRIPT: compilable/extra-files/json-postscript.sh
-// EXTRA_SOURCES: imports/jsonimport1.d imports/jsonimport2.d imports/jsonimport3.d imports/jsonimport4.d
+// EXTRA_FILES: imports/jsonimport1.d imports/jsonimport2.d imports/jsonimport3.d imports/jsonimport4.d
 
 module json;
 

--- a/gcc/testsuite/gdc.test/compilable/pull6815.d
+++ b/gcc/testsuite/gdc.test/compilable/pull6815.d
@@ -1,4 +1,5 @@
 /* REQUIRED_ARGS: -inline -Icompilable/extra-files
+   EXTRA_FILES: extra-files/e6815.d
  */
 
 void b()

--- a/gcc/testsuite/gdc.test/compilable/test12624.d
+++ b/gcc/testsuite/gdc.test/compilable/test12624.d
@@ -1,4 +1,5 @@
 // REQUIRED_ARGS: -lib -Icompilable/extra-files
+// EXTRA_FILES: extra-files/imp12624.d
 // https://issues.dlang.org/show_bug.cgi?id=12624
 
 struct SysTime

--- a/gcc/testsuite/gdc.test/compilable/test16080.d
+++ b/gcc/testsuite/gdc.test/compilable/test16080.d
@@ -1,5 +1,6 @@
 // REQUIRED_ARGS: -lib -Icompilable/imports
-// EXTRA_SOURCES: extra-files/test16080b.d
+// COMPILED_IMPORTS: extra-files/test16080b.d
+// EXTRA_FILES: imports/imp16080.d
 // https://issues.dlang.org/show_bug.cgi?id=16080
 
 import imp16080;

--- a/gcc/testsuite/gdc.test/compilable/test7190.d
+++ b/gcc/testsuite/gdc.test/compilable/test7190.d
@@ -1,5 +1,6 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -c -Icompilable/extra-files
+// REQUIRED_ARGS: -Icompilable/extra-files
+// EXTRA_FILES: extra-files/example7190/controllers/HomeController.d extra-files/example7190/models/HomeModel.d extra-files/serenity7190/core/Controller.d  extra-files/serenity7190/core/Model.d
 
 import example7190.controllers.HomeController;
 import example7190.models.HomeModel;

--- a/gcc/testsuite/gdc.test/compilable/test9057.d
+++ b/gcc/testsuite/gdc.test/compilable/test9057.d
@@ -1,5 +1,6 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -c -Icompilable/extra-files
+// REQUIRED_ARGS: -Icompilable/extra-files
+// EXTRA_FILES: extra-files/imp9057.d extra-files/imp9057_2.d
 
 struct Bug9057(T)
 {

--- a/gcc/testsuite/gdc.test/compilable/testDIP37.d
+++ b/gcc/testsuite/gdc.test/compilable/testDIP37.d
@@ -1,5 +1,6 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -c -Icompilable/extra-files
+// REQUIRED_ARGS: -Icompilable/extra-files
+// EXTRA_FILES: extra-files/pkgDIP37/datetime/package.d extra-files/pkgDIP37/datetime/common.d extra-files/pkgDIP37/test17629/package.di extra-files/pkgDIP37/test17629/common.di
 
 void test1()
 {

--- a/gcc/testsuite/gdc.test/compilable/testDIP37_10302.d
+++ b/gcc/testsuite/gdc.test/compilable/testDIP37_10302.d
@@ -1,6 +1,7 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -c -Icompilable/extra-files
 // EXTRA_SOURCES: extra-files/pkgDIP37_10302/liba.d extra-files/pkgDIP37_10302/libb.d
+// EXTRA_FILES: extra-files/pkgDIP37_10302/package.d
 
 module test;
 import pkgDIP37_10302;

--- a/gcc/testsuite/gdc.test/compilable/testDIP37_10354.d
+++ b/gcc/testsuite/gdc.test/compilable/testDIP37_10354.d
@@ -1,5 +1,6 @@
 // PERMUTE_ARGS:
 // REQUIRED_ARGS: -o- -Icompilable/extra-files
+// EXTRA_FILES: extra-files/pkgDIP37_10354/mbar.d extra-files/pkgDIP37_10354/mfoo.d extra-files/pkgDIP37_10354/package.d
 
 module testDIP37_10354;
 import pkgDIP37_10354.mfoo;

--- a/gcc/testsuite/gdc.test/compilable/testDIP37_10421.d
+++ b/gcc/testsuite/gdc.test/compilable/testDIP37_10421.d
@@ -1,8 +1,6 @@
 // PERMUTE_ARGS:
-// REQUIRED_ARGS: -c -Icompilable/extra-files
-// EXTRA_SOURCES: extra-files/pkgDIP37_10421/algo/package.d
-// EXTRA_SOURCES: extra-files/pkgDIP37_10421/algo/mod.d
-// EXTRA_SOURCES: extra-files/pkgDIP37_10421/except.d
+// REQUIRED_ARGS: -Icompilable/extra-files
+// COMPILED_IMPORTS: extra-files/pkgDIP37_10421/algo/package.d extra-files/pkgDIP37_10421/algo/mod.d extra-files/pkgDIP37_10421/except.d
 
 module testDIP37_10421;
 import pkgDIP37_10421.algo;

--- a/gcc/testsuite/gdc.test/d_do_test.exp
+++ b/gcc/testsuite/gdc.test/d_do_test.exp
@@ -22,16 +22,16 @@ load_lib gdc-dg.exp
 # Convert DMD arguments to GDC equivalent
 #
 
-proc gdc-convert-args { base args } {
+proc gdc-convert-args { args } {
     set out ""
 
     foreach arg [split [lindex $args 0] " "] {
         # List of switches kept in ASCII collated order.
         if { [regexp -- {^-I([\w+/-]+)} $arg pattern path] } {
-            lappend out "-I$base/$path"
+            lappend out "-I$path"
 
         } elseif { [regexp -- {^-J([\w+/-]+)} $arg pattern path] } {
-            lappend out "-J$base/$path"
+            lappend out "-J$path"
 
         } elseif [string match "-allinst" $arg] {
             lappend out "-fall-instantiations"
@@ -158,6 +158,9 @@ proc gdc-copy-extra { base extra } {
 #
 #   COMPILE_SEPARATELY: Not handled.
 #   EXECUTE_ARGS:       Parameters to add to the execution of the test.
+#   COMPILED_IMPORTS:   List of modules files that are imported by the main
+#                       source file that should be included in compilation.
+#                       Currently handled the same as EXTRA_SOURCES.
 #   EXTRA_SOURCES:      List of extra sources to build and link along with
 #                       the test.
 #   EXTRA_FILES:        List of extra files to copy for the test runs.
@@ -207,7 +210,7 @@ proc dmd2dg { base test } {
 
         } elseif [regexp -- {PERMUTE_ARGS\s*:\s*(.*)} $copy_line match args] {
             # PERMUTE_ARGS is handled by gdc-do-test.
-            set PERMUTE_ARGS [gdc-convert-args $base $args]
+            set PERMUTE_ARGS [gdc-convert-args $args]
             regsub -- {PERMUTE_ARGS.*$} $copy_line "" out_line
 
         } elseif [regexp -- {EXECUTE_ARGS\s*:\s*(.*)} $copy_line match args] {
@@ -219,7 +222,7 @@ proc dmd2dg { base test } {
 
         } elseif [regexp -- {REQUIRED_ARGS\s*:\s*(.*)} $copy_line match args] {
             # Convert all listed arguments to from dmd to gdc-style.
-            set new_option "{ dg-additional-options \"[gdc-convert-args $base $args]\" }"
+            set new_option "{ dg-additional-options \"[gdc-convert-args $args]\" }"
             regsub -- {REQUIRED_ARGS.*$} $copy_line $new_option out_line
 
         } elseif [regexp -- {EXTRA_SOURCES\s*:\s*(.*)} $copy_line match sources] {
@@ -241,13 +244,22 @@ proc dmd2dg { base test } {
             regsub -- {EXTRA_CPP_SOURCES.*$} $copy_line $new_option out_line
 
         } elseif [regexp -- {EXTRA_FILES\s*:\s*(.*)} $copy_line match files] {
-            # Copy all sources to the testsuite build directory.
+            # Copy all files to the testsuite build directory.
             foreach import $files {
                 # print "Import: $base $type/$import"
                 gdc-copy-extra $base "$type/$import"
             }
             set new_option "{ dg-additional-files \"$files\" }"
             regsub -- {EXTRA_FILES.*$} $copy_line $new_option out_line
+
+        } elseif [regexp -- {COMPILED_IMPORTS\s*:\s*(.*)} $copy_line match sources] {
+            # Copy all sources to the testsuite build directory.
+            foreach import $sources {
+                # print "Import: $base $type/$import"
+                gdc-copy-extra $base "$type/$import"
+            }
+            set new_option "{ dg-additional-sources \"$sources\" }"
+            regsub -- {COMPILED_IMPORTS.*$} $copy_line $new_option out_line
 
         }
 


### PR DESCRIPTION
… include paths

Backported from master. To fix testsuite failures related to wrong -J / -I flags and symlinks.