### PR TITLE
Fix backtrace if printing thread is not initialized

### DIFF
--- a/libphobos/libdruntime/gcc/backtrace.d
+++ b/libphobos/libdruntime/gcc/backtrace.d
@@ -271,13 +271,23 @@ static if (BACKTRACE_SUPPORTED && !BACKTRACE_USES_MALLOC)
 
         int opApply(scope ApplyCallback dg) const
         {
+            initLibBacktrace();
+
             // If backtrace_simple produced an error report it and exit
             if (!state || error != 0)
             {
                 size_t pos = 0;
                 SymbolOrError symError;
-                symError.errnum = error;
-                symError.msg = errorBuf.ptr;
+                if (!state)
+                {
+                    symError.msg = "libbacktrace failed to initialize\0";
+                    symError.errnum = 1;
+                }
+                else
+                {
+                    symError.errnum = error;
+                    symError.msg = errorBuf.ptr;
+                }
 
                 return dg(pos, symError);
             }
@@ -342,7 +352,7 @@ static if (BACKTRACE_SUPPORTED && !BACKTRACE_USES_MALLOC)
 
         int       error = 0;
         int _firstFrame = 0;
-        char[128] errorBuf;
+        char[128] errorBuf = "\0";
     }
 }
 else


### PR DESCRIPTION
It is possible to create Exceptions in one thread, pass them to another thread and print in that other thread. In this case, libbacktrace might not be initialized yet and resolving the pc values to symbol info will fail. (e.g. this happens if you immediately start a new thread in main and throw there).

Additionally improve the error handling code if state failed to initialize for some reason: Currently due to setting error code as `0` in this case, the printing function will try to print a valid symbol. As `errorBuf` is not updated in this case, it will however print an old message, or garbage.